### PR TITLE
add feedback button, rename google analytics events

### DIFF
--- a/Lets Do This/Controllers/Profile/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTSettingsViewController.m
@@ -30,14 +30,22 @@
 @property (weak, nonatomic) IBOutlet UILabel *notificationsLabel;
 @property (weak, nonatomic) IBOutlet UIView *notificationSwitchView;
 @property (weak, nonatomic) IBOutlet UISwitch *notificationsSwitch;
+
+@property (weak, nonatomic) IBOutlet UIView *feedbackView;
+@property (weak, nonatomic) IBOutlet UILabel *feedbackHeadingLabel;
+@property (weak, nonatomic) IBOutlet UILabel *feedbackLabel;
+@property (weak, nonatomic) IBOutlet UIImageView *feedbackArrowImageView;
+
 @property (weak, nonatomic) IBOutlet UIView *rateView;
 @property (weak, nonatomic) IBOutlet UILabel *rateLabel;
 @property (weak, nonatomic) IBOutlet UIImageView *rateArrowImageView;
 @property (weak, nonatomic) IBOutlet UILabel *rateDisclaimerLabel;
-@property (weak, nonatomic) IBOutlet UIButton *feedbackButton;
+
+@property (weak, nonatomic) IBOutlet UIButton *submitIdeasButton;
+
 @property (weak, nonatomic) IBOutlet UILabel *versionLabel;
 
-- (IBAction)feedbackButtonTouchUpInside:(id)sender;
+- (IBAction)submitIdeasButtonTouchUpInside:(id)sender;
 
 @end
 
@@ -61,6 +69,8 @@
     [self.notificationSwitchView addGestureRecognizer:notificationSwitchTap];
     UITapGestureRecognizer *rateTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleRateTap:)];
     [self.rateView addGestureRecognizer:rateTap];
+    UITapGestureRecognizer *feedbackTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleFeedbackTap:)];
+    [self.feedbackView addGestureRecognizer:feedbackTap];
     UIBarButtonItem *rightButton = [[UIBarButtonItem alloc] initWithTitle:@"Done" style:UIBarButtonItemStylePlain target:self action:@selector(dismissSettings:)];
     self.navigationItem.rightBarButtonItem = rightButton;
     [self styleRightBarButton];
@@ -94,15 +104,21 @@
     self.notificationsHeadingLabel.textColor = [LDTTheme mediumGrayColor];
     self.notificationsLabel.font = [LDTTheme font];
     
+    self.feedbackHeadingLabel.font = [LDTTheme fontBold];
+    self.feedbackHeadingLabel.textColor = [LDTTheme mediumGrayColor];
+    self.feedbackLabel.font = [LDTTheme font];
+    self.feedbackArrowImageView.image = [UIImage imageNamed:@"Arrow"];
+
+    
     self.rateLabel.font = [LDTTheme font];
     self.rateArrowImageView.image = [UIImage imageNamed:@"Arrow"];
     
     self.rateDisclaimerLabel.font = [LDTTheme fontCaption];
     
-    [self.feedbackButton.titleLabel setFont:[LDTTheme fontCaption]];
-    self.feedbackButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+    [self.submitIdeasButton.titleLabel setFont:[LDTTheme fontCaption]];
+    self.submitIdeasButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
     // wraps button text if multiple lines are needed on smaller screens
-    self.feedbackButton.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    self.submitIdeasButton.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
     
     [self.versionLabel setFont:[LDTTheme fontCaption]];
     self.versionLabel.text = [NSString stringWithFormat:@"Version %@",[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]];
@@ -162,13 +178,18 @@
     [self presentViewController:logoutAlertController animated:YES completion:nil];
 }
 
+- (void)handleFeedbackTap:(UITapGestureRecognizer *)recognizer {
+    [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"tap on feedback form" label:nil value:nil];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://docs.google.com/a/dosomething.org/forms/d/1KUWQgfuoKpUXg7uuurXSgYQ3RCuxwNVSrGeb_kDRqf8/viewform?edit_requested=true"]];
+}
+
 - (void)handleRateTap:(UITapGestureRecognizer *)recognizer {
     [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"tap on review app button" label:nil value:nil];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://itunes.apple.com/app/998995766"]];
 }
 
-- (IBAction)feedbackButtonTouchUpInside:(id)sender {
-    [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"tap on feedback form" label:nil value:nil];
+- (IBAction)submitIdeasButtonTouchUpInside:(id)sender {
+    [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"tap on ideas form" label:nil value:nil];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://www.dosomething.org/campaigns/submit-your-idea"]];
 }
 @end

--- a/Lets Do This/Views/Profile/LDTSettingsView.xib
+++ b/Lets Do This/Views/Profile/LDTSettingsView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LDTSettingsViewController">
@@ -11,7 +11,10 @@
                 <outlet property="changePhotoArrowImageView" destination="Pqd-zN-hmm" id="pUd-M0-Ib3"/>
                 <outlet property="changePhotoLabel" destination="WAq-aZ-WOJ" id="ubc-h9-fKz"/>
                 <outlet property="changePhotoView" destination="oQe-dL-E6M" id="Z41-p4-Qda"/>
-                <outlet property="feedbackButton" destination="2kM-5s-5No" id="nWg-af-SK1"/>
+                <outlet property="feedbackArrowImageView" destination="mNY-Yd-zp7" id="46u-37-50y"/>
+                <outlet property="feedbackHeadingLabel" destination="XUP-Pb-3Bz" id="XIw-lw-dfd"/>
+                <outlet property="feedbackLabel" destination="Vy4-AI-c59" id="9b9-Jj-GAU"/>
+                <outlet property="feedbackView" destination="yIG-b6-LNx" id="ZwJ-cK-4UM"/>
                 <outlet property="logoutLabel" destination="zfw-aS-Vub" id="I6H-RR-Siw"/>
                 <outlet property="logoutView" destination="m5t-YK-XBL" id="Vm5-Ue-Am9"/>
                 <outlet property="notificationSwitchView" destination="CNd-YW-Iyu" id="0bW-wD-SjV"/>
@@ -22,6 +25,7 @@
                 <outlet property="rateDisclaimerLabel" destination="J1z-Uv-f8i" id="SCU-Ap-O0a"/>
                 <outlet property="rateLabel" destination="LiH-Ep-Uee" id="WTL-Eo-J7L"/>
                 <outlet property="rateView" destination="uZy-Vd-msE" id="JKS-Sl-lz4"/>
+                <outlet property="submitIdeasButton" destination="2kM-5s-5No" id="t3U-z0-IAz"/>
                 <outlet property="versionLabel" destination="PFp-Li-SKL" id="bhQ-XY-Seh"/>
                 <outlet property="view" destination="iN0-l3-epB" id="oQO-g4-VRl"/>
             </connections>
@@ -36,6 +40,7 @@
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ACCOUNT" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zZ6-bA-0iX" userLabel="Account Heading">
                             <rect key="frame" x="16" y="20" width="82" height="21"/>
+                            <animations/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
@@ -45,6 +50,7 @@
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s07-pC-Llz" userLabel="Top Border View">
                                     <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
+                                    <animations/>
                                     <color key="backgroundColor" red="0.78431372549019607" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="akm-5e-g5I"/>
@@ -52,12 +58,14 @@
                                 </view>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Change Photo" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WAq-aZ-WOJ">
                                     <rect key="frame" x="16" y="12" width="109" height="20"/>
+                                    <animations/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0fQ-gC-eIh" userLabel="Bottom Border View">
                                     <rect key="frame" x="16" y="43" width="584" height="1"/>
+                                    <animations/>
                                     <color key="backgroundColor" red="0.7843137255" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="5YE-Qm-WbC"/>
@@ -65,12 +73,14 @@
                                 </view>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Pqd-zN-hmm">
                                     <rect key="frame" x="576" y="17" width="7" height="11"/>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="7" id="Mki-LO-lj1"/>
                                         <constraint firstAttribute="height" constant="11" id="O0g-Bh-EYB"/>
                                     </constraints>
                                 </imageView>
                             </subviews>
+                            <animations/>
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="WAq-aZ-WOJ" secondAttribute="bottom" constant="12" id="3HF-XO-9KW"/>
                                 <constraint firstItem="s07-pC-Llz" firstAttribute="top" secondItem="oQe-dL-E6M" secondAttribute="top" id="N88-Rv-SBk"/>
@@ -88,6 +98,7 @@
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NOTIFICATIONS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tun-mR-gRE" userLabel="Notifications Heading">
                             <rect key="frame" x="16" y="166" width="124" height="21"/>
+                            <animations/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
@@ -97,6 +108,7 @@
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XBy-34-hV9" userLabel="Top Border View">
                                     <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
+                                    <animations/>
                                     <color key="backgroundColor" red="0.7843137255" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="ayM-Bm-nDP"/>
@@ -104,24 +116,28 @@
                                 </view>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Receive Notifications" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Nu-TY-cY3" userLabel="Receive Notifications Label">
                                     <rect key="frame" x="17" y="12" width="161" height="21"/>
+                                    <animations/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="17t-ud-SWl" userLabel="Notifications Enabled Switch">
                                     <rect key="frame" x="533" y="7" width="51" height="31"/>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="31" id="Dp8-LF-Se9"/>
                                     </constraints>
                                 </switch>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f9q-PT-ypz" userLabel="Bottom Border View">
-                                    <rect key="frame" x="0.0" y="43" width="600" height="1"/>
+                                    <rect key="frame" x="0.0" y="44" width="600" height="1"/>
+                                    <animations/>
                                     <color key="backgroundColor" red="0.7843137255" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="zQT-Lp-87l"/>
                                     </constraints>
                                 </view>
                             </subviews>
+                            <animations/>
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="1Nu-TY-cY3" secondAttribute="bottom" constant="12" id="0AM-BW-2Yy"/>
                                 <constraint firstAttribute="trailing" secondItem="XBy-34-hV9" secondAttribute="trailing" id="2Yw-Kc-pLy"/>
@@ -136,48 +152,26 @@
                                 <constraint firstItem="1Nu-TY-cY3" firstAttribute="leading" secondItem="CNd-YW-Iyu" secondAttribute="leading" constant="17" id="reS-sT-ATh"/>
                             </constraints>
                         </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PFp-Li-SKL" userLabel="Version Number Label">
-                            <rect key="frame" x="0.0" y="549" width="600" height="21"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2kM-5s-5No">
-                            <rect key="frame" x="16" y="512" width="568" height="21"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="21" id="eIc-Yw-xju"/>
-                            </constraints>
-                            <state key="normal" title="Have your own ideas? Fill out this form and let us know."/>
-                            <connections>
-                                <action selector="feedbackButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="SYc-Rs-Sjf"/>
-                            </connections>
-                        </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We'll never interrupt you to ask for ratings." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1z-Uv-f8i">
-                            <rect key="frame" x="16" y="403" width="568" height="21"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="21" id="UXf-ba-c3e"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m5t-YK-XBL" userLabel="Logout Container View">
                             <rect key="frame" x="0.0" y="91" width="600" height="44"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Log Out" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zfw-aS-Vub">
                                     <rect key="frame" x="16" y="12" width="61" height="20"/>
+                                    <animations/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E8E-NQ-5ya" userLabel="Bottom Border View">
                                     <rect key="frame" x="0.0" y="43" width="600" height="1"/>
+                                    <animations/>
                                     <color key="backgroundColor" red="0.7843137255" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="s9P-sD-gmr"/>
                                     </constraints>
                                 </view>
                             </subviews>
+                            <animations/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="6e6-xx-HeK"/>
                                 <constraint firstItem="E8E-NQ-5ya" firstAttribute="leading" secondItem="m5t-YK-XBL" secondAttribute="leading" id="883-hU-Uat"/>
@@ -188,11 +182,19 @@
                                 <constraint firstAttribute="bottom" secondItem="zfw-aS-Vub" secondAttribute="bottom" constant="12" id="ffU-a4-iGy"/>
                             </constraints>
                         </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FEEDBACK" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XUP-Pb-3Bz" userLabel="Feedback Heading">
+                            <rect key="frame" x="16" y="265" width="85" height="21"/>
+                            <animations/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uZy-Vd-msE">
-                            <rect key="frame" x="0.0" y="342" width="600" height="45"/>
+                            <rect key="frame" x="0.0" y="332" width="600" height="45"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rate Let's Do This" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LiH-Ep-Uee">
                                     <rect key="frame" x="17" y="12" width="139" height="21"/>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="21" id="I9t-oS-Nb1"/>
                                     </constraints>
@@ -202,6 +204,7 @@
                                 </label>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rFh-UQ-28U">
                                     <rect key="frame" x="576" y="17" width="7" height="11"/>
+                                    <animations/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="7" id="ZJq-LO-doS"/>
                                         <constraint firstAttribute="height" constant="11" id="u6n-RN-5ih"/>
@@ -209,75 +212,152 @@
                                 </imageView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uo8-Y1-cKe" userLabel="Bottom Border View">
                                     <rect key="frame" x="0.0" y="44" width="600" height="1"/>
+                                    <animations/>
                                     <color key="backgroundColor" red="0.7843137255" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="x8C-mx-AS4"/>
                                     </constraints>
                                 </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ilb-4d-vrn" userLabel="Top Border View">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
-                                    <color key="backgroundColor" red="0.7843137255" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="1" id="XVX-ki-S2v"/>
-                                    </constraints>
-                                </view>
                             </subviews>
+                            <animations/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             <constraints>
-                                <constraint firstAttribute="trailing" secondItem="uo8-Y1-cKe" secondAttribute="trailing" id="1HG-no-Elu"/>
-                                <constraint firstItem="Ilb-4d-vrn" firstAttribute="leading" secondItem="uZy-Vd-msE" secondAttribute="leading" id="52b-j8-1FR"/>
+                                <constraint firstItem="uo8-Y1-cKe" firstAttribute="leading" secondItem="uZy-Vd-msE" secondAttribute="leading" id="6Z5-YR-9MJ"/>
+                                <constraint firstAttribute="bottom" secondItem="uo8-Y1-cKe" secondAttribute="bottom" id="7Ba-Gh-y3A"/>
                                 <constraint firstItem="LiH-Ep-Uee" firstAttribute="leading" secondItem="uZy-Vd-msE" secondAttribute="leading" constant="17" id="95c-1B-Wcv"/>
                                 <constraint firstItem="LiH-Ep-Uee" firstAttribute="top" secondItem="uZy-Vd-msE" secondAttribute="top" constant="12" id="BTb-yv-Ymy"/>
-                                <constraint firstItem="Ilb-4d-vrn" firstAttribute="top" secondItem="uZy-Vd-msE" secondAttribute="top" id="EJu-Rf-9R8"/>
-                                <constraint firstAttribute="trailing" secondItem="Ilb-4d-vrn" secondAttribute="trailing" id="GMR-1c-ODR"/>
                                 <constraint firstAttribute="bottom" secondItem="LiH-Ep-Uee" secondAttribute="bottom" constant="12" id="ICD-Y5-opi"/>
                                 <constraint firstAttribute="height" constant="45" id="KqL-uS-Pk9"/>
                                 <constraint firstItem="rFh-UQ-28U" firstAttribute="centerY" secondItem="uZy-Vd-msE" secondAttribute="centerY" id="Owh-fI-iCI"/>
-                                <constraint firstItem="uo8-Y1-cKe" firstAttribute="leading" secondItem="uZy-Vd-msE" secondAttribute="leading" id="VNA-b3-a0k"/>
-                                <constraint firstAttribute="bottom" secondItem="uo8-Y1-cKe" secondAttribute="bottom" id="fit-jM-OKX"/>
+                                <constraint firstAttribute="trailing" secondItem="uo8-Y1-cKe" secondAttribute="trailing" id="TAT-tJ-AmA"/>
                                 <constraint firstAttribute="trailing" secondItem="rFh-UQ-28U" secondAttribute="trailing" constant="17" id="yBB-1U-kHX"/>
                             </constraints>
                         </view>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2kM-5s-5No" userLabel="Submit Ideas Button">
+                            <rect key="frame" x="8" y="503" width="584" height="21"/>
+                            <animations/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="21" id="eIc-Yw-xju"/>
+                            </constraints>
+                            <state key="normal" title="Have your own ideas? Fill out this form and let us know. "/>
+                            <connections>
+                                <action selector="submitIdeasButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="KbJ-7n-fo4"/>
+                            </connections>
+                        </button>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PFp-Li-SKL" userLabel="Version Number Label">
+                            <rect key="frame" x="0.0" y="540" width="600" height="21"/>
+                            <animations/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We'll never interrupt you to ask for ratings." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1z-Uv-f8i">
+                            <rect key="frame" x="16" y="386" width="568" height="21"/>
+                            <animations/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="21" id="UXf-ba-c3e"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yIG-b6-LNx" userLabel="Switch Container View">
+                            <rect key="frame" x="0.0" y="287" width="600" height="45"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bU8-FB-rxe" userLabel="Top Border View">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
+                                    <animations/>
+                                    <color key="backgroundColor" red="0.7843137255" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="Rbr-zs-pgZ"/>
+                                    </constraints>
+                                </view>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Give Us Your Feedback" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vy4-AI-c59" userLabel="Give Us Your Feedback Label">
+                                    <rect key="frame" x="17" y="12" width="178" height="21"/>
+                                    <animations/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="21" id="HNe-xO-fYa"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="mNY-Yd-zp7">
+                                    <rect key="frame" x="576" y="17" width="7" height="11"/>
+                                    <animations/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="7" id="7hk-f9-LhP"/>
+                                        <constraint firstAttribute="height" constant="11" id="Nra-as-GT7"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="11" id="O6P-5E-igv"/>
+                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="7" id="kYd-DD-8lq"/>
+                                    </constraints>
+                                </imageView>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gNZ-IV-PYK" userLabel="Bottom Border View">
+                                    <rect key="frame" x="16" y="44" width="584" height="1"/>
+                                    <animations/>
+                                    <color key="backgroundColor" red="0.7843137255" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="RFx-p5-AKX"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <animations/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstAttribute="bottom" secondItem="Vy4-AI-c59" secondAttribute="bottom" constant="12" id="07X-fr-C1d"/>
+                                <constraint firstItem="mNY-Yd-zp7" firstAttribute="centerY" secondItem="yIG-b6-LNx" secondAttribute="centerY" id="2MY-g6-9Yo"/>
+                                <constraint firstItem="bU8-FB-rxe" firstAttribute="top" secondItem="yIG-b6-LNx" secondAttribute="top" id="7bJ-1Z-JDS"/>
+                                <constraint firstAttribute="trailing" secondItem="bU8-FB-rxe" secondAttribute="trailing" id="CaP-4Y-a8h"/>
+                                <constraint firstItem="Vy4-AI-c59" firstAttribute="top" secondItem="yIG-b6-LNx" secondAttribute="top" constant="12" id="Rx2-2v-oRW"/>
+                                <constraint firstAttribute="trailing" secondItem="gNZ-IV-PYK" secondAttribute="trailing" id="Z30-iu-RzT"/>
+                                <constraint firstItem="gNZ-IV-PYK" firstAttribute="leading" secondItem="yIG-b6-LNx" secondAttribute="leading" constant="16" id="kzD-Rd-PA3"/>
+                                <constraint firstAttribute="bottom" secondItem="gNZ-IV-PYK" secondAttribute="bottom" id="mPU-SN-g6u"/>
+                                <constraint firstItem="Vy4-AI-c59" firstAttribute="leading" secondItem="yIG-b6-LNx" secondAttribute="leading" constant="17" id="oex-9K-48H"/>
+                                <constraint firstAttribute="height" constant="45" id="oxD-Do-TkE"/>
+                                <constraint firstItem="bU8-FB-rxe" firstAttribute="leading" secondItem="yIG-b6-LNx" secondAttribute="leading" id="sVp-Vw-329"/>
+                                <constraint firstAttribute="trailing" secondItem="mNY-Yd-zp7" secondAttribute="trailing" constant="17" id="tGr-8Y-H6K"/>
+                            </constraints>
+                        </view>
                     </subviews>
+                    <animations/>
                     <constraints>
                         <constraint firstItem="PFp-Li-SKL" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" id="0t1-hR-JQ0"/>
                         <constraint firstItem="oQe-dL-E6M" firstAttribute="top" secondItem="zZ6-bA-0iX" secondAttribute="bottom" constant="7" id="48G-n3-Phq"/>
+                        <constraint firstItem="XUP-Pb-3Bz" firstAttribute="top" secondItem="CNd-YW-Iyu" secondAttribute="bottom" constant="31" id="5gH-uE-wC6"/>
+                        <constraint firstAttribute="bottom" secondItem="PFp-Li-SKL" secondAttribute="bottom" constant="39.5" id="7n4-Ug-j1y"/>
+                        <constraint firstItem="J1z-Uv-f8i" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" constant="16" id="7t5-DV-iYh"/>
                         <constraint firstAttribute="trailing" secondItem="PFp-Li-SKL" secondAttribute="trailing" id="7xL-lg-82F"/>
-                        <constraint firstItem="uZy-Vd-msE" firstAttribute="top" secondItem="CNd-YW-Iyu" secondAttribute="bottom" constant="109" id="BoV-pI-Inl"/>
+                        <constraint firstAttribute="trailing" secondItem="yIG-b6-LNx" secondAttribute="trailing" id="97W-Tf-zeX"/>
+                        <constraint firstItem="2kM-5s-5No" firstAttribute="top" secondItem="J1z-Uv-f8i" secondAttribute="bottom" constant="96" id="A9T-dX-HMO"/>
                         <constraint firstItem="zZ6-bA-0iX" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" constant="16" id="Cs1-xO-9Iy"/>
-                        <constraint firstItem="2kM-5s-5No" firstAttribute="top" secondItem="J1z-Uv-f8i" secondAttribute="bottom" constant="88" id="DBf-QW-x2G"/>
                         <constraint firstAttribute="trailing" secondItem="m5t-YK-XBL" secondAttribute="trailing" id="EQh-dY-QIP"/>
+                        <constraint firstItem="yIG-b6-LNx" firstAttribute="top" secondItem="XUP-Pb-3Bz" secondAttribute="bottom" constant="2" id="FAQ-Ku-C91"/>
                         <constraint firstItem="uZy-Vd-msE" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" id="Fql-z7-J8n"/>
-                        <constraint firstItem="PFp-Li-SKL" firstAttribute="top" secondItem="2kM-5s-5No" secondAttribute="bottom" constant="8" id="G1L-WZ-ZDg"/>
-                        <constraint firstItem="PFp-Li-SKL" firstAttribute="top" secondItem="2kM-5s-5No" secondAttribute="bottom" constant="16" id="HBU-0H-9EN"/>
+                        <constraint firstItem="uZy-Vd-msE" firstAttribute="top" secondItem="yIG-b6-LNx" secondAttribute="bottom" id="Fyf-e3-sZT"/>
+                        <constraint firstAttribute="trailing" secondItem="2kM-5s-5No" secondAttribute="trailing" constant="8" id="GQq-m4-IX4"/>
                         <constraint firstItem="m5t-YK-XBL" firstAttribute="top" secondItem="oQe-dL-E6M" secondAttribute="bottom" id="HKT-rW-Ufl"/>
                         <constraint firstItem="oQe-dL-E6M" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" id="L3h-zt-PfX"/>
-                        <constraint firstAttribute="trailing" secondItem="J1z-Uv-f8i" secondAttribute="trailing" constant="16" id="NwQ-Se-1df"/>
+                        <constraint firstItem="XUP-Pb-3Bz" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" constant="16" id="NaY-vk-jcI"/>
                         <constraint firstItem="tun-mR-gRE" firstAttribute="top" secondItem="m5t-YK-XBL" secondAttribute="bottom" constant="31" id="PKE-iA-oMf"/>
                         <constraint firstAttribute="trailing" secondItem="CNd-YW-Iyu" secondAttribute="trailing" id="Qfd-oN-JmR"/>
                         <constraint firstAttribute="trailing" secondItem="oQe-dL-E6M" secondAttribute="trailing" id="RqB-sU-8DZ"/>
                         <constraint firstItem="oQe-dL-E6M" firstAttribute="width" secondItem="W5A-hO-k9M" secondAttribute="width" id="S1A-w5-pKz"/>
+                        <constraint firstItem="J1z-Uv-f8i" firstAttribute="top" secondItem="uZy-Vd-msE" secondAttribute="bottom" constant="9" id="SpP-IZ-VuH"/>
+                        <constraint firstItem="2kM-5s-5No" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" constant="8" id="UaW-vx-g6D"/>
                         <constraint firstItem="zZ6-bA-0iX" firstAttribute="top" secondItem="W5A-hO-k9M" secondAttribute="top" constant="20" id="Vdf-rM-crp"/>
                         <constraint firstItem="m5t-YK-XBL" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" id="W1k-GB-BeR"/>
-                        <constraint firstItem="J1z-Uv-f8i" firstAttribute="top" secondItem="uZy-Vd-msE" secondAttribute="bottom" constant="16" id="WTW-VT-oce"/>
+                        <constraint firstItem="J1z-Uv-f8i" firstAttribute="centerX" secondItem="W5A-hO-k9M" secondAttribute="centerX" id="W76-X5-dYO"/>
                         <constraint firstAttribute="trailing" secondItem="uZy-Vd-msE" secondAttribute="trailing" id="XL3-wj-OB5"/>
-                        <constraint firstItem="J1z-Uv-f8i" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" constant="16" id="dGS-ka-81v"/>
-                        <constraint firstItem="PFp-Li-SKL" firstAttribute="top" secondItem="CNd-YW-Iyu" secondAttribute="bottom" constant="300" id="dex-Mz-Kmm"/>
-                        <constraint firstAttribute="trailing" secondItem="2kM-5s-5No" secondAttribute="trailing" constant="16" id="k7y-mV-4lQ"/>
-                        <constraint firstAttribute="bottom" secondItem="PFp-Li-SKL" secondAttribute="bottom" constant="20" id="lWv-9C-ylu"/>
-                        <constraint firstItem="2kM-5s-5No" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" constant="16" id="riV-2b-UDl"/>
+                        <constraint firstItem="yIG-b6-LNx" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" id="dPd-6n-J82"/>
+                        <constraint firstAttribute="trailing" secondItem="J1z-Uv-f8i" secondAttribute="trailing" constant="16" id="dro-A3-Af3"/>
                         <constraint firstItem="tun-mR-gRE" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" constant="16" id="tJ5-tm-M7K"/>
                         <constraint firstItem="CNd-YW-Iyu" firstAttribute="top" secondItem="tun-mR-gRE" secondAttribute="bottom" constant="2" id="taZ-XA-nFX"/>
+                        <constraint firstItem="PFp-Li-SKL" firstAttribute="top" secondItem="2kM-5s-5No" secondAttribute="bottom" constant="16" id="wKg-np-SK4"/>
                         <constraint firstItem="CNd-YW-Iyu" firstAttribute="leading" secondItem="W5A-hO-k9M" secondAttribute="leading" id="zgM-Yh-9fg"/>
                     </constraints>
-                    <variation key="default">
-                        <mask key="constraints">
-                            <exclude reference="G1L-WZ-ZDg"/>
-                            <exclude reference="dex-Mz-Kmm"/>
-                        </mask>
-                    </variation>
                 </scrollView>
             </subviews>
+            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="W5A-hO-k9M" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="4aQ-a0-8Nq"/>


### PR DESCRIPTION
#### What's this PR do?

1) Adds a feedback form to the profile/settings page, adding another bar button above "Rate Let's Do This" which would link to the feedback form. 

2) Adds a "FEEDBACK" header which encompasses the "Rate" and "Give Us Feedback" buttons

3) change the Google Analytics event tracking values. `tap on feedback form` is now fired when the feedback form button is tapped, `tap on ideas form` is now tapped when the user generated campaign ideas link at the bottom of the screen is tapped. 
#### What are the relevant tickets?

Closes #533. 
