### PR TITLE
Prove It

### DIFF
--- a/Lets Do This/Controllers/LDTCampaignActionsViewController.m
+++ b/Lets Do This/Controllers/LDTCampaignActionsViewController.m
@@ -12,10 +12,13 @@
 #import "DSOCampaign.h"
 #import "LDTCampaignDetailViewController.h"
 #import "TSMessage.h"
+#import "DSOSession.h"
+#import "DSOUser.h"
 
 @interface LDTCampaignActionsViewController ()
 @property (nonatomic, strong) NSArray *campaigns;
 @property (nonatomic, weak) IBOutlet LDTCampaignActionsLayout *layout;
+@property (nonatomic, strong) DSOUser *user;
 @end
 
 @implementation LDTCampaignActionsViewController
@@ -24,6 +27,16 @@
     [super viewDidLoad];
 
     self.campaigns = [DSOCampaign MR_findAllSortedBy:@"title" ascending:YES];
+    self.user = [DSOSession currentSession].user;
+    NSLog(@"viewDidLoad self.user %@", self.user);
+     [self.collectionView reloadData];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    // Testing if redeclaring here makes a difference.
+    self.user = [DSOSession currentSession].user;
+    NSLog(@"viewDidAppear self.user %@", self.user);
     [self.collectionView reloadData];
 }
 
@@ -32,8 +45,22 @@
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+
     LDTCampaignCollectionCell *cell = [self.collectionView dequeueReusableCellWithReuseIdentifier:@"CampaignCell" forIndexPath:indexPath];
     cell.campaign = self.campaigns[indexPath.row];
+
+    NSString *IDstring = [NSString stringWithFormat:@"%li", cell.campaign.campaignID];
+    NSLog(@"IDString %@", IDstring);
+    NSString *actionTitle = @"Stop being bored";
+    NSLog(@"campaignsDoing %@", self.user.campaignsDoing);
+    if ([self.user.campaignsDoing objectForKey:IDstring]) {
+        actionTitle = @"Prove it";
+    }
+    else if ([self.user.campaignsCompleted objectForKey:IDstring]) {
+        actionTitle = @"Proved it";
+    }
+    [cell.actionButton setTitle:actionTitle forState:UIControlStateNormal];
+
     return cell;
 }
 

--- a/Lets Do This/Controllers/LDTCampaignActionsViewController.m
+++ b/Lets Do This/Controllers/LDTCampaignActionsViewController.m
@@ -28,15 +28,10 @@
 
     self.campaigns = [DSOCampaign MR_findAllSortedBy:@"title" ascending:YES];
     self.user = [DSOSession currentSession].user;
-    NSLog(@"viewDidLoad self.user %@", self.user);
-     [self.collectionView reloadData];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    // Testing if redeclaring here makes a difference.
-    self.user = [DSOSession currentSession].user;
-    NSLog(@"viewDidAppear self.user %@", self.user);
     [self.collectionView reloadData];
 }
 

--- a/Lets Do This/Controllers/LDTCampaignActionsViewController.m
+++ b/Lets Do This/Controllers/LDTCampaignActionsViewController.m
@@ -25,13 +25,12 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-
     self.campaigns = [DSOCampaign MR_findAllSortedBy:@"title" ascending:YES];
-    self.user = [DSOSession currentSession].user;
 }
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
+    self.user = [DSOSession currentSession].user;
     [self.collectionView reloadData];
 }
 

--- a/Lets Do This/Controllers/LDTTabBarController.m
+++ b/Lets Do This/Controllers/LDTTabBarController.m
@@ -48,9 +48,6 @@
         }
     }
     else {
-        [[DSOSession currentSession].user campaignActions:^(NSArray *campaignActions, NSError *error) {
-            NSLog(@"campaignActions %@", campaignActions);
-        }];
         [DSOCampaign allCampaigns:^(NSArray *campaigns, NSError *error) {
             NSLog(@"campaigns count: %li", [campaigns count]);
             // For now, always refresh:

--- a/Lets Do This/Models/DSOSession.m
+++ b/Lets Do This/Models/DSOSession.m
@@ -176,8 +176,8 @@ static NSString *_APIKey;
     self = [super initWithBaseURL:baseURL];
 
     if (self != nil) {
-        [[AFNetworkActivityLogger sharedLogger] startLogging];
-        [[AFNetworkActivityLogger sharedLogger] setLevel:AFLoggerLevelDebug];
+//        [[AFNetworkActivityLogger sharedLogger] startLogging];
+//        [[AFNetworkActivityLogger sharedLogger] setLevel:AFLoggerLevelDebug];
 
         self.responseSerializer = [AFJSONResponseSerializer serializer];
         self.requestSerializer = [AFJSONRequestSerializer serializer];

--- a/Lets Do This/Views/LDTCampaignCollectionCell.h
+++ b/Lets Do This/Views/LDTCampaignCollectionCell.h
@@ -12,5 +12,6 @@
 @interface LDTCampaignCollectionCell : UICollectionViewCell
 
 @property (nonatomic, strong) DSOCampaign *campaign;
+@property (weak, nonatomic) IBOutlet UIButton *actionButton;
 
 @end

--- a/Lets Do This/Views/LDTCampaignCollectionCell.m
+++ b/Lets Do This/Views/LDTCampaignCollectionCell.m
@@ -13,7 +13,6 @@
 @property (nonatomic, strong) IBOutlet UIImageView *backgroundImageView;
 @property (nonatomic, strong) IBOutlet UILabel *titleLabel;
 @property (nonatomic, strong) IBOutlet UILabel *callToActionLabel;
-@property (weak, nonatomic) IBOutlet UIButton *actionButton;
 @property (nonatomic, strong) IBOutlet UILabel *factProblemLabel;
 @end
 


### PR DESCRIPTION
Refs #57 -- Sets action title on Main Feed based on campaign activity:

* Sets the title to "Prove it" if the user has signed up for the campaign but not yet completed
* Sets title to "Proved it" if the user has completed the campaign
* Sets title to "Stop being bored" if the user has not signed up

This is a work in progress.  known bug is that after campaign signup, the button doesn't change right away. Need to refresh the campaigns properties for the logged in user upon posting a campaign signup (refs #65)