### PR TITLE
hotfix for inconsistent id's

### DIFF
--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -37,6 +37,10 @@
 
     if (self) {
         self.userID = dict[@"_id"];
+        // Hack to hotfix inconsistent API id property: https://github.com/DoSomething/LetsDoThis-iOS/issues/340
+        if (!self.userID) {
+            self.userID = dict[@"id"];
+        }
         if ([dict objectForKey:@"country"]) {
             self.countryCode = dict[@"country"];
         }


### PR DESCRIPTION
Phoenix returns the User id as `id`, but Northstar returns it as `_id`. This alters the check in `initWithDict` to look for `id` if `_id` was not found.
