### PR TITLE
deleteCachedSession

### DIFF
--- a/Lets Do This/Models/DSOSession.m
+++ b/Lets Do This/Models/DSOSession.m
@@ -154,6 +154,7 @@ static NSString *_APIKey;
             successBlock(session);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
+        [session deleteCachedSession];
         if (failure) {
             failure(error);
         }
@@ -162,6 +163,10 @@ static NSString *_APIKey;
 
 + (DSOSession *)currentSession {
     return _currentSession;
+}
+
+- (void)deleteCachedSession {
+    [SSKeychain deletePasswordForService:@"org.dosomething.slothkit" account:@"Session"];
 }
 
 - (instancetype)init {


### PR DESCRIPTION
Closes #30, which was causing an infinite loop. Issue was created once I changed my northstar email to a value different from the one saved in the SSKeychain.  The loop occurs because `hasCachedSession` would return TRUE, since the relevant tokens existed.. but `startWithCachedSession` would fail, and then call `[self dismissViewControllerAnimated:NO completion:nil];` to dismiss the Session Loading VC, which then calls `viewDidAppear` again to call the Session Loading VC, and infinite loop.

The cached session never gets deleted upon error, so this aims to fix that by deleting the Session keychain value if `startWithCachedSession` fails.