### PR TITLE
ensure app transport security compliance

### DIFF
--- a/Lets Do This/Info.plist
+++ b/Lets Do This/Info.plist
@@ -36,30 +36,6 @@
 	</dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>northstar-qa.dosomething.org</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSTemporaryExceptionMinimumTLSVersion</key>
-				<string>TLSv1.1</string>
-			</dict>
-			<key>staging.beta.dosomething.org</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSTemporaryExceptionMinimumTLSVersion</key>
-				<string>TLSv1.1</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>We need your location to give you the most relevant campaigns!</string>
 	<key>UIAppFonts</key>

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -15,7 +15,7 @@
 
 // API Constants
 #define isActivityLogging NO
-#define DSOPROTOCOL @"http"
+#define DSOPROTOCOL @"https"
 #define DSOSERVER @"staging.beta.dosomething.org"
 #define LDTSERVER @"northstar-qa.dosomething.org"
 #define LDTSOURCENAME @"letsdothis_ios"


### PR DESCRIPTION
#### What's this PR do?

With iOS9, new security protocols were introduced which mandated that communication between backend servers and iOS apps needed to confirm to certain security settings. 

With Uy's help, I've confirmed that both production and staging versions of Northstar and Phoenix conform to these settings. The only changes were to make our API calls with `HTTPS` instead of `HTTP`, as well as delete the added XML to our `info.plist` which overrides the security protocols. 
#### How should this be manually tested?

Tested API calls on both production and staging environments. 
#### What are the relevant tickets?

Closes #388.
#### Questions:

@aaronschachter--since my last PR, the "CODE_SIGN_IDENTITY" parameter has changed in my `project.pbxproj` file. I'm not sure why this has happened--this may be related to Uy giving my apple developer account "technical" permissions yesterday in order to give me access to the iTunes Connect account. 

The mysterious parameter change bothers me--do you have any insight? 
