### PR TITLE
add red highlight around email textfield on login error

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -12,6 +12,7 @@
 #import "LDTMessage.h"
 #import "LDTUserRegisterViewController.h"
 #import "LDTTabBarController.h"
+#import "UITextField+LDT.h"
 
 @interface LDTUserLoginViewController ()
 
@@ -25,6 +26,7 @@
 - (IBAction)registerLinkTouchUpInside:(id)sender;
 - (IBAction)submitButtonTouchUpInside:(id)sender;
 - (IBAction)passwordButtonTouchUpInside:(id)sender;
+- (IBAction)emailEditingDidBegin:(id)sender;
 - (IBAction)emailEditingDidEnd:(id)sender;
 - (IBAction)passwordEditingDidEnd:(id)sender;
 - (IBAction)passwordEditingChanged:(id)sender;
@@ -131,12 +133,17 @@
     } errorHandler:^(NSError *error) {
         [self.passwordTextField becomeFirstResponder];
         [LDTMessage displayErrorMessageForError:error];
+        [self.emailTextField setBorderColor:[UIColor redColor]];
     }];
 }
 
 - (IBAction)passwordButtonTouchUpInside:(id)sender {
     NSString *resetUrl = [NSString stringWithFormat:@"%@user/password", [[DSOAPI sharedInstance] phoenixBaseUrl]];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:resetUrl]];
+}
+
+- (IBAction)emailEditingDidBegin:(id)sender {
+    [self.emailTextField setBorderColor:[UIColor clearColor]];
 }
 
 - (IBAction)emailEditingDidEnd:(id)sender {

--- a/Lets Do This/Views/Login/LDTUserLoginView.xib
+++ b/Lets Do This/Views/Login/LDTUserLoginView.xib
@@ -61,6 +61,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
+                                        <action selector="emailEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="O3p-wm-uBo"/>
                                         <action selector="emailEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="Geq-eG-sRW"/>
                                     </connections>
                                 </textField>


### PR DESCRIPTION
#### What's this PR do?

Adds a red border around the email textfield when the user receives a login error. Removes the red border when user begins to edit the email textfield. 
#### What are the relevant tickets?

Closes #296. 
