### PR TITLE
remove "avatar stored at local path" nslog messages

### DIFF
--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -101,9 +101,6 @@
             else {
                 [storedUserDefaults setObject:storedAvatarPhotoPath forKey:@"storedAvatarPhotoPath"];
                 [storedUserDefaults synchronize];
-				
-                NSString *successMessage = [NSString stringWithFormat:@"Avatar successfully stored locally at path: %@", storedAvatarPhotoPath];
-                NSLog(successMessage, nil);
             }
         }
     }


### PR DESCRIPTION
Removes the log which fires when a new `_photo` is stored locally. 
