### PR TITLE
DSOAPI cleanup / Fetch Reportback Items by status

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -77,7 +77,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailSectionType) {
 }
 
 - (void)fetchReportbackItems {
-    [[DSOAPI sharedInstance] fetchReportbackItemsForCampaigns:@[self.campaign] completionHandler:^(NSArray *rbItems) {
+    [[DSOAPI sharedInstance] fetchReportbackItemsForCampaigns:@[self.campaign] status:@"promoted" completionHandler:^(NSArray *rbItems) {
 		[self.reportbackItems addObjectsFromArray:rbItems];
         [self.collectionView reloadData];
     } errorHandler:^(NSError *error) {

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -132,7 +132,7 @@ const CGFloat kHeightExpanded = 400;
     }
 
     for (NSNumber *key in self.interestGroups) {
-        [[DSOAPI sharedInstance] fetchReportbackItemsForCampaigns:self.interestGroups[key][@"campaigns"] completionHandler:^(NSArray *rbItems) {
+        [[DSOAPI sharedInstance] fetchReportbackItemsForCampaigns:self.interestGroups[key][@"campaigns"] status:@"promoted" completionHandler:^(NSArray *rbItems) {
             for (DSOReportbackItem *rbItem in rbItems) {
                 [self.interestGroups[key][@"reportbackItems"] addObject:rbItem];
             }

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -37,6 +37,6 @@
 
 - (void)fetchCampaignsWithCompletionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)fetchReportbackItemsForCampaigns:(NSArray *)campaigns completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+- (void)fetchReportbackItemsForCampaigns:(NSArray *)campaigns status:(NSString *)status completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 @end

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -222,13 +222,13 @@
     }];
 }
 
-- (void)fetchReportbackItemsForCampaigns:(NSArray *)campaigns completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+- (void)fetchReportbackItemsForCampaigns:(NSArray *)campaigns status:(NSString *)status completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSMutableArray *campaignIds = [[NSMutableArray alloc] init];
     for (DSOCampaign *campaign in campaigns) {
         [campaignIds addObject:[NSString stringWithFormat:@"%li", (long)campaign.campaignID]];
     }
 
-    NSString *url = [NSString stringWithFormat:@"%@reportback-items.json?status=promoted&campaigns=%@", self.phoenixApiURL, [campaignIds componentsJoinedByString:@","]];
+    NSString *url = [NSString stringWithFormat:@"%@reportback-items.json?status=%@&campaigns=%@", self.phoenixApiURL, status,[campaignIds componentsJoinedByString:@","]];
 
     [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
           NSMutableArray *rbItems = [[NSMutableArray alloc] init];


### PR DESCRIPTION
- Cleanup success / failure blocks: https://github.com/DoSomething/LetsDoThis-iOS/pull/246/files#diff-2aea389f640f43f009a52f9eaca4a165R155
- Cleanup line spacing: https://github.com/DoSomething/LetsDoThis-iOS/pull/273/files#diff-47c0ca5dc8c7d668f0fd3248f3d56d2cR19
- Refactor `fetchReportbackItemsForCampaigns:` method to accept `(NSString *)status` and query API accordingly - refs #58
