### PR TITLE
fix buggy link to register screen

### DIFF
--- a/Lets Do This/Views/Login/LDTUserLoginView.xib
+++ b/Lets Do This/Views/Login/LDTUserLoginView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LDTUserLoginViewController">
@@ -30,6 +30,7 @@
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="DS Logo" translatesAutoresizingMaskIntoConstraints="NO" id="cTZ-YE-jBE">
                                     <rect key="frame" x="100" y="0.0" width="100" height="80"/>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="100" id="61i-p2-521"/>
                                         <constraint firstAttribute="height" constant="80" id="KGS-wi-ncl"/>
@@ -37,11 +38,13 @@
                                 </imageView>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="50F-0i-WQW" userLabel="Headline">
                                     <rect key="frame" x="129" y="102" width="42" height="21"/>
+                                    <animations/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>
+                            <animations/>
                             <constraints>
                                 <constraint firstAttribute="centerX" secondItem="50F-0i-WQW" secondAttribute="centerX" id="10H-BF-JSM"/>
                                 <constraint firstAttribute="height" constant="124" id="998-aR-JZS"/>
@@ -56,6 +59,7 @@
                             <subviews>
                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="84m-fh-8Zr" userLabel="Email TextField">
                                     <rect key="frame" x="0.0" y="0.0" width="584" height="44"/>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="44" id="s2b-2i-x8d"/>
                                     </constraints>
@@ -68,6 +72,7 @@
                                 </textField>
                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="g81-9z-70h" userLabel="Password TextField">
                                     <rect key="frame" x="0.0" y="52" width="584" height="44"/>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="44" id="NVj-95-r96"/>
                                     </constraints>
@@ -79,6 +84,7 @@
                                     </connections>
                                 </textField>
                             </subviews>
+                            <animations/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="84m-fh-8Zr" secondAttribute="trailing" id="79Q-l4-oSY"/>
                                 <constraint firstItem="84m-fh-8Zr" firstAttribute="leading" secondItem="HQA-Wg-qj6" secondAttribute="leading" id="Cw8-0Q-YG3"/>
@@ -90,10 +96,11 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VYf-Yo-Xf8" userLabel="Buttons Container View">
-                            <rect key="frame" x="8" y="276" width="584" height="140"/>
+                            <rect key="frame" x="8" y="276" width="584" height="162"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Eja-ai-TkH" userLabel="Submit Button" customClass="LDTButton">
                                     <rect key="frame" x="0.0" y="0.0" width="584" height="50"/>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="50" id="bDZ-Sy-cDy"/>
                                     </constraints>
@@ -106,6 +113,7 @@
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v0D-uH-55q" userLabel="Forgot Password Button" customClass="LDTButton">
                                     <rect key="frame" x="0.0" y="58" width="584" height="50"/>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="50" id="qnt-OA-4SR"/>
                                     </constraints>
@@ -118,6 +126,7 @@
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wdt-W9-ah3" userLabel="Link to Register Screen" customClass="LDTButton">
                                     <rect key="frame" x="264" y="124" width="57" height="30"/>
+                                    <animations/>
                                     <state key="normal" title="Register">
                                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                     </state>
@@ -126,6 +135,7 @@
                                     </connections>
                                 </button>
                             </subviews>
+                            <animations/>
                             <constraints>
                                 <constraint firstItem="v0D-uH-55q" firstAttribute="leading" secondItem="VYf-Yo-Xf8" secondAttribute="leading" id="8rl-BU-q5d"/>
                                 <constraint firstItem="Eja-ai-TkH" firstAttribute="leading" secondItem="VYf-Yo-Xf8" secondAttribute="leading" id="JA6-fi-Ij4"/>
@@ -134,18 +144,25 @@
                                 <constraint firstItem="Wdt-W9-ah3" firstAttribute="top" secondItem="v0D-uH-55q" secondAttribute="bottom" constant="16" id="TE2-xe-WnL"/>
                                 <constraint firstItem="v0D-uH-55q" firstAttribute="top" secondItem="Eja-ai-TkH" secondAttribute="bottom" constant="8" id="U63-Xw-rkz"/>
                                 <constraint firstAttribute="centerX" secondItem="Wdt-W9-ah3" secondAttribute="centerX" id="Y4G-37-jmh"/>
-                                <constraint firstAttribute="height" constant="140" id="hbw-XU-ZUJ"/>
+                                <constraint firstAttribute="height" constant="160" id="hbw-XU-ZUJ"/>
+                                <constraint firstAttribute="bottom" secondItem="Wdt-W9-ah3" secondAttribute="bottom" constant="8" id="uXR-tG-aBf"/>
                                 <constraint firstItem="Eja-ai-TkH" firstAttribute="top" secondItem="VYf-Yo-Xf8" secondAttribute="top" id="v6d-mo-vAj"/>
                                 <constraint firstAttribute="trailing" secondItem="Eja-ai-TkH" secondAttribute="trailing" id="vTT-JN-MaB"/>
                             </constraints>
+                            <variation key="default">
+                                <mask key="constraints">
+                                    <exclude reference="hbw-XU-ZUJ"/>
+                                </mask>
+                            </variation>
                         </view>
                     </subviews>
+                    <animations/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="VYf-Yo-Xf8" secondAttribute="trailing" constant="8" id="5e1-rx-8sx"/>
                         <constraint firstItem="HQA-Wg-qj6" firstAttribute="top" secondItem="4pK-DW-rH5" secondAttribute="bottom" constant="44" id="6Dk-ft-HVd"/>
                         <constraint firstAttribute="trailing" secondItem="HQA-Wg-qj6" secondAttribute="trailing" constant="8" id="EhN-Q8-P45"/>
                         <constraint firstItem="VYf-Yo-Xf8" firstAttribute="top" secondItem="HQA-Wg-qj6" secondAttribute="bottom" constant="8" id="Gd0-Cl-BnM"/>
-                        <constraint firstAttribute="bottom" secondItem="VYf-Yo-Xf8" secondAttribute="bottom" constant="31" id="MvD-xi-B3t"/>
+                        <constraint firstAttribute="bottom" secondItem="VYf-Yo-Xf8" secondAttribute="bottom" constant="64" id="MvD-xi-B3t"/>
                         <constraint firstAttribute="centerX" secondItem="4pK-DW-rH5" secondAttribute="centerX" id="Q0O-KM-Ti0"/>
                         <constraint firstItem="HQA-Wg-qj6" firstAttribute="top" secondItem="4pK-DW-rH5" secondAttribute="bottom" constant="16" id="UBr-sW-BIg"/>
                         <constraint firstItem="HQA-Wg-qj6" firstAttribute="leading" secondItem="pRb-YO-KnF" secondAttribute="leading" constant="8" id="VTf-Jf-7i1"/>
@@ -163,6 +180,7 @@
                     </variation>
                 </scrollView>
             </subviews>
+            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="pRb-YO-KnF" secondAttribute="trailing" id="LGa-Fm-cl2"/>


### PR DESCRIPTION
#### What's this PR do?

Fixes the buggy link to the register screen on the login screen. Previously, a container view covered up the bottom of the register button, preventing taps on the bottom half of the button from being handled. 

Fixed by increasing the size of the container view. 
#### How should this be manually tested?

Running on simulator and clicking. 
#### Any background context you want to provide?

**Before:**
![screenshot 2015-10-22 17 34 03](https://cloud.githubusercontent.com/assets/5678066/10678930/5d714954-78e3-11e5-9b89-5e9d630d7bc0.png)

**After (fixed):**
![screenshot 2015-10-22 17 34 18](https://cloud.githubusercontent.com/assets/5678066/10678940/69b738fe-78e3-11e5-9314-744bfeaad97d.png)
#### What are the relevant tickets?

Closes #493. 
