### PR TITLE
GoogleAnalytics cocoapod + GAI+LDT category

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		B2629F261BAB460D00A1B5C3 /* LDTUpdateAvatarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2629F251BAB460D00A1B5C3 /* LDTUpdateAvatarView.xib */; };
 		B273A7681B459BB700CBD4E1 /* Brandon_med.otf in Resources */ = {isa = PBXBuildFile; fileRef = B273A7661B459B6C00CBD4E1 /* Brandon_med.otf */; };
 		B273A7691B459BBA00CBD4E1 /* Brandon_bld.otf in Resources */ = {isa = PBXBuildFile; fileRef = B273A7671B459BA300CBD4E1 /* Brandon_bld.otf */; };
+		B2753E391BD17C49004DDD6A /* GAI+LDT.m in Sources */ = {isa = PBXBuildFile; fileRef = B2753E381BD17C49004DDD6A /* GAI+LDT.m */; settings = {ASSET_TAGS = (); }; };
 		B27AF0E41B4F48BC00164926 /* LDTUserProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B27AF0E31B4F48BC00164926 /* LDTUserProfileViewController.m */; };
 		B27AF0E71B4F493D00164926 /* LDTUserProfileView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B27AF0E61B4F493D00164926 /* LDTUserProfileView.xib */; };
 		B27AF0EB1B4F64B200164926 /* LDTLoadingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B27AF0EA1B4F64B200164926 /* LDTLoadingViewController.m */; };
@@ -139,6 +140,8 @@
 		B2629F251BAB460D00A1B5C3 /* LDTUpdateAvatarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTUpdateAvatarView.xib; path = Settings/LDTUpdateAvatarView.xib; sourceTree = "<group>"; };
 		B273A7661B459B6C00CBD4E1 /* Brandon_med.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = Brandon_med.otf; path = Resources/Fonts/Brandon_med.otf; sourceTree = "<group>"; };
 		B273A7671B459BA300CBD4E1 /* Brandon_bld.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = Brandon_bld.otf; path = Resources/Fonts/Brandon_bld.otf; sourceTree = "<group>"; };
+		B2753E371BD17C49004DDD6A /* GAI+LDT.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GAI+LDT.h"; sourceTree = "<group>"; };
+		B2753E381BD17C49004DDD6A /* GAI+LDT.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GAI+LDT.m"; sourceTree = "<group>"; };
 		B27AF0E21B4F48BC00164926 /* LDTUserProfileViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTUserProfileViewController.h; path = Profile/LDTUserProfileViewController.h; sourceTree = "<group>"; };
 		B27AF0E31B4F48BC00164926 /* LDTUserProfileViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTUserProfileViewController.m; path = Profile/LDTUserProfileViewController.m; sourceTree = "<group>"; };
 		B27AF0E61B4F493D00164926 /* LDTUserProfileView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTUserProfileView.xib; path = Profile/LDTUserProfileView.xib; sourceTree = "<group>"; };
@@ -475,6 +478,8 @@
 				EA5C9F1A1B694712001D3EEA /* UITextField+LDT.m */,
 				B28124D01BAA1FB700DF58DA /* UIViewController+LDT.h */,
 				B28124D11BAA1FB700DF58DA /* UIViewController+LDT.m */,
+				B2753E371BD17C49004DDD6A /* GAI+LDT.h */,
+				B2753E381BD17C49004DDD6A /* GAI+LDT.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -772,6 +777,7 @@
 				B20D06D11B3A58F40053D3B6 /* LDTMessage.m in Sources */,
 				C20BA2831AF3DBE400E9886F /* DSOCampaign.m in Sources */,
 				B23E68261B8FC74E005BFB5E /* LDTCampaignDetailReportbackItemCell.m in Sources */,
+				B2753E391BD17C49004DDD6A /* GAI+LDT.m in Sources */,
 				B28124CF1BAA0DF000DF58DA /* UINavigationController+LDT.m in Sources */,
 				B248D5091BCDC1100029DF60 /* LDTCampaignDetailActionButtonCell.m in Sources */,
 			);

--- a/Lets Do This/Categories/GAI+LDT.h
+++ b/Lets Do This/Categories/GAI+LDT.h
@@ -1,0 +1,16 @@
+//
+//  GAI+LDT.h
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 10/16/15.
+//  Copyright © 2015 Do Something. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <GoogleAnalytics/GAI.h>
+
+@interface GAI (LDT)
+
+- (void)trackScreenView:(NSString *)screenName;
+
+@end

--- a/Lets Do This/Categories/GAI+LDT.m
+++ b/Lets Do This/Categories/GAI+LDT.m
@@ -1,0 +1,20 @@
+//
+//  GAI+LDT.m
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 10/16/15.
+//  Copyright © 2015 Do Something. All rights reserved.
+//
+
+#import "GAI+LDT.h"
+#import <GoogleAnalytics/GAIFields.h>
+#import <GoogleAnalytics/GAIDictionaryBuilder.h>
+
+@implementation GAI (LDT)
+
+- (void)trackScreenView:(NSString *)screenName {
+    [self.defaultTracker set:kGAIScreenName value:screenName];
+    [self.defaultTracker send:[[GAIDictionaryBuilder createScreenView] build]];
+}
+
+@end

--- a/Lets Do This/Classes/AppDelegate.m
+++ b/Lets Do This/Classes/AppDelegate.m
@@ -17,9 +17,11 @@
 #import "LDTTabBarController.h"
 #import "DSOUserManager.h"
 #import "TSMessageView.h"
-
+#import "GAI+LDT.h"
 #import <Fabric/Fabric.h>
 #import <Crashlytics/Crashlytics.h>
+
+#define isLoggingGoogleAnalytics NO
 
 @interface AppDelegate ()
 
@@ -31,8 +33,21 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
 	[Fabric with:@[CrashlyticsKit]];
-	
+
     NSDictionary *keysDict = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"keys" ofType:@"plist"]];
+
+    NSString *GAItrackingID = keysDict[@"googleAnalyticsLiveTrackingID"];
+#ifdef DEBUG
+    GAItrackingID = keysDict[@"googleAnalyticsTestTrackingID"];
+#elif THOR
+    GAItrackingID = keysDict[@"googleAnalyticsTestTrackingID"];
+#endif
+
+    [[GAI sharedInstance] trackerWithTrackingId:GAItrackingID];
+    if (isLoggingGoogleAnalytics) {
+        [GAI sharedInstance].trackUncaughtExceptions = YES;
+        [GAI sharedInstance].logger.logLevel = kGAILogLevelVerbose;
+    }
 
     [AFNetworkActivityIndicatorManager sharedManager].enabled = YES;
     [SVProgressHUD setDefaultMaskType:SVProgressHUDMaskTypeBlack];

--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -16,7 +16,7 @@
 #import "LDTUserProfileViewController.h"
 #import "LDTSubmitReportbackViewController.h"
 #import "LDTMessage.h"
-
+#import "GAI+LDT.h"
 
 typedef NS_ENUM(NSInteger, LDTCampaignDetailSectionType) {
     LDTCampaignDetailSectionTypeCampaign,
@@ -95,6 +95,9 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
+
+    // todo: Append the user's status to this string.
+    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"campaign/%ld", (long)self.campaign.campaignID]];
 
     // Might have just come from the Reportback Submit screen,
     // so check for currentUserReportback

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -16,6 +16,7 @@
 #import "LDTCampaignListCampaignCell.h"
 #import "LDTCampaignListReportbackItemCell.h"
 #import "LDTHeaderCollectionReusableView.h"
+#import "GAI+LDT.h"
 
 typedef NS_ENUM(NSInteger, LDTCampaignListSectionType) {
     LDTCampaignListSectionTypeCampaign,
@@ -87,6 +88,8 @@ const CGFloat kHeightExpanded = 420;
     self.navigationItem.title = [@"Let's Do This" uppercaseString];
 
     [self styleView];
+
+    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"taxonomy-term/%@", [self selectedInterestGroupId]]];
 }
 
 #pragma mark - LDTCampaignListViewController
@@ -221,6 +224,7 @@ const CGFloat kHeightExpanded = 420;
         self.selectedIndexPath = nil;
         [self styleButtons];
         [self.collectionView reloadData];
+        [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"taxonomy-term/%@", [self selectedInterestGroupId]]];
     }
 }
 

--- a/Lets Do This/Controllers/Login/LDTUserConnectViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserConnectViewController.m
@@ -11,6 +11,7 @@
 #import "LDTUserLoginViewController.h"
 #import "LDTTheme.h"
 #import "LDTButton.h"
+#import "GAI+LDT.h"
 
 @interface LDTUserConnectViewController ()
 
@@ -38,6 +39,12 @@
     [self.loginButton setTitle:[@"Sign in" uppercaseString] forState:UIControlStateNormal];
 
     [self styleView];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    [[GAI sharedInstance] trackScreenView:@"user-connect"];
 }
 
 #pragma mark - LDTUserConnectViewController

--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -13,6 +13,7 @@
 #import "LDTUserRegisterViewController.h"
 #import "LDTTabBarController.h"
 #import "UITextField+LDT.h"
+#import "GAI+LDT.h"
 
 @interface LDTUserLoginViewController ()
 
@@ -73,6 +74,12 @@
     [self.passwordButton setTitle:[@"Forgot password?" uppercaseString] forState:UIControlStateNormal];
 
     [self styleView];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    [[GAI sharedInstance] trackScreenView:@"user-login"];
 }
 
 #pragma mark - LDTUserLoginViewController

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -11,6 +11,7 @@
 #import "LDTTabBarController.h"
 #import "LDTUserLoginViewController.h"
 #import "UITextField+LDT.h"
+#import "GAI+LDT.h"
 
 @interface LDTUserRegisterViewController () <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
@@ -119,6 +120,12 @@
     if ([self.locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
         [self.locationManager requestWhenInUseAuthorization];
     }
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    [[GAI sharedInstance] trackScreenView:@"user-register"];
 }
 
 #pragma mark - LDTUserRegisterViewController

--- a/Lets Do This/Controllers/Profile/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTSettingsViewController.m
@@ -13,6 +13,7 @@
 #import "LDTTheme.h"
 #import "LDTUserConnectViewController.h"
 #import "LDTUpdateAvatarViewController.h"
+#import "GAI+LDT.h"
 
 @interface LDTSettingsViewController()
 
@@ -64,6 +65,8 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
+
+    [[GAI sharedInstance] trackScreenView:@"settings"];
 
     UIUserNotificationSettings *grantedSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
     self.isNotificationsEnabled = (grantedSettings.types != UIUserNotificationTypeNone);

--- a/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.m
@@ -11,6 +11,7 @@
 #import "LDTTheme.h"
 #import "LDTCampaignDetailViewController.h"
 #import "LDTUserProfileViewController.h"
+#import "GAI+LDT.h"
 
 @interface LDTReportbackItemDetailSingleViewController () <LDTReportbackItemDetailViewDelegate>
 
@@ -50,6 +51,8 @@
     [super viewDidAppear:animated];
 
     [self styleView];
+
+    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"reportback-item/%ld", (long)self.reportbackItem.reportbackItemID]];
 }
 
 #pragma mark - LDTReportbackItemDetailSingleViewController

--- a/Podfile
+++ b/Podfile
@@ -12,6 +12,7 @@ target 'Lets Do This' do
 	pod 'Fabric', '1.5.5'
 	pod 'Crashlytics', '3.3.4'
     pod 'SVProgressHUD', '1.1.3'
+    pod 'GoogleAnalytics', '3.13.0'
 end
 
 xcodeproj 'Lets Do This', 'Thor' => :release, 'Debug' => :debug, 'Release' => :release


### PR DESCRIPTION
Refs #451
- Per https://github.com/DoSomething/LetsDoThis-iOS/pull/479#issuecomment-148227449: Uses the `GoogleAnalytics` cocoapod instead of `Google/Analytics`, which adds more libraries than we need (and doesn't allow us to set version number of GA). 
  - Also simplifies things by not needing build scripts.
- Keeps tracking ID's out of source control: must add `googleAnalyticsTestTrackingID` and `googleAnalyticsLiveTrackingID` to enable.
- Creates `GAI+LDT` category to import all necessary classes (which is why I couldn't get the pod working in first place -- https://github.com/DoSomething/LetsDoThis-iOS/pull/479#issuecomment-148237002), and simplify calls to track screen name via [suggestion on SO](http://stackoverflow.com/a/23128700/1470725)
