### PR TITLE
add red border to UITextFields with invalid values, remove when editing begins

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		C2B1520C1ACE04C30028C336 /* Lets_Do_ThisTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C2B1520B1ACE04C30028C336 /* Lets_Do_ThisTests.m */; };
 		C2B152201ACE05510028C336 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C2B152181ACE05510028C336 /* AppDelegate.m */; };
 		C2B152381ACE0BB50028C336 /* LDTSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2B152371ACE0BB50028C336 /* LDTSettingsViewController.m */; };
+		EA5C9F1B1B694712001D3EEA /* UITextField+LDT.m in Sources */ = {isa = PBXBuildFile; fileRef = EA5C9F1A1B694712001D3EEA /* UITextField+LDT.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -138,6 +139,8 @@
 		C2B152181ACE05510028C336 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		C2B152361ACE0BB50028C336 /* LDTSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTSettingsViewController.h; path = Profile/LDTSettingsViewController.h; sourceTree = "<group>"; };
 		C2B152371ACE0BB50028C336 /* LDTSettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTSettingsViewController.m; path = Profile/LDTSettingsViewController.m; sourceTree = "<group>"; };
+		EA5C9F191B694712001D3EEA /* UITextField+LDT.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITextField+LDT.h"; sourceTree = "<group>"; };
+		EA5C9F1A1B694712001D3EEA /* UITextField+LDT.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITextField+LDT.m"; sourceTree = "<group>"; };
 		FD644C9FDE4E95B4C94D523F /* libPods-Lets Do This.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Lets Do This.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -360,6 +363,8 @@
 				C20BA28C1AF3DCAB00E9886F /* NSDictionary+DSOJsonHelper.m */,
 				B216CFC41B685EE8007E1914 /* UIImageView+LDT.h */,
 				B216CFC51B685EE8007E1914 /* UIImageView+LDT.m */,
+				EA5C9F191B694712001D3EEA /* UITextField+LDT.h */,
+				EA5C9F1A1B694712001D3EEA /* UITextField+LDT.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -587,6 +592,7 @@
 			files = (
 				B260387B1B449491002FE362 /* LDTUserSignupCodeView.m in Sources */,
 				C20BA28E1AF3DCAB00E9886F /* NSDictionary+DSOJsonHelper.m in Sources */,
+				EA5C9F1B1B694712001D3EEA /* UITextField+LDT.m in Sources */,
 				B2A1365E1B3CA4B100D20273 /* LDTUserConnectViewController.m in Sources */,
 				B22274051B587A20005C896D /* LDTCampaignListViewController.m in Sources */,
 				B2A136631B3D9BC600D20273 /* LDTUserRegisterViewController.m in Sources */,

--- a/Lets Do This/Categories/UITextField+LDT.h
+++ b/Lets Do This/Categories/UITextField+LDT.h
@@ -1,0 +1,15 @@
+//
+//  UITextField+LDT.h
+//  Lets Do This
+//
+//  Created by Tong Xiang on 7/29/15.
+//  Copyright (c) 2015 Do Something. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface UITextField (LDT)
+
+- (void) setBorderColor:(UIColor *)color;
+
+@end

--- a/Lets Do This/Categories/UITextField+LDT.m
+++ b/Lets Do This/Categories/UITextField+LDT.m
@@ -1,0 +1,21 @@
+//
+//  UITextField+LDT.m
+//  Lets Do This
+//
+//  Created by Tong Xiang on 7/29/15.
+//  Copyright (c) 2015 Do Something. All rights reserved.
+//
+
+#import "UITextField+LDT.h"
+#import <QuartzCore/QuartzCore.h>
+
+@implementation UITextField (LDT)
+
+- (void) setBorderColor:(UIColor *)color {
+    self.layer.cornerRadius = 8.0f;
+    self.layer.masksToBounds = YES;
+    self.layer.borderColor = [color CGColor];
+    self.layer.borderWidth = 2.0f;
+}
+
+@end

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -14,6 +14,7 @@
 #import "LDTUserProfileViewController.h"
 #import "LDTUserLoginViewController.h"
 #import "DSOAuthenticationManager.h"
+#import "UITextField+LDT.h"
 
 @interface LDTUserRegisterViewController () <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 @property (weak, nonatomic) IBOutlet LDTButton *loginLink;
@@ -38,6 +39,13 @@
 - (IBAction)avatarButtonTouchUpInside:(id)sender;
 - (IBAction)submitButtonTouchUpInside:(id)sender;
 - (IBAction)loginLinkTouchUpInside:(id)sender;
+
+- (IBAction)firstNameEditingDidBegin:(id)sender;
+- (IBAction)lastNameEditingDidBegin:(id)sender;
+- (IBAction)emailEditingDidBegin:(id)sender;
+- (IBAction)mobileEditingDidBegin:(id)sender;
+- (IBAction)passwordEditingDidBegin:(id)sender;
+- (IBAction)birthdayEditingDidBegin:(id)sender;
 
 - (IBAction)lastNameEditingDidEnd:(id)sender;
 - (IBAction)firstNameEditingDidEnd:(id)sender;
@@ -194,6 +202,30 @@
     }
 }
 
+- (IBAction)firstNameEditingDidBegin:(id)sender {
+    [self.firstNameTextField setBorderColor:[UIColor clearColor]];
+}
+
+- (IBAction)lastNameEditingDidBegin:(id)sender {
+    [self.lastNameTextField setBorderColor:[UIColor clearColor]];
+}
+
+- (IBAction)emailEditingDidBegin:(id)sender {
+    [self.emailTextField setBorderColor:[UIColor clearColor]];
+}
+
+- (IBAction)mobileEditingDidBegin:(id)sender {
+    [self.mobileTextField setBorderColor:[UIColor clearColor]];
+}
+
+- (IBAction)passwordEditingDidBegin:(id)sender {
+    [self.passwordTextField setBorderColor:[UIColor clearColor]];
+}
+
+- (IBAction)birthdayEditingDidBegin:(id)sender {
+    // Are we going to do any validations on birthdays?
+}
+
 - (IBAction)lastNameEditingDidEnd:(id)sender {
     UITextField *textField = (UITextField *)sender;
     self.lastNameTextField.text = [textField.text capitalizedString];
@@ -244,21 +276,27 @@
 }
 
 - (BOOL)validateForm {
+    
     NSMutableArray *errorMessages = [[NSMutableArray alloc] init];;
 
     if (![self validateName:self.firstNameTextField.text]) {
+        [self.firstNameTextField setBorderColor:[UIColor redColor]];
         [errorMessages addObject:@"We need your first name."];
     }
     if (![self validateName:self.lastNameTextField.text]) {
+        [self.lastNameTextField setBorderColor:[UIColor redColor]];
         [errorMessages addObject:@"We need your last name."];
     }
     if (![self validateEmail:self.emailTextField.text]) {
+        [self.emailTextField setBorderColor:[UIColor redColor]];
         [errorMessages addObject:@"We need a valid email."];
     }
     if (![self validateMobile:self.mobileTextField.text]) {
+        [self.mobileTextField setBorderColor:[UIColor redColor]];
         [errorMessages addObject:@"Enter a valid telephone number."];
     }
     if (![self validatePassword:self.passwordTextField.text]) {
+        [self.passwordTextField setBorderColor:[UIColor redColor]];
         [errorMessages addObject:@"Password must be 6+ characters."];
     }
 
@@ -356,4 +394,5 @@
     LDTUserLoginViewController *destVC = [[LDTUserLoginViewController alloc] initWithNibName:@"LDTUserLoginView" bundle:nil];
     [self.navigationController pushViewController:destVC animated:YES];
 }
+
 @end

--- a/Lets Do This/Views/Login/LDTUserRegisterView.xib
+++ b/Lets Do This/Views/Login/LDTUserRegisterView.xib
@@ -67,6 +67,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
+                                        <action selector="firstNameEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="86I-af-i9h"/>
                                         <action selector="firstNameEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="nbT-qO-hqj"/>
                                     </connections>
                                 </textField>
@@ -78,6 +79,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
+                                        <action selector="lastNameEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="VQW-iZ-42t"/>
                                         <action selector="lastNameEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="zvy-40-VOw"/>
                                     </connections>
                                 </textField>
@@ -89,6 +91,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
+                                        <action selector="emailEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="LIT-XD-dSn"/>
                                         <action selector="emailEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="HEW-0X-uDa"/>
                                     </connections>
                                 </textField>
@@ -100,6 +103,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
+                                        <action selector="mobileEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="rQP-g7-jLa"/>
                                         <action selector="mobileEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="RSk-J1-pW5"/>
                                     </connections>
                                 </textField>
@@ -111,6 +115,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                     <connections>
+                                        <action selector="passwordEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="P1w-BR-BWV"/>
                                         <action selector="passwordEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="Gf2-ib-CdJ"/>
                                     </connections>
                                 </textField>
@@ -122,6 +127,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
+                                        <action selector="birthdayEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="rVo-tV-Rgx"/>
                                         <action selector="birthdayEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="8wI-YT-Yj7"/>
                                     </connections>
                                 </textField>


### PR DESCRIPTION
#### What's this PR do?

Adds a red border to text fields on the user registration field if the content is invalid when the `CREATE ACCOUNT` button is pressed. 

Then, when the user taps on each text field to begin editing it, the red border is removed. 
#### Where should the reviewer start?

`LDTUserRegisterViewController.m`. 
#### How should this be manually tested?

Building and attempting the flow listed above. 
#### What are the relevant tickets?

Closes #121. 
#### Questions:
1. Are we planning on having any validations for the DOB field? (I added an IBAction called `birthdayEditingDidBegin` which would remove any potential red border, but I noticed that we're not validating it in the first place. If we're not planning on doing any validations, I'll take it out.) 
2. Just wanted to confirm that we want to handle validations as specified in #121: because we validate when the `CREATE ACCOUNT` button is pressed, we won't add red borders to invalid fields until that button is pressed. Secondly, I want to confirm that we want to remove the red border when the user taps that text field and editing begins--not when the field registers as valid, correct? 
