### PR TITLE
Fixes empty signups upon login

### DIFF
--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -52,9 +52,16 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
           [SSKeychain setPassword:self.user.userID forService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"UserID"];
           [[DSOAPI sharedInstance] loadCampaignsWithCompletionHandler:^(NSArray *campaigns) {
               self.activeMobileAppCampaigns = campaigns;
-              if (completionHandler) {
-                  completionHandler(user);
-              }
+              [[DSOAPI sharedInstance] loadCampaignSignupsForUser:self.user completionHandler:^(NSArray *campaignSignups) {
+                  self.user.campaignSignups = (NSMutableArray *)campaignSignups;
+                  if (completionHandler) {
+                      completionHandler(user);
+                  }
+              } errorHandler:^(NSError *error) {
+                  if (errorHandler) {
+                      errorHandler(error);
+                  }
+              }];
           } errorHandler:^(NSError *error) {
               if (errorHandler) {
                   errorHandler(error);


### PR DESCRIPTION
Calls `loadCampaignSignupsForUser:` within `createSessionWithEmail` to populate the logged in user's `campaignSignups` property.

Note: This will fire upon user registration too, which is then an extra API call we don't need to make since we know the new user hasn't signed up for anything. To keep things simple, let's just do it this way for now and to close #477.
