### PR TITLE
add parse crash reporting

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 				C2B151E61ACE04C30028C336 /* Frameworks */,
 				C2B151E71ACE04C30028C336 /* Resources */,
 				57A97D3FE5F4843F35259D92 /* Copy Pods Resources */,
+				EA5104091B28E78300CE79DD /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -506,6 +507,19 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Lets Do This/Pods-Lets Do This-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		EA5104091B28E78300CE79DD /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export PATH=/usr/local/bin:$PATH\ncd /Users/tongxiang/dosomething/LetsDoThis-iOS/parse\n\nparse symbols -p \"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -388,7 +388,7 @@
 				C2B151E61ACE04C30028C336 /* Frameworks */,
 				C2B151E71ACE04C30028C336 /* Resources */,
 				57A97D3FE5F4843F35259D92 /* Copy Pods Resources */,
-				EA5104091B28E78300CE79DD /* ShellScript */,
+				EAD8A0231B2B377A00AE646B /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -508,7 +508,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Lets Do This/Pods-Lets Do This-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EA5104091B28E78300CE79DD /* ShellScript */ = {
+		EAD8A0231B2B377A00AE646B /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -519,7 +519,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=/usr/local/bin:$PATH\ncd /Users/tongxiang/dosomething/LetsDoThis-iOS/parse\n\nparse symbols -p \"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"";
+			shellScript = "echo \"Parse Crash Reporting\"\nexport PATH=/usr/local/bin:$PATH\nCLOUD_CODE_DIR=${PROJECT_DIR}/parse\n\nif [ -d ${CLOUD_CODE_DIR} ]; then\ncd ${CLOUD_CODE_DIR}\nparse symbols MyApp --path=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"\necho \"Finished uploading symbol\"\nelse\necho \"Unable to upload symbols\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Lets Do This/Classes/AppDelegate.m
+++ b/Lets Do This/Classes/AppDelegate.m
@@ -9,6 +9,7 @@
 #import "AppDelegate.h"
 #import "DSOSession.h"
 #import <Parse/Parse.h>
+#import <ParseCrashReporting/ParseCrashReporting.h>
 
 @interface AppDelegate ()
 
@@ -23,6 +24,8 @@
     NSDictionary *keysDictionary = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"keys" ofType:@"plist"]];
 
     [DSOSession setupWithAPIKey:keysDictionary[@"northstarApiKey"] environment:DSOSessionEnvironmentProduction];
+    
+    [ParseCrashReporting enable];
 
     [Parse setApplicationId:keysDictionary[@"parseApplicationId"] clientKey:keysDictionary[@"parseClientKey"]];
     UIUserNotificationType userNotificationTypes = (UIUserNotificationTypeAlert |
@@ -32,6 +35,10 @@
                                                                              categories:nil];
     [application registerUserNotificationSettings:settings];
     [application registerForRemoteNotifications];
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [NSException raise:NSGenericException format:@"Everything is ok. This is just a test crash."];
+    });
 
     return YES;
 }

--- a/Lets Do This/Classes/AppDelegate.m
+++ b/Lets Do This/Classes/AppDelegate.m
@@ -35,10 +35,6 @@
                                                                              categories:nil];
     [application registerUserNotificationSettings:settings];
     [application registerForRemoteNotifications];
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [NSException raise:NSGenericException format:@"Everything is ok. This is just a test crash."];
-    });
 
     return YES;
 }

--- a/Podfile
+++ b/Podfile
@@ -10,4 +10,5 @@ target 'Lets Do This' do
     pod 'SDWebImage', '~> 3.7.2'
     pod 'SSKeychain', '~> 1.2'
     pod 'TSMessages', '~> 0.9'
+    pod 'ParseCrashReporting', '~> 1.7'
 end

--- a/parse/cloud/main.js
+++ b/parse/cloud/main.js
@@ -1,0 +1,6 @@
+
+// Use Parse.Cloud.define to define as many cloud functions as you want.
+// For example:
+Parse.Cloud.define("hello", function(request, response) {
+  response.success("Hello world!");
+});

--- a/parse/public/index.html
+++ b/parse/public/index.html
@@ -1,0 +1,21 @@
+
+<html>
+  <head>
+    <title>My ParseApp site</title>
+    <style>
+    body { font-family: Helvetica, Arial, sans-serif; }
+    div { width: 800px; height: 400px; margin: 40px auto; padding: 20px; border: 2px solid #5298fc; }
+    h1 { font-size: 30px; margin: 0; }
+    p { margin: 40px 0; }
+    em { font-family: monospace; }
+    a { color: #5298fc; text-decoration: none; }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>Congratulations! You're already hosting with Parse.</h1>
+      <p>To get started, edit this file at <em>public/index.html</em> and start adding static content.</p>
+      <p>If you want something a bit more dynamic, delete this file and check out <a href="https://parse.com/docs/hosting_guide#webapp">our hosting docs</a>.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
#### What's this PR do?
Adds Parse crash reporting. 

#### How should this be manually tested?
We've added some exception code (below) to the AppDelegate within `didFinishLaunchingWithOptions`. We've run the app on an iPhone running the app connected to a machine, and thrown the test exception below a few times. We're waiting to see whether or not this implementation of Parse crash reporting actually works, and actually shows up in the Parse console. 

```
    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
        [NSException raise:NSGenericException format:@"Everything is ok. This is just a test crash."];
    });
```
#### Any background context you want to provide?
See #60 for a bit more details into what we've went to. 

#### What are the relevant tickets?
#60. 

#### Questions:
Is this actually working with Parse? Do we need to install the Parse CLI onto each dev's machine before the build works? (We will test this with @jonuy). 