### PR TITLE
Fetch and display approved Reportback Items additionally

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -77,12 +77,15 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailSectionType) {
 }
 
 - (void)fetchReportbackItems {
-    [[DSOAPI sharedInstance] fetchReportbackItemsForCampaigns:@[self.campaign] status:@"promoted" completionHandler:^(NSArray *rbItems) {
+    NSArray *statusValues = @[@"promoted", @"approved"];
+    for (NSString *status in statusValues) {
+        [[DSOAPI sharedInstance] fetchReportbackItemsForCampaigns:@[self.campaign] status:status completionHandler:^(NSArray *rbItems) {
 		[self.reportbackItems addObjectsFromArray:rbItems];
         [self.collectionView reloadData];
-    } errorHandler:^(NSError *error) {
-        [LDTMessage displayErrorMessageForError:error];
-    }];
+        } errorHandler:^(NSError *error) {
+            [LDTMessage displayErrorMessageForError:error];
+        }];
+    }
 }
 
 - (void)configureCampaignCell:(LDTCampaignDetailCampaignCell *)cell {

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -131,16 +131,20 @@ const CGFloat kHeightExpanded = 400;
         }
     }
 
-    for (NSNumber *key in self.interestGroups) {
-        [[DSOAPI sharedInstance] fetchReportbackItemsForCampaigns:self.interestGroups[key][@"campaigns"] status:@"promoted" completionHandler:^(NSArray *rbItems) {
-            for (DSOReportbackItem *rbItem in rbItems) {
-                [self.interestGroups[key][@"reportbackItems"] addObject:rbItem];
-            }
-            [self.collectionView reloadData];
-        } errorHandler:^(NSError *error) {
-            [LDTMessage displayErrorMessageForError:error];
-        }];
+    NSArray *statusValues = @[@"promoted", @"approved"];
+    for (NSString *status in statusValues) {
+        for (NSNumber *key in self.interestGroups) {
+            [[DSOAPI sharedInstance] fetchReportbackItemsForCampaigns:self.interestGroups[key][@"campaigns"] status:status completionHandler:^(NSArray *rbItems) {
+                for (DSOReportbackItem *rbItem in rbItems) {
+                    [self.interestGroups[key][@"reportbackItems"] addObject:rbItem];
+                }
+                [self.collectionView reloadData];
+            } errorHandler:^(NSError *error) {
+                [LDTMessage displayErrorMessageForError:error];
+            }];
+        }
     }
+
 }
 
 - (NSNumber *)selectedInterestGroupId {


### PR DESCRIPTION
Refs #58 -- Fetches approved Reportback Items as well as promoted, and displays the approved Reportback Items after the promoted ones.

This is placeholder code for now. When I began testing paginated requests to begin building infinite scrolling, discovered https://github.com/DoSomething/phoenix/issues/5047.
