### PR TITLE
Add circle frame to Reportback Item Detail avatar 

### DIFF
--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
@@ -31,6 +31,7 @@
 }
 
 - (void)styleView {
+    [self.userAvatarImageView addCircleFrame];
     self.campaignTitleButton.titleLabel.font = [LDTTheme fontBold];
     self.reportbackItemCaptionLabel.font = [LDTTheme font];
     self.reportbackItemQuantityLabel.font = [LDTTheme fontCaptionBold];


### PR DESCRIPTION
Missed this because the actual Default Avatar image has the circle mask saved in the image (exported from Sketch)

![ios simulator screen shot sep 18 2015 2 13 26 pm](https://cloud.githubusercontent.com/assets/1236811/9971292/8c8f484c-5e0f-11e5-9e44-c3815cc6ba5a.png)
