### PR TITLE
Break, not continue

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -134,7 +134,7 @@ const CGFloat kHeightExpanded = 420;
             if ([self.interestGroups objectForKey:termID]) {
                 NSMutableArray *campaigns = self.interestGroups[termID][@"campaigns"];
                 [campaigns addObject:campaign];
-                continue;
+                break;
             }
         }
     }


### PR DESCRIPTION
Fixes duplicate campaigns, when a campaign has been tagged with a duplicate Interest Group taxonomy term.
