### PR TITLE
add GA account actions event tracking

### DIFF
--- a/Lets Do This/Categories/GAI+LDT.h
+++ b/Lets Do This/Categories/GAI+LDT.h
@@ -13,4 +13,6 @@
 
 - (void)trackScreenView:(NSString *)screenName;
 
+- (void)trackEventWithCategory:(NSString *)category action:(NSString *)action label:(NSString *)label value:(NSNumber *)value;
+
 @end

--- a/Lets Do This/Categories/GAI+LDT.m
+++ b/Lets Do This/Categories/GAI+LDT.m
@@ -17,4 +17,14 @@
     [self.defaultTracker send:[[GAIDictionaryBuilder createScreenView] build]];
 }
 
+- (void)trackEventWithCategory:(NSString *)category action:(NSString *)action label:(NSString *)label value:(NSNumber *)value {
+    if (!category || !action) {
+        NSLog(@"Google Analytics events must be fired with non-nil category and action parameters.");
+        return;
+    }
+    [self.defaultTracker send:[[GAIDictionaryBuilder createEventWithCategory:category action:action label:label value:value] build]];
+}
+
+
+
 @end

--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -149,6 +149,8 @@
 
 - (IBAction)passwordButtonTouchUpInside:(id)sender {
     NSString *resetUrl = [NSString stringWithFormat:@"%@user/password", [[DSOAPI sharedInstance] phoenixBaseURL]];
+    [[GAI sharedInstance] trackEventWithCategory:@"account" action:@"forgot password" label:nil value:nil];
+
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:resetUrl]];
 }
 

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -152,6 +152,10 @@
     if ([self validateForm]) {
         [SVProgressHUD show];
         [[DSOAPI sharedInstance] createUserWithEmail:self.emailTextField.text password:self.passwordTextField.text firstName:self.firstNameTextField.text mobile:self.mobileTextField.text countryCode:self.countryCode success:^(NSDictionary *response) {
+            
+            if (self.mobileTextField.text) {
+                [[GAI sharedInstance] trackEventWithCategory:@"account" action:@"provide mobile number" label:nil value:nil];
+            }
 
             [[DSOUserManager sharedInstance] createSessionWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
                 
@@ -194,6 +198,8 @@
 
 - (IBAction)avatarButtonTouchUpInside:(id)sender {
     UIAlertController *avatarAlertController = [UIAlertController alertControllerWithTitle:@"Set your photo" message:nil                                                              preferredStyle:UIAlertControllerStyleActionSheet];
+    
+    [[GAI sharedInstance] trackEventWithCategory:@"account" action:@"tap avatar button" label:nil value:nil];
     
     UIAlertAction *cameraAlertAction;
     if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {


### PR DESCRIPTION
Adds GA event tracking for account actions. 

```
 clicks on forgot password (account / forgot password)
 user clicks avatar button register screen (account / tap avatar button)
 user provides mobile # on register screen (account / provide mobile number)
```

Refs #451. 
