### PR TITLE
Start of Campaign Reportback gallery

### DIFF
--- a/Lets Do This/Base.lproj/Main.storyboard
+++ b/Lets Do This/Base.lproj/Main.storyboard
@@ -738,7 +738,7 @@ activities and group up with friends.</string>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7YO-kD-3pD" id="s3F-TM-cUn">
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WLL-XZ-dBI">
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WLL-XZ-dBI">
                                                     <rect key="frame" x="8" y="8" width="584" height="283"/>
                                                 </imageView>
                                                 <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U12-Kl-XBd">

--- a/Lets Do This/Controllers/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/LDTCampaignDetailViewController.m
@@ -10,8 +10,8 @@
 #import "LDTReportbackSubmitViewController.h"
 
 @interface LDTCampaignDetailViewController()
+@property (strong, nonatomic) NSArray *reportbackItems;
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *proveButton;
-
 @end
 
 @implementation LDTCampaignDetailViewController
@@ -21,6 +21,9 @@
     if (self.campaign.title != nil) {
         self.title = self.campaign.title;
     }
+    [self.campaign reportbackItemsWithStatus:@"promoted" :^(NSArray *reportbackItems, NSError *error) {
+        NSLog(@"reportbackItems %@", reportbackItems);
+    }];
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {

--- a/Lets Do This/Controllers/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/LDTCampaignDetailViewController.m
@@ -8,6 +8,8 @@
 
 #import "LDTCampaignDetailViewController.h"
 #import "LDTReportbackSubmitViewController.h"
+#import <SDWebImage/UIImageView+WebCache.h>
+
 
 @interface LDTCampaignDetailViewController()
 @property (strong, nonatomic) NSArray *reportbackItems;
@@ -82,6 +84,12 @@
     else if (indexPath.section == 2) {
         NSDictionary *reportbackItem = self.reportbackItems[indexPath.row];
         text = reportbackItem[@"caption"];
+        NSURL *imageUrl = [NSURL URLWithString:[reportbackItem valueForKeyPath:@"media.uri"]];
+        NSLog(@"imageUrl %@", imageUrl);
+
+        [cell.imageView sd_setImageWithURL:imageUrl];
+        // Bizarre hack to get the reportback image to display.
+        cell.imageView.image = [UIImage imageNamed:@"ds-logo"];
     }
     cell.textLabel.text = text;
     return cell;

--- a/Lets Do This/Controllers/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/LDTCampaignDetailViewController.m
@@ -22,7 +22,8 @@
         self.title = self.campaign.title;
     }
     [self.campaign reportbackItemsWithStatus:@"promoted" :^(NSArray *reportbackItems, NSError *error) {
-        NSLog(@"reportbackItems %@", reportbackItems);
+        self.reportbackItems = reportbackItems;
+        [self.tableView reloadData];
     }];
 }
 
@@ -46,6 +47,9 @@
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     if (section == 1) {
         return 2;
+    }
+    else if (section == 2) {
+        return [self.reportbackItems count];
     }
     return 1;
 }
@@ -76,7 +80,8 @@
         }
     }
     else if (indexPath.section == 2) {
-        text = @"Reportback pic";
+        NSDictionary *reportbackItem = self.reportbackItems[indexPath.row];
+        text = reportbackItem[@"caption"];
     }
     cell.textLabel.text = text;
     return cell;

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -42,6 +42,8 @@ typedef NS_ENUM(NSUInteger, DSOCampaignInterestGroup) {
 - (void)reportbackValues:(NSDictionary *)values completionHandler:(DSOCampaignReportBackBlock)completionBlock;
 - (void)reportbacksInInbox:(NSInteger)maxNumber completionHandler:(DSOCampaignInboxReportBackBlock)completionBlock;
 
+// Define this here for now.
+- (void)reportbackItemsWithStatus:(NSString *)status :(DSOCampaignListBlock)completionBlock;
 
 @property (nonatomic) NSInteger campaignID;
 @property (strong, nonatomic) NSString *title;

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -104,7 +104,7 @@
     NSString *url = @"campaigns.json?parameters[is_staff_pick]=1";
     [[DSOSession currentSession] GET:url parameters:nil success:^(NSURLSessionDataTask *task, NSArray *response) {
         NSMutableArray *campaigns = [NSMutableArray arrayWithCapacity:response.count];
-        for(NSDictionary *campaignData in response) {
+        for (NSDictionary *campaignData in response) {
             DSOCampaign *campaign = [[DSOCampaign alloc] init];
             [campaign syncWithDictionary:campaignData];
             [campaigns addObject:campaign];
@@ -188,6 +188,22 @@
     }];
 }
 
+- (void)reportbackItemsWithStatus:(NSString *)status :(DSOCampaignListBlock)completionBlock;{
+    NSString *url = [NSString stringWithFormat:@"reportback-items.json?campaigns=%li&status=%@", self.campaignID, status];
+    AFHTTPSessionManager *legacySession = [[DSOSession currentSession] legacyServerSession];
+
+    [legacySession GET:url parameters:nil success:^(NSURLSessionDataTask *task, NSDictionary *response) {
+        NSArray *reportbackItemsResponse = response[@"data"];
+        NSMutableArray *reportbackItems = [NSMutableArray arrayWithCapacity:reportbackItemsResponse.count];
+        for(NSDictionary *reportbackItemData in response[@"data"]) {
+
+            [reportbackItems addObject:reportbackItemData];
+        }
+        completionBlock([reportbackItems copy], nil);
+    } failure:^(NSURLSessionDataTask *task, NSError *error) {
+        NSLog(@"error %@", error.localizedDescription);
+    }];
+}
 
 - (void)syncWithDictionary:(NSDictionary *)values {
     self.campaignID = [values valueForKeyAsInt:@"id" nullValue:self.campaignID];


### PR DESCRIPTION
Refs #54

Adds a new `DSOCampaign reportbackItemsWithStatus` method. TBD how to match block syntax of existing API functions.

Displays promoted reportback captions and images as a tiny tiny little `UITableViewCell.imageView`.

Next up is a custom ReportbackItemTableViewCell to display bigger image / better info.