### PR TITLE
fix register view scrollview 

### DIFF
--- a/Lets Do This/Views/Login/LDTUserRegisterView.xib
+++ b/Lets Do This/Views/Login/LDTUserRegisterView.xib
@@ -35,7 +35,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hON-y7-TtZ">
-                            <rect key="frame" x="250" y="29" width="100" height="100"/>
+                            <rect key="frame" x="250" y="28" width="100" height="100"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="100" id="Xfx-6N-hU8"/>
                                 <constraint firstAttribute="height" constant="100" id="fJv-s0-Eg5"/>
@@ -48,7 +48,7 @@
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bhL-AU-dqT">
-                            <rect key="frame" x="8" y="158" width="584" height="200"/>
+                            <rect key="frame" x="8" y="157" width="584" height="200"/>
                             <subviews>
                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="First Name" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QjS-W9-vkE">
                                     <rect key="frame" x="0.0" y="0.0" width="584" height="44"/>
@@ -116,17 +116,8 @@
                                 <constraint firstItem="CZ0-O0-iWG" firstAttribute="leading" secondItem="bhL-AU-dqT" secondAttribute="leading" id="yDN-mg-NSy"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WQo-g9-7HX" customClass="LDTButton">
-                            <rect key="frame" x="8" y="374" width="584" height="30"/>
-                            <state key="normal" title="Submit">
-                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                            </state>
-                            <connections>
-                                <action selector="submitButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="fSU-lp-hwo"/>
-                            </connections>
-                        </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ggr-KI-p8I" customClass="LDTButton">
-                            <rect key="frame" x="276" y="412" width="48" height="30"/>
+                            <rect key="frame" x="276" y="411" width="48" height="30"/>
                             <state key="normal" title="Sign In">
                                 <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
@@ -134,13 +125,13 @@
                                 <action selector="loginLinkTouchUpInside:" destination="-1" eventType="touchUpInside" id="Uj6-8b-X7n"/>
                             </connections>
                         </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cyo-DU-kOw">
-                            <rect key="frame" x="8" y="458" width="584" height="0.0"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disclaimer Text" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cyo-DU-kOw">
+                            <rect key="frame" x="8" y="458" width="584" height="21"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="21" id="9xr-Pb-sNQ"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
                             <variation key="default">
                                 <mask key="constraints">
@@ -154,12 +145,21 @@
                             </variation>
                         </label>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Nkh-6g-VOu">
-                            <rect key="frame" x="250" y="29" width="100" height="100"/>
+                            <rect key="frame" x="250" y="28" width="100" height="100"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="100" id="nta-qi-c8g"/>
                                 <constraint firstAttribute="width" constant="100" id="pzn-S8-LOs"/>
                             </constraints>
                         </imageView>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WQo-g9-7HX" customClass="LDTButton">
+                            <rect key="frame" x="8" y="373" width="584" height="30"/>
+                            <state key="normal" title="Submit">
+                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                            </state>
+                            <connections>
+                                <action selector="submitButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="fSU-lp-hwo"/>
+                            </connections>
+                        </button>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <constraints>
@@ -208,6 +208,7 @@
                 <constraint firstItem="lQg-IH-mxS" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Uor-sb-zGr"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="242" y="618"/>
         </view>
     </objects>


### PR DESCRIPTION
#### What's this PR do?

Previously, the disclaimer text at the bottom of the register view wouldn't display on screen sizes smaller than an iphone 6. 

Now this is fixed--> on screens smaller than an iPhone 6, you'll be able to scroll down on the register view to see all the text. 

This was due to faulty autolayout usage with scroll views. Generally, how far the scroll view scrolls is determined by the `contentSize` property of the scroll view. But with auto layout enabled, the `contentSize` is determined by the things inside the scroll view. 

The items inside the scrollview can't solely have constraints relative to the boundaries of the scroll view. They need to have constraints relative to themselves **and** the scrollview in order to "push" the scroll view open. For the disclaimer text, we added a top space constraint to the sign in button and a button space constraint to the edge of the scroll view. This fixed our problem. 
