### PR TITLE
change app icon title

### DIFF
--- a/Lets Do This/Info.plist
+++ b/Lets Do This/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>Let&apos;s Do This</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Changes app icon title displayed from "Lets Do This" to "Let's Do This". Closes #547. 

BEFORE (ignore lack of icon image, only text is relevant):

![](https://cloud.githubusercontent.com/assets/1236811/10807101/464c2f22-7d99-11e5-8838-048e6828c6e0.jpeg)

AFTER:

<img width="99" alt="screenshot 2015-10-29 10 17 15" src="https://cloud.githubusercontent.com/assets/5678066/10820963/42baafd6-7e26-11e5-8040-92bcc073b2ce.png">
