### PR TITLE
add enable register button when user has inputted password longer than 5 chars

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -44,6 +44,7 @@
 - (IBAction)emailEditingDidEnd:(id)sender;
 - (IBAction)mobileEditingDidBegin:(id)sender;
 - (IBAction)mobileEditingDidEnd:(id)sender;
+- (IBAction)passwordEditingChanged:(id)sender;
 - (IBAction)passwordEditingDidBegin:(id)sender;
 - (IBAction)passwordEditingDidEnd:(id)sender;
 
@@ -216,15 +217,22 @@
     [self updateCreateAccountButton];
 }
 
+- (IBAction)passwordEditingChanged:(id)sender {
+    [self updateCreateAccountButton];
+}
+
 - (void)updateCreateAccountButton {
     BOOL enabled = NO;
-    for (UITextField *aTextField in self.textFieldsRequired) {
-        if (aTextField.text.length > 0) {
-            enabled = YES;
-        }
-        else {
-            enabled = NO;
-            break;
+    
+    if (self.passwordTextField.text.length > 5) {
+        for (UITextField *aTextField in self.textFieldsRequired) {
+            if (aTextField.text.length > 0) {
+                enabled = YES;
+            }
+            else {
+                enabled = NO;
+                break;
+            }
         }
     }
     if (enabled) {

--- a/Lets Do This/Views/Login/LDTUserRegisterView.xib
+++ b/Lets Do This/Views/Login/LDTUserRegisterView.xib
@@ -90,6 +90,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                     <connections>
+                                        <action selector="passwordEditingChanged:" destination="-1" eventType="editingChanged" id="kE1-qZ-Eh0"/>
                                         <action selector="passwordEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="P1w-BR-BWV"/>
                                         <action selector="passwordEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="Gf2-ib-CdJ"/>
                                     </connections>


### PR DESCRIPTION
#### What's this PR do?

Within the register view, enables the register button when the user has inputted a password longer than 5 characters. Disables register button if user edits text text and text field has 5 or fewer characters. (To prevent user from deleting characters while putting in password, submitting a password of <=5 characters, and then being unable to ever login to the login view, which requires > 5 chars.) 
#### Background Information?

This was previously implemented by #390. But I pushed a messy rebase which caused merge conflicts in the `LDTUserRegisterView.xib`, and then reverted that PR. 
#### What are the relevant tickets?

Closes #360. 
