### PR TITLE
add campaign screen tracking

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -95,12 +95,22 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
+        
+    NSString *screenStatus;
+    if ([[self user] hasCompletedCampaign:self.campaign]) {
+        screenStatus = @"completed";
+    }
+    else if ([self.user isDoingCampaign:self.campaign]) {
+        screenStatus = @"proveit";
+    }
+    else {
+        screenStatus = @"pitch";
+    }
 
-    // todo: Append the user's status to this string.
-    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"campaign/%ld", (long)self.campaign.campaignID]];
+    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"campaign/%ld/%@", (long)self.campaign.campaignID, screenStatus]];
 
-    // Might have just come from the Reportback Submit screen,
-    // so check for currentUserReportback
+    // Enters this control flow when user submits a reportback
+    // and then is returned to the campaign detail view.
     if ([[self user] hasCompletedCampaign:self.campaign] && !self.currentUserReportback) {
         for (DSOCampaignSignup *signup in [self user].campaignSignups) {
             if (self.campaign.campaignID == signup.campaign.campaignID) {

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -8,6 +8,7 @@
 
 #import "LDTSubmitReportbackViewController.h"
 #import "LDTTheme.h"
+#import "GAI+LDT.h"
 
 @interface LDTSubmitReportbackViewController() <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
@@ -75,6 +76,12 @@
 
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(dismissModalViewControllerAnimated:)];
     [self styleRightBarButton];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    
+    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"campaign/%ld/reportbackform", (long)self.reportbackItem.campaign.campaignID]];
 }
 
 - (void)styleView {


### PR DESCRIPTION
#### What's this PR do?

Adds tracking of the four different campaign screen states: 

```
campaign/:id/completed
campaign/:id/proveit
campaign/:id/pitch
campaign/:id/reportbackform
```

Note that: 
1. tracking `campaign/:id/reportbackform` happens within the `LDTSubmitReportbackViewController.m`
2. to prevent double counting of a user navigating to the `proveit` screen, we've added a flag `shouldTrackScreenView` to `LDTCampaignDetailViewController`. 

Without this flag, the prove it screen would get hit twice when a user attempts to reportback—once when we first get to the campaign detail page and see the prove it button. Then again when we actually hit the prove it button, navigate to the UIImagePickerController, and then navigate back to that prove it view for a split second (sending the screen event again) before navigating to the `LDTSubmitReportbackViewController`.
#### How should this be manually tested?

Tested by a) stepping with the debugger and confirming the number of hits during the entire campaign signup-reportback flow, b) confirming that the right hits are listed in GA. 
#### What are the relevant tickets?
#451.
