### PR TITLE
Error cleanup

### DIFF
--- a/Lets Do This/Categories/NSError+LDT.m
+++ b/Lets Do This/Categories/NSError+LDT.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSError+LDT.h"
+#import "NSDictionary+DSOJsonHelper.h"
 
 @implementation NSError (LDT)
 
@@ -27,10 +28,24 @@
             return @"Seems like the Internet is trying to cause drama.";
         }
     }
+    NSData *errorData = self.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
+    if (errorData) {
+        NSError *error = self;
+        NSDictionary *reponseDict = [NSJSONSerialization JSONObjectWithData:errorData options:kNilOptions error:&error];
+        NSLog(@"responseDict %@", reponseDict);
+        NSDictionary *errorDict = reponseDict[@"error"];
+        NSInteger code = [errorDict valueForKeyAsInt:@"code" nullValue:0];
+        if (code >= 400 && code < 500) {
+            if (isTitle) {
+                return nil;
+            }
+            return [errorDict valueForKeyAsString:@"message"];
+        }
+    }
     if (isTitle) {
         return @"Oops! Our bad.";
     }
-    return @"Seems like the Internet is trying to cause drama.";
+    return @"Looks like there was an issue with that request. We're looking into it now!";
 }
 
 @end

--- a/Lets Do This/Views/LDTMessage.m
+++ b/Lets Do This/Views/LDTMessage.m
@@ -16,24 +16,7 @@
 }
 
 +(void)displayErrorMessageForError:(NSError *)error {
-    NSInteger code = error.code;
-    NSString *title;
-    NSString *message = error.localizedDescription;
-
-    if (code == -1009) {
-        title = @"No connection.";
-        message = @"Seems like the Internet is trying to cause drama.";
-    }
-    NSData *errorData = error.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
-    if (errorData) {
-        NSDictionary *reponseDict = [NSJSONSerialization JSONObjectWithData:errorData options:kNilOptions error:&error];
-        NSLog(@"responseDict %@", reponseDict);
-        NSDictionary *errorDict = reponseDict[@"error"];
-        code = [errorDict valueForKeyAsInt:@"code" nullValue:0];
-        title = [NSString stringWithFormat:@"O noes, error %li", (long)code];
-        message = [errorDict valueForKeyAsString:@"message"];
-    }
-    [TSMessage showNotificationInViewController:[TSMessage defaultViewController] title:title subtitle:message image:nil type:TSMessageNotificationTypeError duration:TSMessageNotificationDurationAutomatic callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionNavBarOverlay canBeDismissedByUser:YES];
+    [TSMessage showNotificationInViewController:[TSMessage defaultViewController] title:[error readableTitle] subtitle:[error readableMessage] image:nil type:TSMessageNotificationTypeError duration:TSMessageNotificationDurationAutomatic callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionNavBarOverlay canBeDismissedByUser:YES];
 }
 
 +(void)displaySuccessMessageWithTitle:(NSString *)title subtitle:(NSString *)subtitle {


### PR DESCRIPTION
- Fixes #363: moves AFNetworking error message logic into the `NSError+LDT` category
  - DRY for error message definitions (refs https://github.com/DoSomething/LetsDoThis-iOS/pull/537#discussion_r43266096)
  - stops displaying those "O noes status codez" titles (RIP)
- Closes remaining item in #462 if user is able to post signup to closed campaign

![simulator screen shot oct 28 2015 12 26 55 pm](https://cloud.githubusercontent.com/assets/1236811/10800991/57d48432-7d72-11e5-8d1f-8c06deb986c6.png)

![simulator screen shot oct 27 2015 4 59 59 pm](https://cloud.githubusercontent.com/assets/1236811/10801002/61d81c50-7d72-11e5-9bd4-a148f142728f.png)

![simulator screen shot oct 28 2015 12 35 24 pm](https://cloud.githubusercontent.com/assets/1236811/10800996/5d7dbaf2-7d72-11e5-9ae8-8c08b3053e55.png)
