### PR TITLE
Let there be QA

### DIFF
--- a/Lets Do This/Classes/AppDelegate.m
+++ b/Lets Do This/Classes/AppDelegate.m
@@ -22,7 +22,12 @@
 
     NSDictionary *keysDictionary = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"keys" ofType:@"plist"]];
 
-    [DSOSession setupWithAPIKey:keysDictionary[@"northstarApiKey"] environment:DSOSessionEnvironmentProduction];
+    NSString *apiKey = @"northstarLiveKey";
+    if (DEBUG) {
+        apiKey = @"northstarTestKey";
+    }
+    // @todo: Use environment param correctly (GH #93)
+    [DSOSession setupWithAPIKey:keysDictionary[apiKey] environment:DSOSessionEnvironmentProduction];
 
     [Parse setApplicationId:keysDictionary[@"parseApplicationId"] clientKey:keysDictionary[@"parseClientKey"]];
     UIUserNotificationType userNotificationTypes = (UIUserNotificationTypeAlert |

--- a/Lets Do This/Models/DSOSession.m
+++ b/Lets Do This/Models/DSOSession.m
@@ -19,9 +19,11 @@
 #ifdef DEBUG
 #define DSOPROTOCOL @"http"
 #define DSOSERVER @"staging.beta.dosomething.org"
+#define LDTSERVER @"northstar-qa.dosomething.org"
 #else
 #define DSOPROTOCOL @"https"
 #define DSOSERVER @"www.dosomething.org"
+#define LDTSERVER @"northstar.dosomething.org"
 #endif
 
 
@@ -172,7 +174,7 @@ static NSString *_APIKey;
 }
 
 - (instancetype)init {
-    NSURL *baseURL = [NSURL URLWithString:@"https://api.dosomething.org/v1/"];
+    NSURL *baseURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@/v1/", DSOPROTOCOL, LDTSERVER]];
     self = [super initWithBaseURL:baseURL];
 
     if (self != nil) {

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An iPhone app by DoSomething.org, written in Objective C.
 You'll need to add a `keys.plist` into the "Let's Do This" directory.
 
 Add entries for the following keys (along with their relevant values):
-* `northstarApiKey`
+* `northstarLiveKey`
+* `northstarTestKey`
 * `parseApplicationId`
 * `parseClientKey`


### PR DESCRIPTION
Removes `api.dosomething.org` URL in favor of `northstar.dosomething.org` and `northstar-qa.dosomething.org`.

Refactors `northstarApiKey` element in `keys.plist` as `northstarTestKey` and `northstarLiveKey`.

Makes this so much easier to test correctly.

Refs  #93 - still need to determine if we should instead be using the `DSOSessionEnvironment` typedef for this.