### PR TITLE
add countryName method to user object

### DIFF
--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -38,7 +38,7 @@
 
     if (self) {
         self.userID = northstarDict[@"_id"];
-        if ([northstarDict objectForKey:@"country"] != nil) {
+        if ([northstarDict objectForKey:@"country"]) {
             self.countryCode = northstarDict[@"country"];
         }
         self.phoenixID = [northstarDict[@"drupal_id"] intValue];
@@ -79,20 +79,22 @@
     if (!self.countryCode) {
         return @"";
     }
-    else {
-        NSArray *countryCodes = [NSLocale ISOCountryCodes];
-        NSMutableArray *countries = [NSMutableArray arrayWithCapacity:[countryCodes count]];
-        
-        for (NSString *countryCode in countryCodes)
-        {
-            NSString *identifier = [NSLocale localeIdentifierFromComponents: [NSDictionary dictionaryWithObject: countryCode forKey: NSLocaleCountryCode]];
-            NSString *country = [[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"] displayNameForKey: NSLocaleIdentifier value: identifier];
-            [countries addObject: country];
-        }
-        
-        NSDictionary *codeForCountryDictionary = [[NSDictionary alloc] initWithObjects:countries forKeys:countryCodes];
+    NSArray *countryCodes = [NSLocale ISOCountryCodes];
+    NSMutableArray *fullCountryNames = [NSMutableArray arrayWithCapacity:countryCodes.count];
+    
+    for (NSString *countryCode in countryCodes) {
+        // Finding a unique locale identifier from one geographic datum: the countryCode.
+        NSString *localeIdentifier = [NSLocale localeIdentifierFromComponents:[NSDictionary dictionaryWithObject:countryCode forKey:NSLocaleCountryCode]];
+        // Using that locale identifier to find all the information about that locale, and specifically retrieving its full name.
+        NSString *fullCountryName = [[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"] displayNameForKey:NSLocaleIdentifier value:localeIdentifier];
+        [fullCountryNames addObject:fullCountryName];
+    }
+    
+    NSDictionary *codeForCountryDictionary = [[NSDictionary alloc] initWithObjects:fullCountryNames forKeys:countryCodes];
+    if (codeForCountryDictionary[self.countryCode]) {
         return codeForCountryDictionary[self.countryCode];
     }
+    return @"";
 }
 
 - (void)setPhoto:(UIImage *)photo {


### PR DESCRIPTION
#### What's this PR do?

Adds a new property, `countryName`, to the `DSOUser` class. If the user object holds a country code, this property returns the full name of the country. 

The `initWithNorthstarDict` property now initializes users with a `countryCode` object if they've previously created their profiles with one. 
#### How should this be manually tested?

By referencing the property--`NSLog("%@", self.countryName)`-- after a user object is created. I'll put the staging credentials for a non-American user in the IOS room. If you log in as that user, you'll be able to see `CN` rendered as `China`. 
#### What are the relevant tickets?

Closes #240. 
