### PR TITLE
Epic Fail, Our Bad special edition

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -148,9 +148,16 @@ const BOOL isTestingForNoCampaigns = NO;
     } errorHandler:^(NSError *error) {
         [SVProgressHUD dismiss];
 
-        // Need to inspect error here to determine what error is.
-        // If something's up with the session, we'll want to logout and push to user connect.
-        LDTEpicFailViewController *epicFailVC = [[LDTEpicFailViewController alloc] initWithTitle:@"No network connection!" subtitle:@"We can't connect to the internet, please check your connection and try again."];
+        // @todo: Need to figure out case where we'd need to logout and push to user connect.
+        // Extract this logic into a LDTError? Refs GH #363  
+        NSInteger code = error.code;
+        LDTEpicFailViewController *epicFailVC;
+        if (code == -1009) {
+            epicFailVC = [[LDTEpicFailViewController alloc] initWithTitle:@"No network connection!" subtitle:@"We can't connect to the internet, please check your connection and try again."];
+        }
+        else {
+            epicFailVC = [[LDTEpicFailViewController alloc] initWithTitle:@"Oops! Our bad." subtitle:@"Looks like there was an issue with that request. We're looking into it now!"];
+        }
         epicFailVC.delegate = self;
         UINavigationController *navVC = [[UINavigationController alloc] initWithRootViewController:epicFailVC];
         [navVC styleNavigationBar:LDTNavigationBarStyleNormal];

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -324,7 +324,7 @@
 }
 
 - (void)logError:(NSError *)error {
-    NSLog(@"logError: %@", error.localizedDescription);
+    NSLog(@"DSOAPI error %li: %@", (long)error.code, error.localizedDescription);
 }
 
 @end


### PR DESCRIPTION
Fixes #529 to display the "Our bad" message when we get an error status code back from the GET campaigns endpoint.
