### PR TITLE
change notification messages to appear at top of viewport

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -174,7 +174,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailSectionType) {
     }
     else {
         [[DSOUserManager sharedInstance] signupUserForCampaign:cell.campaign completionHandler:^(NSDictionary *response) {
-            [LDTMessage showNotificationWithTitle:@"Great!" subtitle:[NSString stringWithFormat:@"You signed up for %@!", cell.campaign.title] type:TSMessageNotificationTypeSuccess];
+            [LDTMessage displaySuccessMessageWithTitle:@"Great!" subtitle:[NSString stringWithFormat:@"You signed up for %@!", cell.campaign.title]];
             cell.actionButtonTitle = @"Prove it";
          } errorHandler:^(NSError *error) {
              [LDTMessage displayErrorMessageForError:error];

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -238,9 +238,9 @@ const CGFloat kHeightExpanded = 400;
             cell.actionButtonTitle = @"More info";
             [self.navigationController pushViewController:destVC animated:YES];
             [LDTMessage setDefaultViewController:self.navigationController];
-            [LDTMessage showNotificationWithTitle:@"Great!" subtitle:[NSString stringWithFormat:@"You signed up for %@!", cell.campaign.title] type:TSMessageNotificationTypeSuccess];
+            [LDTMessage displaySuccessMessageWithTitle:@"Great!" subtitle:[NSString stringWithFormat:@"You signed up for %@!", cell.campaign.title]];
         } errorHandler:^(NSError *error) {
-             [LDTMessage displayErrorMessageForError:error];
+            [LDTMessage displayErrorMessageForError:error];
         }];
     }
 }

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -97,7 +97,7 @@
     self.reportbackItem.quantity = [self.quantityTextField.text integerValue];
     [[DSOUserManager sharedInstance] postUserReportbackItem:self.reportbackItem completionHandler:^(NSDictionary *response) {
         [self dismissViewControllerAnimated:YES completion:nil];
-        [LDTMessage showNotificationWithTitle:@"Stunning!" subtitle:[NSString stringWithFormat:@"You submitted a %@ photo for approval.", self.reportbackItem.campaign.title] type:TSMessageNotificationTypeSuccess];
+        [LDTMessage displaySuccessMessageWithTitle:@"Stunning!" subtitle:[NSString stringWithFormat:@"You submitted a %@ photo for approval.", self.reportbackItem.campaign.title]];
     } errorHandler:^(NSError *error) {
         [LDTMessage setDefaultViewController:self.navigationController];
         [LDTMessage displayErrorMessageForError:error];

--- a/Lets Do This/Views/LDTMessage.h
+++ b/Lets Do This/Views/LDTMessage.h
@@ -12,5 +12,6 @@
 
 +(void)displayErrorMessageForString:(NSString *)title;
 +(void)displayErrorMessageForError:(NSError *)error;
++(void)displaySuccessMessageWithTitle:(NSString *)title subtitle:(NSString *)subtitle;
 
 @end

--- a/Lets Do This/Views/LDTMessage.m
+++ b/Lets Do This/Views/LDTMessage.m
@@ -12,8 +12,7 @@
 @implementation LDTMessage
 
 +(void)displayErrorMessageForString:(NSString *)title {
-    [TSMessage showNotificationWithTitle:title
-                                    type:TSMessageNotificationTypeError];
+    [TSMessage showNotificationInViewController:[TSMessage defaultViewController] title:title subtitle:nil image:nil type:TSMessageNotificationTypeError duration:TSMessageNotificationDurationAutomatic callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionNavBarOverlay canBeDismissedByUser:YES];
 }
 
 +(void)displayErrorMessageForError:(NSError *)error {
@@ -31,10 +30,12 @@
         code = [errorDict valueForKeyAsInt:@"code" nullValue:0];
         message = [errorDict valueForKeyAsString:@"message"];
     }
+    [TSMessage showNotificationInViewController:[TSMessage defaultViewController] title:[NSString stringWithFormat:@"O noes, error %li", (long)code] subtitle:message image:nil type:TSMessageNotificationTypeError duration:TSMessageNotificationDurationAutomatic callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionNavBarOverlay canBeDismissedByUser:YES];
+}
 
-    [TSMessage showNotificationWithTitle:[NSString stringWithFormat:@"O noes, error %li", (long)code]
-                                subtitle:message
-                                    type:TSMessageNotificationTypeError];
++(void)displaySuccessMessageWithTitle:(NSString *)title subtitle:(NSString *)subtitle {
+    [TSMessage showNotificationInViewController:[TSMessage defaultViewController] title:title subtitle:subtitle image:nil type:TSMessageNotificationTypeSuccess duration:TSMessageNotificationDurationAutomatic callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionNavBarOverlay canBeDismissedByUser:YES];
+
 }
 
 @end


### PR DESCRIPTION
#### What's this PR do?

Changes notification messages to appear at top of viewport. 

Does this by: 
1. Modifying the `LDTMessage` subclass to use a different `TSMessage` method (`showNotificationInViewController`) which has more customizability. 
2. Calling this method with the `TSMessageNotificationPositionNavBarOverlay` enum, which forces the notification message to appear over the NavBar, if one exists in the view. 
3. Adding a new method, `displaySuccessMessageWithTitle` to the `LDTMessage` subclass, and then replacing all success message calls with this new message. 
#### Where should the reviewer start?

`LDTMessage.m`. Then, check out the method invocations in the other view controller files. 
#### How should this be manually tested?

Tested by navigating to screens where these messages are displayed. Tested: 
1. AppDelegate.h - LDTMessage displayErrorMessageForError
2. LDTUserLoginViewController - LDTMessage displayErrorMessageForString
3. LDTCampaignListViewController - LDTMessage displaySuccessMessageWithTitle
#### What are the relevant tickets?

Closes #352. 
#### Questions:
1. I'm thinking that we can refactor the `displayErrorMessageWithString` function in another PR. Think we should handle it now?
2. Do you think the message notifications are too large? (I.e., have too much height?) Could be that the message images are stretching the view. 
