### PR TITLE
Hotfix

### DIFF
--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -19,7 +19,7 @@
 #define LDTSOURCENAME @"letsdothis_ios"
 
 #ifdef DEBUG
-#define DSOSERVER @"staging.beta.dosomething.org"
+#define DSOSERVER @"staging.dosomething.org"
 #define LDTSERVER @"northstar-qa.dosomething.org"
 #define LDTSERVERKEYNAME @"northstarTestKey"
 #endif


### PR DESCRIPTION
Whoops. Fixes redeclaration error.

Also points debug to `staging.dosomething.org` per recent #DEVOPS changes
