### PR TITLE
Dynamic Interest Group names

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -166,7 +166,7 @@ const CGFloat kHeightExpanded = 420;
 
 - (void)createInterestGroups {
     self.interestGroups = [[NSMutableDictionary alloc] init];
-    for (NSNumber *termID in [DSOAPI sharedInstance].interestGroupIds) {
+    for (NSNumber *termID in self.interestGroupIds) {
         self.interestGroups[termID] = @{@"campaigns" : [[NSMutableArray alloc] init], @"reportbackItems" : [[NSMutableArray alloc] init], @"name" : [NSMutableString stringWithCapacity:10]};
     }
 
@@ -192,7 +192,7 @@ const CGFloat kHeightExpanded = 420;
     }
 
     for (int i = 0; i < 4; i++) {
-        NSNumber *groupID = [DSOAPI sharedInstance].interestGroupIds[i];
+        NSNumber *groupID = self.interestGroupIds[i];
         LDTButton *aButton = self.interestGroupButtons[i];
         aButton.hidden = NO;
         [aButton setTitle:self.interestGroups[groupID][@"name"] forState:UIControlStateNormal];
@@ -255,7 +255,7 @@ const CGFloat kHeightExpanded = 420;
 }
 
 - (NSNumber *)selectedInterestGroupId {
-    return (NSNumber *)[DSOAPI sharedInstance].interestGroupIds[self.selectedGroupButtonIndex];
+    return (NSNumber *)self.interestGroupIds[self.selectedGroupButtonIndex];
 }
 
 - (void)configureCampaignCell:(LDTCampaignListCampaignCell *)cell atIndexPath:(NSIndexPath *)indexPath {

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -14,11 +14,12 @@
 
 @interface DSOAPI : AFHTTPSessionManager
 
-@property (nonatomic, strong, readonly) NSArray *interestGroupIds;
-
 + (DSOAPI *)sharedInstance;
+
 - (instancetype)initWithApiKey:(NSString *)apiKey;
+
 - (NSString *)phoenixBaseURL;
+
 - (NSString *)northstarBaseURL;
 
 - (void)setHTTPHeaderFieldSession:(NSString *)token;

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -39,7 +39,6 @@
 
 @interface DSOAPI()
 
-@property (nonatomic, strong, readwrite) NSArray *interestGroupIds;
 @property (nonatomic, strong) NSString *phoenixBaseURL;
 @property (nonatomic, strong) NSString *phoenixApiURL;
 @property (nonatomic, strong) NSString *northstarBaseURL;
@@ -81,10 +80,6 @@
         self.phoenixBaseURL =  [NSString stringWithFormat:@"%@://%@/", DSOPROTOCOL, DSOSERVER];
         self.phoenixApiURL = [NSString stringWithFormat:@"%@api/v1/", self.phoenixBaseURL];
         self.northstarBaseURL = [NSString stringWithFormat:@"%@://%@/", DSOPROTOCOL, LDTSERVER];
-        self.interestGroupIds = @[@1300, @1301, @1302, @1303];
-#ifdef DEBUG
-        self.interestGroupIds = @[@667, @668, @669, @670];
-#endif
     }
     return self;
 }


### PR DESCRIPTION
Closes #464, setting the Interest Group names based on Campaign.tags data instead of hardcoding.

Also defines the term id's to query for on the `LDTCampaignListViewController` instead of the `DSOAPI` class, since the Campaign List VC is now responsible for loading all active mobile app campaigns.
