### PR TITLE
Notification Settings

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -664,13 +664,13 @@
 			baseConfigurationReference = 481832CD7E534871B0CC8938 /* Pods-Lets Do This.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Do Something/, Inc (S4HV7AJFFK)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				GCC_PREFIX_HEADER = "Lets Do This/LetsDoThis.pch";
 				INFOPLIST_FILE = "Lets Do This/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "1c91197a-38bc-48a4-b37e-ae02f7e864e4";
+				PROVISIONING_PROFILE = "e560335c-8a1f-4c84-97a0-a58c7b387eb4";
 			};
 			name = Debug;
 		};
@@ -679,13 +679,13 @@
 			baseConfigurationReference = B92B81EBB03D9FF4D34E3FD9 /* Pods-Lets Do This.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Do Something/, Inc (S4HV7AJFFK)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				GCC_PREFIX_HEADER = "Lets Do This/LetsDoThis.pch";
 				INFOPLIST_FILE = "Lets Do This/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "1c91197a-38bc-48a4-b37e-ae02f7e864e4";
+				PROVISIONING_PROFILE = "e560335c-8a1f-4c84-97a0-a58c7b387eb4";
 			};
 			name = Release;
 		};

--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -664,13 +664,13 @@
 			baseConfigurationReference = 481832CD7E534871B0CC8938 /* Pods-Lets Do This.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Do Something/, Inc (S4HV7AJFFK)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PREFIX_HEADER = "Lets Do This/LetsDoThis.pch";
 				INFOPLIST_FILE = "Lets Do This/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "e560335c-8a1f-4c84-97a0-a58c7b387eb4";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Debug;
 		};
@@ -679,13 +679,13 @@
 			baseConfigurationReference = B92B81EBB03D9FF4D34E3FD9 /* Pods-Lets Do This.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Do Something/, Inc (S4HV7AJFFK)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PREFIX_HEADER = "Lets Do This/LetsDoThis.pch";
 				INFOPLIST_FILE = "Lets Do This/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "e560335c-8a1f-4c84-97a0-a58c7b387eb4";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Release;
 		};

--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -670,7 +670,7 @@
 				INFOPLIST_FILE = "Lets Do This/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "1c91197a-38bc-48a4-b37e-ae02f7e864e4";
 			};
 			name = Debug;
 		};
@@ -685,7 +685,7 @@
 				INFOPLIST_FILE = "Lets Do This/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "1c91197a-38bc-48a4-b37e-ae02f7e864e4";
 			};
 			name = Release;
 		};

--- a/Lets Do This/Base.lproj/Main.storyboard
+++ b/Lets Do This/Base.lproj/Main.storyboard
@@ -716,11 +716,8 @@ activities and group up with friends.</string>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="v0g-NP-By1" id="WoO-io-RRo">
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MwV-gZ-2wI">
+                                                <switch opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MwV-gZ-2wI">
                                                     <rect key="frame" x="535" y="6" width="51" height="31"/>
-                                                    <connections>
-                                                        <action selector="notificationsChanged:" destination="QeS-RT-P7N" eventType="valueChanged" id="NmP-Bd-qIh"/>
-                                                    </connections>
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Receive Notifications" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d3p-Nz-bFg">
                                                     <rect key="frame" x="16" y="11" width="162" height="21"/>
@@ -759,7 +756,7 @@ activities and group up with friends.</string>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="notificationsSwitch" destination="MwV-gZ-2wI" id="qeG-CS-k05"/>
+                        <outlet property="notificationsSwitch" destination="MwV-gZ-2wI" id="fMI-yI-ruA"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="egQ-Jh-ZP6" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Lets Do This/Base.lproj/Main.storyboard
+++ b/Lets Do This/Base.lproj/Main.storyboard
@@ -692,7 +692,7 @@ activities and group up with friends.</string>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Oa-3G-TsX">
-                                                    <rect key="frame" x="272" y="7" width="56" height="30"/>
+                                                    <rect key="frame" x="16" y="7" width="56" height="30"/>
                                                     <state key="normal" title="Log Out">
                                                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                                     </state>
@@ -703,8 +703,44 @@ activities and group up with friends.</string>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="5Oa-3G-TsX" secondAttribute="centerY" id="ZpN-NC-WPV"/>
-                                                <constraint firstAttribute="centerX" secondItem="5Oa-3G-TsX" secondAttribute="centerX" id="a6i-1e-vhU"/>
+                                                <constraint firstItem="5Oa-3G-TsX" firstAttribute="leading" secondItem="ddf-xH-ESO" secondAttribute="leadingMargin" constant="8" id="hBQ-mn-RD5"/>
                                             </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Notifications" id="4g3-py-Iyt">
+                                <cells>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="v0g-NP-By1">
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="v0g-NP-By1" id="WoO-io-RRo">
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MwV-gZ-2wI">
+                                                    <rect key="frame" x="535" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="notificationsChanged:" destination="QeS-RT-P7N" eventType="valueChanged" id="NmP-Bd-qIh"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Receive Notifications" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d3p-Nz-bFg">
+                                                    <rect key="frame" x="16" y="11" width="162" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="MwV-gZ-2wI" secondAttribute="trailing" constant="8" id="813-yb-95R"/>
+                                                <constraint firstAttribute="centerY" secondItem="d3p-Nz-bFg" secondAttribute="centerY" id="Lm6-bz-eOJ"/>
+                                                <constraint firstItem="d3p-Nz-bFg" firstAttribute="leading" secondItem="WoO-io-RRo" secondAttribute="leadingMargin" constant="8" id="Mek-ci-PdQ"/>
+                                                <constraint firstAttribute="centerY" secondItem="MwV-gZ-2wI" secondAttribute="centerY" id="hWv-ch-78v"/>
+                                                <constraint firstAttribute="centerX" secondItem="MwV-gZ-2wI" secondAttribute="centerX" constant="-267.5" id="r0u-u1-x8T"/>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="r0u-u1-x8T"/>
+                                                </mask>
+                                            </variation>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -722,6 +758,9 @@ activities and group up with friends.</string>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="notificationsSwitch" destination="MwV-gZ-2wI" id="qeG-CS-k05"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="egQ-Jh-ZP6" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Lets Do This/Classes/AppDelegate.m
+++ b/Lets Do This/Classes/AppDelegate.m
@@ -64,6 +64,7 @@
     [currentInstallation setDeviceTokenFromData:deviceToken];
     currentInstallation.channels = @[ @"global" ];
     [currentInstallation saveInBackground];
+    NSLog(@"currentInstallation %@", currentInstallation);
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {

--- a/Lets Do This/Classes/AppDelegate.m
+++ b/Lets Do This/Classes/AppDelegate.m
@@ -59,12 +59,7 @@
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-    // Store the deviceToken in the current installation and save it to Parse.
-    PFInstallation *currentInstallation = [PFInstallation currentInstallation];
-    [currentInstallation setDeviceTokenFromData:deviceToken];
-    currentInstallation.channels = @[ @"global" ];
-    [currentInstallation saveInBackground];
-    NSLog(@"currentInstallation %@", currentInstallation);
+    [DSOSession setDeviceToken:deviceToken];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {

--- a/Lets Do This/Controllers/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/LDTSettingsViewController.m
@@ -9,7 +9,36 @@
 #import "LDTSettingsViewController.h"
 #import "DSOSession.h"
 
+@interface LDTSettingsViewController()
+@property (weak, nonatomic) IBOutlet UISwitch *notificationsSwitch;
+
+@end
+
 @implementation LDTSettingsViewController
+
+- (void)viewDidLoad {
+    [self.notificationsSwitch setOn:NO];
+    if ([[UIApplication sharedApplication] isRegisteredForRemoteNotifications]) {
+        NSLog(@"Is registered");
+        [self.notificationsSwitch setOn:YES];
+    }
+}
+
+- (IBAction)notificationsChanged:(id)sender {
+    if (self.notificationsSwitch.isOn) {
+        NSLog(@"User tapped ON for notifications");
+        UIUserNotificationType userNotificationTypes = (UIUserNotificationTypeAlert |
+                                                        UIUserNotificationTypeBadge |
+                                                        UIUserNotificationTypeSound);
+        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:userNotificationTypes
+                                                                                 categories:nil];
+        [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+        [[UIApplication sharedApplication] registerForRemoteNotifications];
+    }
+    else {
+         NSLog(@"User tapped OFF for notifications");
+    }
+}
 
 - (IBAction)logoutTapped:(id)sender {
     [self confirmLogout];

--- a/Lets Do This/Controllers/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/LDTSettingsViewController.m
@@ -16,33 +16,46 @@
 
 @implementation LDTSettingsViewController
 
-- (void)viewDidLoad {
-    [self.notificationsSwitch setOn:NO];
-    if ([[UIApplication sharedApplication] isRegisteredForRemoteNotifications]) {
-        NSLog(@"Is registered");
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    UIUserNotificationSettings *grantedSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
+    if (grantedSettings.types == UIUserNotificationTypeNone) {
+        [self.notificationsSwitch setOn:NO];
+    }
+    else {
         [self.notificationsSwitch setOn:YES];
     }
 }
 
-- (IBAction)notificationsChanged:(id)sender {
-    if (self.notificationsSwitch.isOn) {
-        NSLog(@"User tapped ON for notifications");
-        UIUserNotificationType userNotificationTypes = (UIUserNotificationTypeAlert |
-                                                        UIUserNotificationTypeBadge |
-                                                        UIUserNotificationTypeSound);
-        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:userNotificationTypes
-                                                                                 categories:nil];
-        [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-    }
-    else {
-         NSLog(@"User tapped OFF for notifications");
+- (void)tableView:(UITableView *)tableView
+didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == 1) {
+        [self displayNotificationsInfo];
     }
 }
+
 
 - (IBAction)logoutTapped:(id)sender {
     [self confirmLogout];
 }
+
+- (void) displayNotificationsInfo {
+    UIAlertController *view = [UIAlertController alertControllerWithTitle:@"Notification settings"
+                                                                  message:@"Change your notification settings from Settings > Lets Do This."
+                                                           preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction *confirm = [UIAlertAction
+                              actionWithTitle:@"Oh, ok"
+                              style:UIAlertActionStyleDefault
+                              handler:^(UIAlertAction * action)
+                              {
+                                  [view dismissViewControllerAnimated:YES completion:nil];
+                              }];
+
+    [view addAction:confirm];
+    [self presentViewController:view animated:YES completion:nil];
+}
+
 
 - (void) confirmLogout {
     UIAlertController *view = [UIAlertController alertControllerWithTitle:@"Are you sure you want to log out?"

--- a/Lets Do This/Info.plist
+++ b/Lets Do This/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Lets Do This/Info.plist
+++ b/Lets Do This/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Lets Do This/Info.plist
+++ b/Lets Do This/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Lets Do This/Models/DSOSession.h
+++ b/Lets Do This/Models/DSOSession.h
@@ -59,6 +59,8 @@ typedef NS_ENUM(NSInteger, DSOSessionEnvironment) {
 
 - (void)logout:(DSOSessionLogoutBlock)successBlock failure:(DSOSessionFailureBlock)failureBlock;
 
++ (void)setDeviceToken:(NSData *)deviceToken;
+
 @property (nonatomic, strong, readonly) AFHTTPSessionManager *legacyServerSession;
 
 @end

--- a/Lets Do This/Models/DSOSession.m
+++ b/Lets Do This/Models/DSOSession.m
@@ -10,6 +10,7 @@
 #import "DSOTaxonomyTerm.h"
 #import "AFNetworkActivityLogger.h"
 #import <SSKeychain/SSKeychain.h>
+#import <Parse/Parse.h>
 
 @interface DSOSession ()
 @property (nonatomic, strong) NSString *serviceName;
@@ -225,6 +226,15 @@ static NSString *_APIKey;
             failureBlock(error);
         }
     }];
+}
+
++ (void)setDeviceToken:(NSData *)deviceToken  {
+    // Store the deviceToken in the current installation and save it to Parse.
+    PFInstallation *currentInstallation = [PFInstallation currentInstallation];
+    [currentInstallation setDeviceTokenFromData:deviceToken];
+    currentInstallation.channels = @[ @"global" ];
+    [currentInstallation saveInBackground];
+    NSLog(@"currentInstallation %@", currentInstallation);
 }
 
 - (AFHTTPSessionManager *)legacyServerSession {


### PR DESCRIPTION
Adds a `UISwitch` to indicate whether or not the user has enabled notifications, and displays a popup indicating how to change.

I created a Provisioning Profile for the App Store, and it seems to have resolved the "Missing Push Notification Entitlement - Your app appears to include API used to register with the Apple Push Notification service, but the app signature's entitlements do not include the "aps-environment" entitlemen" email I received upon submitting builds 1 and 2 for v0.1.1.  However, I can no longer build to my iPhone in Xcode, receiving the error: "A valid provisioning profile for this executable was not found."

Related Trello card: https://trello.com/c/3eetV2oh

![Oh, ok](https://cloud.githubusercontent.com/assets/1236811/7925177/c87822be-0876-11e5-9682-8f69005ee803.png)


