### PR TITLE
Fixes blank Main Feed bug

### DIFF
--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -47,25 +47,20 @@
 
     [[DSOAPI sharedInstance] loginWithEmail:email password:password completionHandler:^(DSOUser *user) {
           self.user = user;
-
           [[DSOAPI sharedInstance] setHTTPHeaderFieldSession:user.sessionToken];
-
           // Save session in Keychain for when app is quit.
           [SSKeychain setPassword:user.sessionToken forService:LDTSERVER account:@"Session"];
           [SSKeychain setPassword:self.user.userID forService:LDTSERVER account:@"UserID"];
-
           [[DSOAPI sharedInstance] loadCampaignsWithCompletionHandler:^(NSArray *campaigns) {
               self.activeMobileAppCampaigns = campaigns;
+              if (completionHandler) {
+                  completionHandler(user);
+              }
           } errorHandler:^(NSError *error) {
               if (errorHandler) {
                   errorHandler(error);
               }
           }];
-
-          if (completionHandler) {
-              completionHandler(user);
-          }
-
       } errorHandler:^(NSError *error) {
           if (errorHandler) {
               errorHandler(error);


### PR DESCRIPTION
The bug is in the `createSessionWithEmail:` method, which explains why this only occurred upon Login and Registration when the app first loads (without an authenticated user). 

The fix is to call the `completionHandler` (which in this case, displays the Main Feed) until after we have loaded the Campaigns.
