### PR TITLE
if user inputs password < 6 chars, gray out sign in button

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -161,6 +161,9 @@
     if (self.passwordTextField.text.length > 5) {
         [self.submitButton enable:YES];
     }
+    else {
+        [self.submitButton enable:NO];
+    }
 }
 
 @end


### PR DESCRIPTION
Sign in view: if user inputs a password that's less than 6 characters, keep the sign in button grayed. 

Also means that if a user inputs a password > 5 characters, and then deletes characters to make her password =< 5 characters, the submit button grays out. 

 Closes #465. 
