### PR TITLE
GET campaigns

### DIFF
--- a/Lets Do This/Controllers/LDTTabBarController.m
+++ b/Lets Do This/Controllers/LDTTabBarController.m
@@ -51,7 +51,26 @@
         [[DSOSession currentSession].user campaignActions:^(NSArray *campaignActions, NSError *error) {
             
         }];
+        [DSOCampaign allCampaigns:^(NSArray *campaigns, NSError *error) {
+            NSLog(@"campaigns count: %li", [campaigns count]);
+            // For now, always refresh:
+            // If nothing stored:
+            // if ([DSOCampaign MR_findAll].count == 0) {
+                // Save some campaigns:
+                [MagicalRecord saveWithBlock:^(NSManagedObjectContext *localContext) {
+                    // Loop through campaigns found:
+                    for (NSDictionary *campaign in campaigns) {
+                        NSInteger campaignID = [campaign[@"id"] integerValue];
+                        [DSOCampaign campaignWithID:campaignID inContext:localContext completion:^(DSOCampaign *campaign, NSError *error) {
+                            [localContext MR_saveToPersistentStoreAndWait];
+                        }];
+                    }
 
+                }];
+            //}
+        }];
+
+        /*
         if([DSOCampaign MR_findAll].count == 0) {
             [MagicalRecord saveWithBlock:^(NSManagedObjectContext *localContext) {
                 [DSOCampaign campaignWithID:15 inContext:localContext completion:^(DSOCampaign *campaign, NSError *error) {
@@ -81,6 +100,7 @@
                 }];
             }];
         }
+        */
     }
 }
 

--- a/Lets Do This/Info.plist
+++ b/Lets Do This/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.1</string>
+	<string>0.1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSUInteger, DSOCampaignInterestGroup) {
 
 + (void)campaignWithID:(NSInteger)campaignID inContext:(NSManagedObjectContext *)context completion:(DSOCampaignBlock)completionBlock;
 
++ (void)allCampaigns:(DSOCampaignListBlock)completionBlock;
 + (void)staffPickCampaigns:(DSOCampaignListBlock)completionBlock;
 + (void)reportbacksInInboxForCampaignID:(NSInteger)campaignID maxNumber:(NSInteger)maxNumber completionBlock:(DSOCampaignInboxReportBackBlock)completionBlock;
 


### PR DESCRIPTION
Closes #48: Adds `allCampaigns` method to use the `legacyServerSession` to query the `campaigns` endpoint for all Campaigns featured in the mobile app.

Closes #49: Use new `campaigns` endpoint and response for Campaign objects.
