### PR TITLE
add char limits to reportback caption submission form

### DIFF
--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -19,9 +19,10 @@
 @property (weak, nonatomic) IBOutlet LDTButton *submitButton;
 
 - (IBAction)submitButtonTouchUpInside:(id)sender;
-- (IBAction)captionTextFieldEditingDidEnd:(id)sender;
-- (IBAction)quantityTextFieldEditingDidEnd:(id)sender;
 - (IBAction)quantityTextFieldEditingChanged:(id)sender;
+- (IBAction)quantityTextFieldEditingDidEnd:(id)sender;
+- (IBAction)captionTextFieldEditingChanged:(id)sender;
+- (IBAction)captionTextFieldEditingDidEnd:(id)sender;
 
 @end
 
@@ -85,7 +86,7 @@
 }
 
 - (void)updateSubmitButton {
-    if (self.captionTextField.text.length > 0 && self.quantityTextField.text.length > 0 && self.quantityTextField.text.intValue > 0) {
+    if (self.captionTextField.text.length > 0 && self.captionTextField.text.length < 61 && self.quantityTextField.text.length > 0 && self.quantityTextField.text.intValue > 0) {
         [self.submitButton enable:YES];
     }
     else {
@@ -107,21 +108,20 @@
     }];
 }
 
+- (IBAction)quantityTextFieldEditingChanged:(id)sender {
+    [self updateSubmitButton];
+}
+
+- (IBAction)captionTextFieldEditingChanged:(id)sender {
+    [self updateSubmitButton];
+}
+
 - (IBAction)captionTextFieldEditingDidEnd:(id)sender {
     [self updateSubmitButton];
 }
 
 - (IBAction)quantityTextFieldEditingDidEnd:(id)sender {
     [self updateSubmitButton];
-}
-
-- (IBAction)quantityTextFieldEditingChanged:(id)sender {
-    if (self.quantityTextField.text.intValue > 0) {
-        [self.submitButton enable];
-    }
-    else {
-        [self.submitButton disable];
-    }
 }
 
 @end

--- a/Lets Do This/Views/Reportback/LDTSubmitReportbackView.xib
+++ b/Lets Do This/Views/Reportback/LDTSubmitReportbackView.xib
@@ -57,7 +57,8 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
-                                        <action selector="captionTextFieldEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="2jt-1S-6ee"/>
+                                        <action selector="captionTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="Mdm-3a-o57"/>
+                                        <action selector="captionTextFieldEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="oml-KD-67w"/>
                                     </connections>
                                 </textField>
                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Number of nouns verbed" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="z5z-3H-aUv" userLabel="Quantity Text Field">
@@ -66,7 +67,7 @@
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
                                         <action selector="quantityTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="ht6-pZ-PPT"/>
-                                        <action selector="quantityTextFieldEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="hdS-Ji-9uB"/>
+                                        <action selector="quantityTextFieldEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="sFY-4U-8Oh"/>
                                     </connections>
                                 </textField>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g7X-Cr-BiL" userLabel="Submit Button" customClass="LDTButton">


### PR DESCRIPTION
#### What's this PR do?
1. Adds a 60 character limit to reportback caption submissions. If the user goes above 60 characters, the submission button is disabled. 
2. Adds a `captionTextFieldEditingChanged` IBAction to make sure user gets instantaneous feedback about character length (and doesn't need to tap outside of text field in order to get feedback from submission button.) 
#### What are the relevant tickets?

Closes #369. 
