### PR TITLE
specify MagicalRecord version, change MagicalRecord header filename

### DIFF
--- a/Lets Do This/LetsDoThis.pch
+++ b/Lets Do This/LetsDoThis.pch
@@ -15,6 +15,6 @@
 #import <CoreData/CoreData.h>
 #import "DSOSession.h"
 #import "LDTImportQueue.h"
-#import <MagicalRecord/CoreData+MagicalRecord.h>
+#import <MagicalRecord/MagicalRecord.h>
 
 #endif

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ inhibit_all_warnings!
 target 'Lets Do This' do
 	pod 'AFNetworking', '~> 2.5'
 	pod 'AFNetworkActivityLogger', '~> 2.0.4'
-	pod 'MagicalRecord'
+	pod 'MagicalRecord', '~> 2.3'
     pod 'Parse', '~> 1.7'
     pod 'SDWebImage', '~> 3.7.2'
     pod 'SSKeychain', '~> 1.2'


### PR DESCRIPTION
#### What's this PR do?
Previously, with MagicalRecord 2.2, the main header file of the Cocoapod [was named `CoreData+MagicalRecord.h`](https://github.com/magicalpanda/MagicalRecord/tree/2.2/MagicalRecord). With the newest stable release, 2.3, the name of this header file [was changed to `MagicalRecord.h`](https://github.com/magicalpanda/MagicalRecord/tree/v2.3.0/MagicalRecord). 

This PR updates where we import this header file. It also specifies the `2.3` version of MagicalRecord. 
