### PR TITLE
Dynamic Height: Sizing Cell -- opened for review

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
 @property (strong, nonatomic) DSOCampaign *campaign;
 @property (strong, nonatomic) DSOReportbackItem *currentUserReportback;
+@property (strong, nonatomic) LDTCampaignDetailCampaignCell *sizingCampaignCell;
 @property (strong, nonatomic) NSMutableArray *reportbackItems;
 @property (strong, nonatomic) UIImagePickerController *imagePickerController;
 
@@ -60,7 +61,11 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
     [self styleBackBarButton];
 
-    [self.collectionView registerNib:[UINib nibWithNibName:@"LDTCampaignDetailCampaignCell" bundle:nil] forCellWithReuseIdentifier:@"CampaignCell"];
+    UINib *campaignCellNib = [UINib nibWithNibName:@"LDTCampaignDetailCampaignCell" bundle:nil];
+    [self.collectionView registerNib:campaignCellNib forCellWithReuseIdentifier:@"CampaignCell"];
+    self.sizingCampaignCell = [[campaignCellNib instantiateWithOwner:nil options:nil] firstObject];
+    NSLog(@"self.sizingCampaignCell %@", self.sizingCampaignCell);
+
     [self.collectionView registerNib:[UINib nibWithNibName:@"LDTCampaignDetailReportbackItemCell" bundle:nil] forCellWithReuseIdentifier:@"ReportbackItemCell"];
     [self.collectionView registerNib:[UINib nibWithNibName:@"LDTCampaignDetailSelfReportbackCell" bundle:nil] forCellWithReuseIdentifier:@"SelfReportbackCell"];
     [self.collectionView registerNib:[UINib nibWithNibName:@"LDTHeaderCollectionReusableView" bundle:nil] forSupplementaryViewOfKind:UICollectionElementKindSectionHeader withReuseIdentifier:@"ReusableView"];
@@ -303,8 +308,13 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     CGFloat reportbackItemHeight = screenWidth + 36 + 70;
 
     if (indexPath.section == LDTCampaignDetailSectionTypeCampaign) {
-        // @todo: Dynamic height (GH issue #320)
-        CGFloat campaignCellHeight = 660;
+        // Set the sizingCell with campaign data to populate the xib contents.
+        [self configureCampaignCell:self.sizingCampaignCell];
+        CGSize campaignCellSize = [self.sizingCampaignCell systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
+        NSLog(@"campaignCellSize width = %f height = %f", campaignCellSize.width, campaignCellSize. height);
+        CGFloat campaignCellHeight = campaignCellSize.height;
+//        CGFloat campaignCellHeight = 660;
+
         if ([[self user] hasCompletedCampaign:self.campaign]) {
             if (indexPath.row == LDTCampaignDetailCampaignSectionRowSelfReportback) {
                 // Button height + top and bottom margins = 90

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
@@ -113,6 +113,7 @@
                 <constraint firstItem="q5F-7f-Qdj" firstAttribute="top" secondItem="jAl-nc-WCh" secondAttribute="bottom" constant="25" id="SxG-Ji-lUg"/>
                 <constraint firstItem="jAl-nc-WCh" firstAttribute="top" secondItem="AS3-o6-YFe" secondAttribute="bottom" constant="8" id="Ty8-q8-gyH"/>
                 <constraint firstAttribute="trailing" secondItem="3QF-fG-65U" secondAttribute="trailing" id="UWa-SM-rwS"/>
+                <constraint firstAttribute="bottom" secondItem="q5F-7f-Qdj" secondAttribute="bottom" constant="12" id="XuO-WG-Uym"/>
                 <constraint firstItem="jAl-nc-WCh" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="aln-zq-RCi"/>
                 <constraint firstItem="AS3-o6-YFe" firstAttribute="top" secondItem="3QF-fG-65U" secondAttribute="bottom" constant="16" id="iZ5-Hc-Ob5"/>
                 <constraint firstAttribute="trailing" secondItem="AS3-o6-YFe" secondAttribute="trailing" constant="21" id="k6K-xQ-WGQ"/>


### PR DESCRIPTION
Refs #320 but does not resolve yet... 

@eroth Trying to get a sizing cell working as a last resort -- haven't had luck with any of the tutorials in https://github.com/DoSomething/LetsDoThis-iOS/issues/320#issuecomment-141836064

i need to add a bottom constraint from the "Prove it" button to the bottom of the cell container view in order to get `[self.sizingCampaignCell systemLayoutSizeFittingSize:UILayoutFittingCompressedSize]` to return a non zero value.

However, when we subtract the height of the "Prove it" button when the user has already proved it... the bottom constraint cuts into the DO It block instead of cutting off the Action Button (since it now has a bottom constraint to the bottom)

One idea is that we refactor "Prove It" button as a different type of UICollectionViewCell, so we won't have to do math to subtract the height to remove the button.

However, I'm still running into odd behavior where the height returned by ` `[self.sizingCampaignCell systemLayoutSizeFittingSize:UILayoutFittingCompressedSize]` is off in general .. the text will cut itself off with the "..."

All text fields have their number of lines set to 0.
## Before Proving it:

![simulator screen shot sep 30 2015 12 27 59 pm](https://cloud.githubusercontent.com/assets/1236811/10204092/b78b5258-676e-11e5-87bf-dd0498f4356a.png)
## After Proving It:

![simulator screen shot sep 30 2015 12 31 18 pm](https://cloud.githubusercontent.com/assets/1236811/10204196/36bd6228-676f-11e5-9d59-467a94d71cd2.png)
