### PR TITLE
add functionality to delete avatar from storage upon logout

### DIFF
--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -19,7 +19,6 @@
 @property (nonatomic, strong, readonly) NSString *email;
 @property (nonatomic, strong, readonly) NSString *firstName;
 @property (nonatomic, strong, readonly) NSString *mobile;
-@property (nonatomic, strong, readonly) NSString *photoNameString;
 @property (nonatomic, strong, readonly) NSString *sessionToken;
 @property (nonatomic, strong, readonly) NSString *userID;
 @property (nonatomic, strong, readonly) UIImage *photo;

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -43,4 +43,10 @@
 // Returns DSOCampaign for a given Campaign id if it exists in the activeMobileAppCampaigns property.
 - (DSOCampaign *)activeMobileAppCampaignWithId:(NSInteger)campaignID;
 
+// Stores the user's avatar image within the filesystem. 
+- (void)storeAvatar:(UIImage *)photo;
+
+// Retrieves the user's avatar image from the filesystem. Returns nil if photo doesn't exist.
+- (UIImage *)retrieveAvatar;
+
 @end


### PR DESCRIPTION
#### What's this PR do?

Adds functionality to delete the user avatar from local storage when the user logs out. 
#### Any background context you want to provide?

This is to fix a problem we had previously: if user1 logs out, her photo is preserved locally. When user2 logs into the app on the same device, user1's profile photo is displayed in user2's account. 
#### What are the relevant tickets?

Closes #443. 
