### PR TITLE
Messages

### DIFF
--- a/Lets Do This/Controllers/LDTLoginViewController.m
+++ b/Lets Do This/Controllers/LDTLoginViewController.m
@@ -8,8 +8,8 @@
 
 #import "LDTLoginViewController.h"
 #import "LDTLoginRegNavigationController.h"
-
 #import "DSOSession.h"
+#import <TSMessages/TSMessage.h>
 
 
 @implementation LDTLoginViewController
@@ -18,6 +18,7 @@
     [super viewDidLoad];
     self.emailField.delegate = self;
     self.passwordField.delegate = self;
+    [TSMessage setDefaultViewController:self.navigationController];
 }
 
 -(BOOL) textFieldShouldReturn:(UITextField *)textField{
@@ -34,6 +35,9 @@
             }
         } failure:^(NSError *error) {
             [self.passwordField becomeFirstResponder];
+            [TSMessage showNotificationWithTitle:@"Epic fail"
+                                        subtitle:error.localizedDescription
+                                            type:TSMessageNotificationTypeError];
         }];
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -5,8 +5,9 @@ inhibit_all_warnings!
 target 'Lets Do This' do
 	pod 'AFNetworking', '~> 2.5'
 	pod 'AFNetworkActivityLogger', '~> 2.0.4'
-	pod 'SDWebImage', '~> 3.7.2'
-	pod 'SSKeychain', '~> 1.2'
 	pod 'MagicalRecord'
     pod 'Parse', '~> 1.7'
+    pod 'SDWebImage', '~> 3.7.2'
+    pod 'SSKeychain', '~> 1.2'
+    pod 'TSMessages', '~> 0.9'
 end


### PR DESCRIPTION
Closes #59 by adding `TSMessages`

Adds default `error.localizedDescription` message for now upon failed login.

![epic-fail](https://cloud.githubusercontent.com/assets/1236811/7993472/2dccf6d0-0abb-11e5-96dd-9e1fada497f4.jpg)
