### PR TITLE
Only add campaign if object exists

### DIFF
--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -174,7 +174,9 @@
         NSString *IDstring = campaignActivityData[@"drupal_id"];
         DSOCampaign *campaign = [DSOCampaign MR_findFirstByAttribute:@"campaignID"
                                                            withValue:IDstring];
-
+        if (campaign == nil) {
+            continue;
+        }
         // Store campaigns indexed by ID for easy status lookup by CampaignID.
         if ([campaignActivityData objectForKey:@"reportback_id"]) {
             self.campaignsCompleted[IDstring] = campaign;


### PR DESCRIPTION
Order of operations is off in sync'ing. Refs #65

What happened is my User activity was syncing before the relevant Campaigns were stored into Coredata.