### PR TITLE
Reportback Submit VC

### DIFF
--- a/Lets Do This/Base.lproj/Main.storyboard
+++ b/Lets Do This/Base.lproj/Main.storyboard
@@ -714,6 +714,9 @@ activities and group up with friends.</string>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="proveButton" destination="WBe-KD-MGJ" id="nsC-jt-bTt"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cwc-6q-Ooe" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Lets Do This/Base.lproj/Main.storyboard
+++ b/Lets Do This/Base.lproj/Main.storyboard
@@ -735,11 +735,11 @@ activities and group up with friends.</string>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7YO-kD-3pD" id="s3F-TM-cUn">
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WLL-XZ-dBI">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="299"/>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WLL-XZ-dBI">
+                                                    <rect key="frame" x="8" y="8" width="584" height="283"/>
                                                 </imageView>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U12-Kl-XBd">
-                                                    <rect key="frame" x="280" y="135" width="41" height="30"/>
+                                                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U12-Kl-XBd">
+                                                    <rect key="frame" x="8" y="8" width="600" height="288"/>
                                                     <state key="normal" title="Photo">
                                                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                                     </state>
@@ -750,8 +750,23 @@ activities and group up with friends.</string>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstAttribute="centerX" secondItem="U12-Kl-XBd" secondAttribute="centerX" id="1Sf-DR-xtn"/>
+                                                <constraint firstItem="WLL-XZ-dBI" firstAttribute="leading" secondItem="s3F-TM-cUn" secondAttribute="leadingMargin" id="3hB-7z-LON"/>
+                                                <constraint firstItem="U12-Kl-XBd" firstAttribute="top" secondItem="WLL-XZ-dBI" secondAttribute="top" id="94e-BB-Hfm"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="WLL-XZ-dBI" secondAttribute="trailing" id="BNo-EV-aXU"/>
                                                 <constraint firstAttribute="centerY" secondItem="U12-Kl-XBd" secondAttribute="centerY" id="Rdu-Gx-iu2"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="U12-Kl-XBd" secondAttribute="trailing" constant="-23" id="dva-yE-wMc"/>
+                                                <constraint firstItem="WLL-XZ-dBI" firstAttribute="top" secondItem="s3F-TM-cUn" secondAttribute="topMargin" id="qek-rx-xWQ"/>
+                                                <constraint firstItem="U12-Kl-XBd" firstAttribute="leading" secondItem="WLL-XZ-dBI" secondAttribute="leading" id="tst-wZ-TOJ"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="WLL-XZ-dBI" secondAttribute="bottom" id="vuy-Yk-yEN"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="U12-Kl-XBd" secondAttribute="bottom" constant="-5" id="ygg-Vr-YHQ"/>
+                                                <constraint firstItem="U12-Kl-XBd" firstAttribute="leading" secondItem="s3F-TM-cUn" secondAttribute="leadingMargin" constant="-7" id="znW-Dj-ppc"/>
                                             </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="1Sf-DR-xtn"/>
+                                                    <exclude reference="Rdu-Gx-iu2"/>
+                                                </mask>
+                                            </variation>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="gn1-xr-xZz">

--- a/Lets Do This/Base.lproj/Main.storyboard
+++ b/Lets Do This/Base.lproj/Main.storyboard
@@ -820,7 +820,11 @@ activities and group up with friends.</string>
                     </tableView>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="khg-TK-UgK">
-                        <barButtonItem key="rightBarButtonItem" systemItem="save" id="2GH-uH-ffU"/>
+                        <barButtonItem key="rightBarButtonItem" systemItem="save" id="2GH-uH-ffU">
+                            <connections>
+                                <action selector="saveButtonTapped:" destination="5Po-B3-Jvj" id="3mG-fu-rPh"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>

--- a/Lets Do This/Base.lproj/Main.storyboard
+++ b/Lets Do This/Base.lproj/Main.storyboard
@@ -821,8 +821,11 @@ activities and group up with friends.</string>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="captionTextField" destination="N9W-HS-6TY" id="eyg-8P-kZm"/>
                         <outlet property="getImageButton" destination="U12-Kl-XBd" id="qbs-Ps-UM4"/>
                         <outlet property="imageView" destination="WLL-XZ-dBI" id="bhn-5a-gR0"/>
+                        <outlet property="quantityTextField" destination="EMw-Ld-DSi" id="2p3-9R-hiI"/>
+                        <outlet property="saveButton" destination="2GH-uH-ffU" id="N6P-et-kI3"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="J87-4j-SGd" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Lets Do This/Controllers/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/LDTCampaignDetailViewController.m
@@ -7,6 +7,12 @@
 //
 
 #import "LDTCampaignDetailViewController.h"
+#import "LDTReportbackSubmitViewController.h"
+
+@interface LDTCampaignDetailViewController()
+@property (weak, nonatomic) IBOutlet UIBarButtonItem *proveButton;
+
+@end
 
 @implementation LDTCampaignDetailViewController
 
@@ -73,5 +79,15 @@
     return cell;
 }
 
+# pragma navigation
+
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender{
+    UINavigationController *destNavVC = segue.destinationViewController;
+    if (sender != self.proveButton) {
+        return;
+    }
+    LDTReportbackSubmitViewController *destVC = (LDTReportbackSubmitViewController *)destNavVC.topViewController;
+    [destVC setCampaign:self.campaign];
+}
 
 @end

--- a/Lets Do This/Controllers/LDTReportbackSubmitViewController.h
+++ b/Lets Do This/Controllers/LDTReportbackSubmitViewController.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "DSOCampaign.h"
 
 @interface LDTReportbackSubmitViewController : UITableViewController <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
-
+@property (strong, nonatomic) DSOCampaign *campaign;
 @end

--- a/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
+++ b/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
@@ -9,6 +9,7 @@
 #import "LDTReportbackSubmitViewController.h"
 
 @interface LDTReportbackSubmitViewController ()
+@property (strong, nonatomic) UIImagePickerController *picker;
 @property (weak, nonatomic) IBOutlet UIImageView *imageView;
 @property (weak, nonatomic) IBOutlet UIButton *getImageButton;
 - (IBAction)getImageTapped:(id)sender;
@@ -20,6 +21,9 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.title = @"Prove it";
+    self.picker = [[UIImagePickerController alloc] init];
+    self.picker.delegate = self;
+    self.picker.allowsEditing = YES;
 }
 
 - (IBAction)getImageTapped:(id)sender {
@@ -29,21 +33,35 @@
 - (void) getImageMenu {
     UIAlertController *view = [UIAlertController alertControllerWithTitle:@"Prove it"
                                                                   message:@"Pics or it didn't happen!"                                                               preferredStyle:UIAlertControllerStyleActionSheet];
+    UIAlertAction *camera;
+    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+        camera = [UIAlertAction
+                  actionWithTitle:@"Take Photo"
+                  style:UIAlertActionStyleDefault
+                  handler:^(UIAlertAction * action)
+                  {
+                      self.picker.sourceType = UIImagePickerControllerSourceTypeCamera;
+                      [self presentViewController:self.picker animated:YES completion:NULL];
+                  }];
+    }
+    else {
+        camera = [UIAlertAction
+                  actionWithTitle:@"(Camera Unavailable)"
+                  style:UIAlertActionStyleDefault
+                  handler:^(UIAlertAction * action)
+                  {
+                      [view dismissViewControllerAnimated:YES completion:nil];
+                  }];
+    }
 
-    UIAlertAction *camera = [UIAlertAction
-                              actionWithTitle:@"Take Photo"
-                              style:UIAlertActionStyleDefault
-                              handler:^(UIAlertAction * action)
-                              {
-                                  [view dismissViewControllerAnimated:YES completion:nil];
-                              }];
 
     UIAlertAction *library = [UIAlertAction
                              actionWithTitle:@"Choose From Library"
                              style:UIAlertActionStyleDefault
                              handler:^(UIAlertAction * action)
                              {
-                                 [view dismissViewControllerAnimated:YES completion:nil];
+                                 self.picker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+                                 [self presentViewController:self.picker animated:YES completion:NULL];
                              }];
     UIAlertAction *cancel = [UIAlertAction
                              actionWithTitle:@"Cancel"

--- a/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
+++ b/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
@@ -14,6 +14,9 @@
 @property (strong, nonatomic) NSString *selectedFilestring;
 @property (strong, nonatomic) UIImagePickerController *picker;
 @property (weak, nonatomic) IBOutlet UIImageView *imageView;
+@property (weak, nonatomic) IBOutlet UITextField *quantityTextField;
+@property (weak, nonatomic) IBOutlet UITextField *captionTextField;
+@property (weak, nonatomic) IBOutlet UIBarButtonItem *saveButton;
 @property (weak, nonatomic) IBOutlet UIButton *getImageButton;
 - (IBAction)getImageTapped:(id)sender;
 

--- a/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
+++ b/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
@@ -7,8 +7,11 @@
 //
 
 #import "LDTReportbackSubmitViewController.h"
+#import <AssetsLibrary/AssetsLibrary.h>
 
 @interface LDTReportbackSubmitViewController ()
+@property (strong, nonatomic) NSString *selectedFilename;
+@property (strong, nonatomic) NSString *selectedFilestring;
 @property (strong, nonatomic) UIImagePickerController *picker;
 @property (weak, nonatomic) IBOutlet UIImageView *imageView;
 @property (weak, nonatomic) IBOutlet UIButton *getImageButton;
@@ -74,5 +77,40 @@
     [view addAction:library];
     [view addAction:cancel];
     [self presentViewController:view animated:YES completion:nil];
+}
+#pragma mark - Image Picker Controller delegate methods
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
+    UIImage *chosenImage = info[UIImagePickerControllerEditedImage];
+    self.imageView.image = chosenImage;
+    self.selectedFilestring = [UIImagePNGRepresentation(chosenImage) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+
+    if (picker.sourceType == UIImagePickerControllerSourceTypeCamera) {
+        // Use JPG to preserve the JPG extension (what camera saves file as).
+        self.selectedFilename = @"temp.JPG";
+        [picker dismissViewControllerAnimated:YES completion:NULL];
+        return;
+    }
+
+
+    // Get filename of selected file to preserve its file extension.
+    NSURL *refURL = [info valueForKey:UIImagePickerControllerReferenceURL];
+    ALAssetsLibraryAssetForURLResultBlock resultblock = ^(ALAsset *imageAsset)
+    {
+        ALAssetRepresentation *imageRep = [imageAsset defaultRepresentation];
+        self.selectedFilename = [imageRep filename];
+    };
+    // Get the asset library and fetch the asset based on the ref url (pass in block above).
+    ALAssetsLibrary* assetslibrary = [[ALAssetsLibrary alloc] init];
+    [assetslibrary assetForURL:refURL resultBlock:resultblock failureBlock:nil];
+    [picker dismissViewControllerAnimated:YES completion:NULL];
+
+    // @todo: self.selectedFilename is null.. not sure whats going on here.
+    NSLog(@"self.selectedFilename %@", self.selectedFilename);
+
+}
+
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
+    [picker dismissViewControllerAnimated:YES completion:NULL];
 }
 @end

--- a/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
+++ b/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
@@ -10,7 +10,6 @@
 #import <AssetsLibrary/AssetsLibrary.h>
 
 @interface LDTReportbackSubmitViewController ()
-@property (strong, nonatomic) NSString *selectedFilename;
 @property (strong, nonatomic) NSString *selectedFilestring;
 @property (strong, nonatomic) UIImagePickerController *picker;
 @property (weak, nonatomic) IBOutlet UIImageView *imageView;
@@ -87,30 +86,7 @@
     UIImage *chosenImage = info[UIImagePickerControllerEditedImage];
     self.imageView.image = chosenImage;
     self.selectedFilestring = [UIImagePNGRepresentation(chosenImage) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-
-    if (picker.sourceType == UIImagePickerControllerSourceTypeCamera) {
-        // Use JPG to preserve the JPG extension (what camera saves file as).
-        self.selectedFilename = @"temp.JPG";
-        [picker dismissViewControllerAnimated:YES completion:NULL];
-        return;
-    }
-
-
-    // Get filename of selected file to preserve its file extension.
-    NSURL *refURL = [info valueForKey:UIImagePickerControllerReferenceURL];
-    ALAssetsLibraryAssetForURLResultBlock resultblock = ^(ALAsset *imageAsset)
-    {
-        ALAssetRepresentation *imageRep = [imageAsset defaultRepresentation];
-        self.selectedFilename = [imageRep filename];
-    };
-    // Get the asset library and fetch the asset based on the ref url (pass in block above).
-    ALAssetsLibrary* assetslibrary = [[ALAssetsLibrary alloc] init];
-    [assetslibrary assetForURL:refURL resultBlock:resultblock failureBlock:nil];
     [picker dismissViewControllerAnimated:YES completion:NULL];
-
-    // @todo: self.selectedFilename is null.. not sure whats going on here.
-    NSLog(@"self.selectedFilename %@", self.selectedFilename);
-
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {

--- a/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
+++ b/Lets Do This/Controllers/LDTReportbackSubmitViewController.m
@@ -18,6 +18,7 @@
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *saveButton;
 @property (weak, nonatomic) IBOutlet UIButton *getImageButton;
 - (IBAction)getImageTapped:(id)sender;
+- (IBAction)saveButtonTapped:(id)sender;
 
 @end
 
@@ -33,6 +34,10 @@
 
 - (IBAction)getImageTapped:(id)sender {
     [self getImageMenu];
+}
+
+- (IBAction)saveButtonTapped:(id)sender {
+     [self.tabBarController setSelectedIndex:1];
 }
 
 - (void) getImageMenu {


### PR DESCRIPTION
Adds imagePicker for camera or photo library, and displays the selcted image in the `imageView` outlet.  Doesn't POST the reportback to API yet.

`ALAssetsLibrary` stuff was copied from http://www.raywenderlich.com/forums/viewtopic.php?f=2&p=34901. in the SlothKit to get the name of the selected file (to preserve its file extension).  This library is deprecated and should be replaced by the Photos Framework: https://developer.apple.com/library/ios/documentation/Photos/Reference/Photos_Framework/index.html#//apple_ref/doc/uid/TP40014408