### PR TITLE
add onboarding screen GA tracking

### DIFF
--- a/Lets Do This/Controllers/Onboarding/LDTOnboardingChildViewController.h
+++ b/Lets Do This/Controllers/Onboarding/LDTOnboardingChildViewController.h
@@ -10,6 +10,6 @@
 
 @interface LDTOnboardingChildViewController : UIViewController
 
-- (instancetype)initWithHeadlineText:(NSString *)headlineText descriptionText:(NSString *)descriptionText primaryImage:(UIImage *)primaryImage;
+- (instancetype)initWithHeadlineText:(NSString *)headlineText descriptionText:(NSString *)descriptionText primaryImage:(UIImage *)primaryImage gaiScreenName:(NSString *)gaiScreenName;
 
 @end

--- a/Lets Do This/Controllers/Onboarding/LDTOnboardingChildViewController.m
+++ b/Lets Do This/Controllers/Onboarding/LDTOnboardingChildViewController.m
@@ -8,9 +8,11 @@
 
 #import "LDTOnboardingChildViewController.h"
 #import "LDTTheme.h"
+#import "GAI+LDT.h"
 
 @interface LDTOnboardingChildViewController ()
 
+@property (strong, nonatomic) NSString *gaiScreenName;
 @property (strong, nonatomic) NSString *headlineText;
 @property (strong, nonatomic) NSString *descriptionText;
 @property (strong, nonatomic) UIImage *primaryImage;
@@ -25,12 +27,13 @@
 
 #pragma mark - NSObject
 
-- (instancetype)initWithHeadlineText:(NSString *)headlineText descriptionText:(NSString *)descriptionText primaryImage:(UIImage *)primaryImage {
+- (instancetype)initWithHeadlineText:(NSString *)headlineText descriptionText:(NSString *)descriptionText primaryImage:(UIImage *)primaryImage gaiScreenName:(NSString *)gaiScreenName {
     self = [super initWithNibName:@"LDTOnboardingChildView" bundle:nil];
     if (self) {
         self.headlineText = headlineText;
         self.descriptionText = descriptionText;
         self.primaryImage = primaryImage;
+        self.gaiScreenName = gaiScreenName;
     }
 
     return self;
@@ -47,6 +50,12 @@
 
     [self styleView];
 
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    
+    [[GAI sharedInstance] trackScreenView:self.gaiScreenName];
 }
 
 - (void)styleView {

--- a/Lets Do This/Controllers/Onboarding/LDTOnboardingPageViewController.m
+++ b/Lets Do This/Controllers/Onboarding/LDTOnboardingPageViewController.m
@@ -33,8 +33,8 @@
 
     [self.pageController view].frame = [[self view] bounds];
 
-    self.firstChildViewController = [[LDTOnboardingChildViewController alloc] initWithHeadlineText:@"Stop being bored".uppercaseString descriptionText:@"Are you into sports? Crafting? Whatever your interests, you can do fun stuff and social good at the same time." primaryImage:[UIImage imageNamed:@"Onboarding_StopBeingBored"]];
-    self.secondChildViewController = [[LDTOnboardingChildViewController alloc] initWithHeadlineText:@"Prove it".uppercaseString descriptionText:@"Submit and share photos of yourself in action -- and see other people’s photos too. #picsoritdidnthappen" primaryImage:[UIImage imageNamed:@"Onboarding_ProveIt"]];
+    self.firstChildViewController = [[LDTOnboardingChildViewController alloc] initWithHeadlineText:@"Stop being bored".uppercaseString descriptionText:@"Are you into sports? Crafting? Whatever your interests, you can do fun stuff and social good at the same time." primaryImage:[UIImage imageNamed:@"Onboarding_StopBeingBored"] gaiScreenName:@"onboarding-first"];
+    self.secondChildViewController = [[LDTOnboardingChildViewController alloc] initWithHeadlineText:@"Prove it".uppercaseString descriptionText:@"Submit and share photos of yourself in action -- and see other people’s photos too. #picsoritdidnthappen" primaryImage:[UIImage imageNamed:@"Onboarding_ProveIt"] gaiScreenName:@"onboarding-second"];
     LDTUserConnectViewController *userConnectVC  = [[LDTUserConnectViewController alloc] initWithNibName:@"LDTUserConnectView" bundle:nil];
     self.userConnectNavigationController = [[UINavigationController alloc] initWithRootViewController:userConnectVC];
     [self.userConnectNavigationController styleNavigationBar:LDTNavigationBarStyleClear];


### PR DESCRIPTION
#### What's this PR do?

Adds GA screen tracking to the two onboarding screens. 
#### Any background context you want to provide?

Since both of the onboarding screens are instances of the same class, I implemented this hacky-ish check of the `self.headlineText` property of the instance in order to send the right tracking event. 

The string equivalence check doesn't feel like the best solution, but it's the simplest. 

I first tried adding GA screen tracking events to `LDTOnboardingPageViewController`, within the `viewControllerBeforeViewController` and `viewControllerAfterViewController` control flow, but this proved to be complicated (for instance, those functions aren't hit upon first screenview) and hard to read/understand. 
#### What are the relevant tickets?
#451
