### PR TITLE
Check your signup before you post your signup

### DIFF
--- a/Lets Do This/Controllers/LDTCampaignActionsViewController.m
+++ b/Lets Do This/Controllers/LDTCampaignActionsViewController.m
@@ -74,6 +74,13 @@
     LDTCampaignDetailViewController *destVC = (LDTCampaignDetailViewController *)destNavVC.topViewController;
     DSOCampaign *campaign = self.campaigns[indexPath.row];
     [destVC setCampaign:campaign];
+    NSString *IDstring = [NSString stringWithFormat:@"%li", campaign.campaignID];
+
+    // If doing or completed, exit function.
+    if ([self.user.campaignsDoing objectForKey:IDstring] || [self.user.campaignsCompleted objectForKey:IDstring]) {
+        return;
+    }
+
     [campaign signupFromSource:@"ios" completion:^(NSError *error) {
         // Message is underneath when set to destNavVC,
         // so setting to destVC for now (too much space though).

--- a/Lets Do This/Controllers/LDTCampaignActionsViewController.m
+++ b/Lets Do This/Controllers/LDTCampaignActionsViewController.m
@@ -85,9 +85,18 @@
         // Message is underneath when set to destNavVC,
         // so setting to destVC for now (too much space though).
         [TSMessage setDefaultViewController:destVC];
-        [TSMessage showNotificationWithTitle:@"Epic fail"
-                                    subtitle:error.localizedDescription
-                                        type:TSMessageNotificationTypeError];
+        // Hack until we figure out block syntax.
+        if (error.localizedDescription == nil) {
+            [TSMessage showNotificationWithTitle:@"You're signed up!"
+                                        subtitle:@"Take a photo and rock this shit!"
+                                            type:TSMessageNotificationTypeSuccess];
+        }
+        else {
+            [TSMessage showNotificationWithTitle:@"Epic fail"
+                                        subtitle:error.localizedDescription
+                                            type:TSMessageNotificationTypeError];
+        }
+
     }];
 }
 


### PR DESCRIPTION
Closes #57 by conditionally checking for signup status before posting a signup.

First pass at copy for the success message.

![ios simulator screen shot jun 9 2015 7 06 10 pm](https://cloud.githubusercontent.com/assets/1236811/8073500/a273e43a-0eda-11e5-8b4f-5fd46e5c914a.png)

