### PR TITLE
add new "expires in" prefix tag label, separating "expires in X days" label into two labels

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -168,13 +168,14 @@ const CGFloat kHeightExpanded = 400;
         cell.signedUp = NO;
     }
 
-    NSString *expiresString = @"";
+    NSString *expiresPrefixString = @"";
+    NSString *expiresSuffixString = @"";
     if (campaign.numberOfDaysLeft > 0) {
-        expiresString = [NSString stringWithFormat:@"%li Days", (long)[campaign numberOfDaysLeft]];
-        cell.expiresDaysPrefixLabelText = @"Expires in";
+        expiresSuffixString = [NSString stringWithFormat:@"%li Days", (long)[campaign numberOfDaysLeft]];
+        expiresPrefixString = @"Expires in";
     }
-    
-    cell.expiresDaysLabelText = expiresString;
+    cell.expiresDaysPrefixLabelText = expiresPrefixString;
+    cell.expiresDaysSuffixLabelText = expiresSuffixString;
 }
 
 - (void)configureReportbackItemCell:(LDTCampaignListReportbackItemCell *)cell atIndexPath:(NSIndexPath *)indexPath {

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.h
@@ -18,7 +18,7 @@
 @property (strong, nonatomic) DSOCampaign *campaign;
 @property (strong, nonatomic) NSString *actionButtonTitle;
 @property (strong, nonatomic) NSString *expiresDaysPrefixLabelText;
-@property (strong, nonatomic) NSString *expiresDaysLabelText;
+@property (strong, nonatomic) NSString *expiresDaysSuffixLabelText;
 @property (strong, nonatomic) NSString *taglineLabelText;
 @property (strong, nonatomic) NSString *titleLabelText;
 @property (strong, nonatomic) NSURL *imageViewImageURL;

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
@@ -16,8 +16,8 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
 @property (nonatomic, assign) CGFloat collapsedTitleLabelTopLayoutConstraintConstant;
 @property (weak, nonatomic) IBOutlet LDTButton *actionButton;
 @property (weak, nonatomic) IBOutlet UIImageView *imageView;
-@property (weak, nonatomic) IBOutlet UILabel *expiresLabel;
 @property (weak, nonatomic) IBOutlet UILabel *expiresPrefixLabel;
+@property (weak, nonatomic) IBOutlet UILabel *expiresSuffixLabel;
 @property (weak, nonatomic) IBOutlet UILabel *taglineLabel;
 @property (weak, nonatomic) IBOutlet UILabel *titleLabel;
 @property (weak, nonatomic) IBOutlet UIView *actionView;
@@ -44,9 +44,9 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
     self.expiresPrefixLabel.textColor = [UIColor grayColor];
     self.expiresPrefixLabel.textAlignment = NSTextAlignmentRight;
 
-    self.expiresLabel.font = [LDTTheme fontBold];
-    self.expiresLabel.textColor = [UIColor blackColor];
-    self.expiresLabel.textAlignment = NSTextAlignmentLeft;
+    self.expiresSuffixLabel.font = [LDTTheme fontBold];
+    self.expiresSuffixLabel.textColor = [UIColor blackColor];
+    self.expiresSuffixLabel.textAlignment = NSTextAlignmentLeft;
     
     self.titleLabel.textColor = [UIColor whiteColor];
     [self.actionButton enable];
@@ -80,8 +80,8 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
     self.expiresPrefixLabel.text = [expiresDaysPrefixLabelText uppercaseString];
 }
 
-- (void)setExpiresDaysLabelText:(NSString *)expiresDaysLabelText {
-     self.expiresLabel.text = [expiresDaysLabelText uppercaseString];
+- (void)setExpiresDaysSuffixLabelText:(NSString *)expiresDaysSuffixLabelText {
+     self.expiresSuffixLabel.text = [expiresDaysSuffixLabelText uppercaseString];
 }
 
 - (void)setActionButtonTitle:(NSString *)actionButtonTitle {

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
@@ -128,8 +128,8 @@
             <connections>
                 <outlet property="actionButton" destination="D5G-Kr-aLa" id="8Mp-o4-dfK"/>
                 <outlet property="actionView" destination="rcw-DX-Omy" id="aWI-gS-8u3"/>
-                <outlet property="expiresLabel" destination="VbD-83-6o3" id="jeS-Y0-zRQ"/>
                 <outlet property="expiresPrefixLabel" destination="AoE-fr-CS1" id="dVg-D4-DBn"/>
+                <outlet property="expiresSuffixLabel" destination="VbD-83-6o3" id="yvO-5o-I4W"/>
                 <outlet property="imageView" destination="YLY-38-HRb" id="cKD-59-2BH"/>
                 <outlet property="imageViewBottom" destination="Rmg-UZ-qQD" id="qpG-BT-Ojb"/>
                 <outlet property="imageViewTop" destination="5Ak-wS-aSM" id="7uL-K5-Q5X"/>


### PR DESCRIPTION
#### What's this PR do?

Splits the "EXPIRES IN 5 DAYS" label on the `LDTCampaignListCampaignCell` into two labels, with different colors to match [this design](https://github.com/DoSomething/product/blob/5b8c919ec895ce36651024fd15e75082ca440701/LetsDoThis/Screens/Discovery/Main%20Feed%20Open.png).

I've also changed the order of properties in `LDTCampaignListCampaignCell.m` and `LDTCampaignListCampaignCell.h` to be listed in alphabetical order (first by type, then by name).

**constraints added**
We added the two labels inside a 168 pixel wide view, which was centered in the view and placed 16 px below the "Let's do this button". The labels have been given constraints so that they're flush against the view. The "EXPIRES IN" prefix view is 95 pixels wide, and the "X DAYS" view is 69 pixels wide (accounting for a two digit number.) The two views are 4 pixels away from each other. 

The text in the left label is right justified, the text in the right label is left justified. 

Tested on iPhone 4, 5, and 6. 
#### What are the relevant tickets?

Closes #226. 
