### PR TITLE
add bug fix: changing profile photo in settings now also changes photo displayed in user profile

### DIFF
--- a/Lets Do This/Controllers/Profile/LDTUserProfileViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTUserProfileViewController.m
@@ -45,13 +45,12 @@ static NSString *cellIdentifier = @"rowCell";
     [super viewDidLoad];
 
     self.navigationItem.title = nil;
-
     [self styleView];
     [self updateUserDetails];
-
     [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:cellIdentifier];
 
     if ([self.user isLoggedInUser]) {
+
         UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"Settings Icon"] style:UIBarButtonItemStylePlain target:self action:@selector(settingsTapped:)];
         self.navigationItem.rightBarButtonItem = settingsButton;
     }
@@ -67,10 +66,9 @@ static NSString *cellIdentifier = @"rowCell";
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-
     [self styleView];
-
     if ([self.user isLoggedInUser]) {
+        [self updateUserDetails];
         // Logged in user may have signed up or reported back since this VC was first loaded.
         [self.tableView reloadData];
     }


### PR DESCRIPTION
#### What's this PR do?

Previously, if we changed the user's profile photo, the photo wouldn't be changed when we navigated back to the settings page. 

This fixes that problem by refreshing the user's profile photo within the `LDTUserProfileViewController`'s `viewDidAppear` function. 
#### What are the relevant tickets?

Closes #456. 
#### Questions:

@aaronschachter: Notice that when we navigate back to the profile view, the profile photo doesn't change until the nav controller animation glitch resolves (roughly <1 second after navigating to that view.) Are these two problems related? Will closing #457 also make the profile photo change immediately? 
