### PR TITLE
Opened for review - disable buttons for API response

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -69,7 +69,7 @@
                                 self.passwordTextField];
 
     [self.submitButton setTitle:[@"Sign in" uppercaseString] forState:UIControlStateNormal];
-    [self.submitButton disable];
+    [self.submitButton enable:NO];
     [self.passwordButton setTitle:[@"Forgot password?" uppercaseString] forState:UIControlStateNormal];
 
     [self styleView];
@@ -106,10 +106,10 @@
         }
     }
     if (enabled) {
-        [self.submitButton enable];
+        [self.submitButton enable:YES];
     }
     else {
-        [self.submitButton disable];
+        [self.submitButton enable:NO];
     }
 }
 
@@ -120,16 +120,12 @@
 }
 
 - (IBAction)submitButtonTouchUpInside:(id)sender {
-	// Think we can just put this here once and then enable it further down if we're successful:
-	[self.submitButton disable];
+    [self.submitButton enable:NO];
 	
     if (![self validateEmailForCandidate:self.emailTextField.text]) {
         [LDTMessage displayErrorMessageForString:@"Please enter a valid email."];
-//        [self.submitButton disable];
-		
         return;
     }
-//    [self.submitButton disable];
     [[DSOUserManager sharedInstance] createSessionWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
         // This VC is always presented within a NavVC, so kill it.
         [self dismissViewControllerAnimated:YES completion:^{
@@ -137,7 +133,7 @@
             [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:destVC animated:NO completion:nil];
         }];
     } errorHandler:^(NSError *error) {
-        [self.submitButton enable];
+        [self.submitButton enable:YES];
         [self.passwordTextField becomeFirstResponder];
         [LDTMessage displayErrorMessageForError:error];
         [self.emailTextField setBorderColor:[UIColor redColor]];
@@ -163,7 +159,7 @@
 
 - (IBAction)passwordEditingChanged:(id)sender {
     if (self.passwordTextField.text.length > 5) {
-        [self.submitButton enable];
+        [self.submitButton enable:YES];
     }
 }
 

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -69,7 +69,7 @@
 	[super viewDidLoad];
 
     [self.submitButton setTitle:[@"Create account" uppercaseString] forState:UIControlStateNormal];
-    [self.submitButton disable];
+    [self.submitButton enable:NO];
     [self.loginLink setTitle:@"Have a DoSomething.org account? Sign in" forState:UIControlStateNormal];
     
     self.footerLabel.adjustsFontSizeToFitWidth = NO;
@@ -139,7 +139,7 @@
 
 - (IBAction)submitButtonTouchUpInside:(id)sender {
     if ([self validateForm]) {
-        [self.submitButton disable];
+        [self.submitButton enable:NO];
         [[DSOAPI sharedInstance] createUserWithEmail:self.emailTextField.text password:self.passwordTextField.text firstName:self.firstNameTextField.text mobile:self.mobileTextField.text countryCode:self.countryCode success:^(NSDictionary *response) {
 
             [[DSOUserManager sharedInstance] createSessionWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
@@ -162,16 +162,16 @@
 
             } errorHandler:^(NSError *error) {
                 [LDTMessage displayErrorMessageForError:error];
-                [self.submitButton enable];
+                [self.submitButton enable:YES];
             }];
 
         } failure:^(NSError *error) {
             [LDTMessage displayErrorMessageForError:error];
-            [self.submitButton enable];
+            [self.submitButton enable:YES];
         }];
     }
     else {
-        [self.submitButton disable];
+        [self.submitButton enable:NO];
     }
 }
 
@@ -231,10 +231,10 @@
         }
     }
     if (enabled) {
-        [self.submitButton enable];
+        [self.submitButton enable:YES];
     }
     else {
-        [self.submitButton disable];
+        [self.submitButton enable:NO];
     }
 }
 

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -80,20 +80,20 @@
     self.primaryImageView.layer.masksToBounds = YES;
     self.primaryImageView.layer.borderColor = [UIColor whiteColor].CGColor;
     self.primaryImageView.layer.borderWidth = 1;
-    [self.submitButton disable];
+    [self.submitButton enable:NO];
 }
 
 - (void)updateSubmitButton {
     if (self.captionTextField.text.length > 0 && self.quantityTextField.text.length > 0 && self.quantityTextField.text.intValue > 0) {
-        [self.submitButton enable];
+        [self.submitButton enable:YES];
     }
     else {
-        [self.submitButton disable];
+        [self.submitButton enable:NO];
     }
 }
 
 - (IBAction)submitButtonTouchUpInside:(id)sender {
-    [self.submitButton disable];
+    [self.submitButton enable:NO];
     self.reportbackItem.caption = self.captionTextField.text;
     self.reportbackItem.quantity = [self.quantityTextField.text integerValue];
     [[DSOUserManager sharedInstance] postUserReportbackItem:self.reportbackItem completionHandler:^(NSDictionary *response) {
@@ -102,7 +102,7 @@
     } errorHandler:^(NSError *error) {
         [LDTMessage setDefaultViewController:self.navigationController];
         [LDTMessage displayErrorMessageForError:error];
-        [self.submitButton enable];
+        [self.submitButton enable:YES];
     }];
 }
 

--- a/Lets Do This/Views/Base/LDTButton.h
+++ b/Lets Do This/Views/Base/LDTButton.h
@@ -10,7 +10,6 @@
 
 @interface LDTButton : UIButton
 
--(void)disable;
--(void)enable;
+-(void)enable:(BOOL)enabled;
 
 @end

--- a/Lets Do This/Views/Base/LDTButton.m
+++ b/Lets Do This/Views/Base/LDTButton.m
@@ -17,9 +17,6 @@
     if (self) {
         [[self titleLabel] setFont:[LDTTheme fontBold]];
         self.layer.cornerRadius = 4;
-		
-		// Can we not set these here once? Don't think we should have to set each time on disabled or not. Also,
-		// Don't we want UIControlStateDisabled for enabled = NO?
 		[self setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
 		[self setTitleColor:[UIColor grayColor] forState:UIControlStateDisabled];
     }
@@ -27,7 +24,6 @@
     return self;
 }
 
-// These both can be combined into one method
 -(void)enable:(BOOL)enabled {
 	if (enabled) {
 		self.backgroundColor = [LDTTheme ctaBlueColor];
@@ -37,18 +33,6 @@
 	}
 	
 	self.enabled = enabled;
-}
-
--(void)disable {
-    self.enabled = NO;
-    self.backgroundColor = [LDTTheme disabledGrayColor];
-    [self setTitleColor:[UIColor grayColor] forState:UIControlStateNormal];
-}
-
--(void)enable {
-    self.enabled = YES;
-    self.backgroundColor = [LDTTheme ctaBlueColor];
-    [self setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
 }
 
 @end

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
@@ -48,7 +48,7 @@
     self.solutionSupportCopyLabel.font = [LDTTheme font];
     self.staticInstructionLabel.textColor = [UIColor whiteColor];
     self.staticInstructionLabel.font = [LDTTheme font];
-    [self.actionButton enable];
+    [self.actionButton enable:YES];
 
     CAShapeLayer *layer = [CAShapeLayer layer];
     UIBezierPath *path = [UIBezierPath bezierPath];

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
@@ -49,7 +49,7 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
     self.expiresSuffixLabel.textAlignment = NSTextAlignmentLeft;
     
     self.titleLabel.textColor = [UIColor whiteColor];
-    [self.actionButton enable];
+    [self.actionButton enable:YES];
     [self.imageView addGrayTint];
 }
 


### PR DESCRIPTION
Disables some submit buttons which are defined on View Controllers (tracked in #378 -- didn't add this code to all of them yet).

When testing on a slow network, what definitely seems to be missing is a better indication to the User that we're waiting for the response back -- like displaying a larger Network Activity Indicator. There's a [Cocoapod, MBProgressHUD](https://github.com/jdg/MBProgressHUD)) which claims to do this

@eroth Any thoughts on a relatively low lift way to implement -- and if current approach I'm starting on looks good? Have you ever used that cocoapod before?
