### PR TITLE
remove totally useless property avatarFileString

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -17,7 +17,6 @@
 @property (assign, nonatomic) BOOL userDidPickAvatarPhoto;
 @property (strong, nonatomic) CLLocationManager *locationManager;
 @property (strong, nonatomic) DSOUser *user;
-@property (strong, nonatomic) NSString *avatarFilestring;
 @property (strong, nonatomic) NSString *countryCode;
 @property (strong, nonatomic) UIImagePickerController *imagePicker;
 @property (weak, nonatomic) IBOutlet LDTButton *loginLink;
@@ -352,7 +351,6 @@
     UIImage *chosenImage = info[UIImagePickerControllerEditedImage];
     self.imageView.image = chosenImage;
     self.userDidPickAvatarPhoto = YES;
-    self.avatarFilestring = [UIImagePNGRepresentation(chosenImage) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
     [picker dismissViewControllerAnimated:YES completion:NULL];
 }
 


### PR DESCRIPTION
#### What's this PR do?

Removes the property `avatarFileString` from `LDTUserRegisterViewController`, which isn't used for anything. 

When I was previously building out the photo upload functionality in the Register View, I included this property since I assumed we were going to upload the image as a Base 64-encoded string. We didn't do this, and the upload functionality is all kept within `DSOAPI`, so there's no need for this property to exist within `LDTUserRegisterViewController` anymore. 
