### PR TITLE
add campaign actions and user behavior event tracking with GA

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -244,7 +244,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 #pragma mark - LDTCampaignDetailSelfReportbackCellDelegate
 
 - (void)didClickSharePhotoButtonForCell:(LDTCampaignDetailSelfReportbackCell *)cell {
-    
+    [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"share photo" label:nil value:nil];
     NSString *title = self.campaign.title;
     NSString *verb = self.campaign.reportbackVerb.lowercaseString;
     NSString *quantity = [NSString stringWithFormat:@"%li", (long)self.currentUserReportback.quantity];

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -372,24 +372,26 @@ const BOOL isTestingForNoCampaigns = NO;
 		
 		return;
 	}
-	
-	LDTCampaignListCampaignCell *campaignCell = (LDTCampaignListCampaignCell *)[collectionView cellForItemAtIndexPath:indexPath];
-	[UIView animateWithDuration:0.6 delay:0 usingSpringWithDamping:0.8 initialSpringVelocity:0 options:0 animations:^{
-		[collectionView performBatchUpdates:^{
-			if ([self.selectedIndexPath isEqual:indexPath]) {
-				self.selectedIndexPath = nil;
-				campaignCell.expanded = NO;
-			}
-			else {
-				LDTCampaignListCampaignCell *expandedCell = (LDTCampaignListCampaignCell *)[collectionView cellForItemAtIndexPath:self.selectedIndexPath];
-				self.selectedIndexPath = indexPath;
-				expandedCell.expanded = NO;
-				campaignCell.expanded = YES;
-			}
-		} completion:^(BOOL finished) {
-			[collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionTop animated:YES];
-		}];
-	} completion:nil];
+
+    LDTCampaignListCampaignCell *campaignCell = (LDTCampaignListCampaignCell *)[collectionView cellForItemAtIndexPath:indexPath];
+    [UIView animateWithDuration:0.6 delay:0 usingSpringWithDamping:0.8 initialSpringVelocity:0 options:0 animations:^{
+        [collectionView performBatchUpdates:^{
+            if ([self.selectedIndexPath isEqual:indexPath]) {
+                self.selectedIndexPath = nil;
+                campaignCell.expanded = NO;
+                [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"collapse campaign cell" label:[NSString stringWithFormat:@"%li", (long)campaignCell.campaign.campaignID] value:nil];
+            }
+            else {
+                LDTCampaignListCampaignCell *expandedCell = (LDTCampaignListCampaignCell *)[collectionView cellForItemAtIndexPath:self.selectedIndexPath];
+                self.selectedIndexPath = indexPath;
+                expandedCell.expanded = NO;
+                campaignCell.expanded = YES;
+                [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"expand campaign cell" label:[NSString stringWithFormat:@"%li", (long)campaignCell.campaign.campaignID] value:nil];
+            }
+        } completion:^(BOOL finished) {
+            [collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionTop animated:YES];
+        }];
+    } completion:nil];
 }
 
 #pragma mark - UICollectionViewDataSource

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -230,6 +230,7 @@
 }
 
 - (void)handleFooterLabelTap {
+    [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"tap on privacy policy" label:nil value:nil];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString: [NSString stringWithFormat:@"%@%@", [DSOAPI sharedInstance].phoenixBaseURL, @"about/privacy-policy"]]];
 }
 

--- a/Lets Do This/Controllers/Profile/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTSettingsViewController.m
@@ -111,6 +111,7 @@
 }
 
 - (void)handleNotificationSwitchTap:(UITapGestureRecognizer *)recognizer {
+    [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"tap on notif switch" label:nil value:nil];
     NSString *alertControllerMessage;
     if (!self.isNotificationsEnabled) {
         alertControllerMessage = @"You've disabled Notifications for Let's Do This. You can turn them on in the Notifications section of the Settings app.";
@@ -131,6 +132,7 @@
     UIAlertController *logoutAlertController = [UIAlertController alertControllerWithTitle:@"Are you sure? We’ll miss you." message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     UIAlertAction *confirmLogoutAction = [UIAlertAction actionWithTitle:@"Log Out" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
         [SVProgressHUD show];
+        [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"log out" label:nil value:nil];
         [[DSOUserManager sharedInstance] endSessionWithCompletionHandler:^ {
             // This VC is always presented within the TabBarVC, so kill it.
             [self dismissViewControllerAnimated:YES completion:^{
@@ -154,10 +156,12 @@
 }
 
 - (void)handleRateTap:(UITapGestureRecognizer *)recognizer {
+    [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"tap on review app button" label:nil value:nil];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://itunes.apple.com/app/998995766"]];
 }
 
 - (IBAction)feedbackButtonTouchUpInside:(id)sender {
+    [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"tap on feedback form" label:nil value:nil];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://www.dosomething.org/campaigns/submit-your-idea"]];
 }
 @end

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -8,6 +8,7 @@
 
 #import "DSOUserManager.h"
 #import <SSKeychain/SSKeychain.h>
+#import "GAI+LDT.h"
 
 NSString *const avatarFileNameString = @"LDTStoredAvatar.jpeg";
 NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
@@ -106,6 +107,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 - (void)signupUserForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     [[DSOAPI sharedInstance] createCampaignSignupForCampaign:campaign completionHandler:^(DSOCampaignSignup *signup) {
         [self.user.campaignSignups addObject:signup];
+        [[GAI sharedInstance] trackEventWithCategory:@"campaign" action:@"submit signup" label:[NSString stringWithFormat:@"%li", (long)campaign.campaignID] value:nil];
         if (completionHandler) {
             completionHandler(signup);
         }
@@ -118,6 +120,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 
 - (void)postUserReportbackItem:(DSOReportbackItem *)reportbackItem completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     [[DSOAPI sharedInstance] postReportbackItem:reportbackItem completionHandler:^(NSDictionary *response) {
+        [[GAI sharedInstance] trackEventWithCategory:@"campaign" action:@"submit reportback" label:[NSString stringWithFormat:@"%li", (long)reportbackItem.campaign.campaignID] value:nil];
         // Update the corresponding campaignSignup with the new reportbackItem.
         for (DSOCampaignSignup *signup in self.user.campaignSignups) {
             if (reportbackItem.campaign.campaignID == signup.campaign.campaignID) {


### PR DESCRIPTION
### What's this PR do?

Adds the following events to be tracked by GA: 
##### Campaign Actions
- `campaign.submit signup.:campaign_id` - submits campaign sign up for campaign `:campaign_id`
- `campaign.submit reportback.:campaign_id` - submits campaign reportback for campaign `:campaign_id`
##### User Behavior
- `behavior.load more photos` - user loads more photos than the preset (not implemented in iOS)
- `behavior.expand campaign cell:campaign_id` - user expands campaign cell
- `behavior.collapse campaign cell:campaign_id` - user collapses campaign cell (note that we're only tracking when the user deliberately taps on a campaign cell to collapse it, **not** when a user opens cell A, scrolls down, and opens cell B, _automatically_ collapsing cell A.)
- `behavior.share photo` - user shares photo
- `behavior.log out` - user logs out
- `behavior.tap on feedback form` - taps on feedback form
- `behavior.tap on privacy policy` - taps on privacy policy
- `behavior.tap on review app button` - taps on review app in app store button 
- `behavior.tap on notif switch` - taps on notifications switch in Settings
#### How should this be manually tested?

Tested by logging GA hits. 
#### What are the relevant tickets?
#451.
