### PR TITLE
add App Transport Security protection override for staging DS servers

### DIFF
--- a/Lets Do This/Info.plist
+++ b/Lets Do This/Info.plist
@@ -65,5 +65,29 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>northstar-qa.dosomething.org</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSTemporaryExceptionMinimumTLSVersion</key>
+				<string>TLSv1.1</string>
+			</dict>
+			<key>staging.beta.dosomething.org</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSTemporaryExceptionMinimumTLSVersion</key>
+				<string>TLSv1.1</string>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
#### What's this PR do?

iOS 9, and XCode 7, have introduced new security requirements (as detailed in #388.) 

We're adding XML here to override those security requirements for our staging servers during development. (Otherwise, our app can't connect to those servers if it's running on iOS 9). Before we launch the app, we'll ensure that the requisite security provisions have been added to our production servers and this XML will be changed.
#### What are the relevant tickets?

Related to, but does not close, #388. 
