### PR TITLE
Dynamic status bar style for Campaign Detail

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -75,7 +75,6 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     [self fetchReportbackItems];
     [LDTMessage setDefaultViewController:self];
 
-
     if ([[self user] hasCompletedCampaign:self.campaign]) {
         for (DSOCampaignSignup *signup in [self user].campaignSignups) {
             if (self.campaign.campaignID == signup.campaign.campaignID) {
@@ -125,7 +124,12 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
 - (void)styleView {
     [self.navigationController styleNavigationBar:LDTNavigationBarStyleClear];
-    self.navigationController.navigationBar.barStyle = UIStatusBarStyleDefault;
+    if (self.campaign.isCoverImageDarkBackground) {
+         self.navigationController.navigationBar.barStyle = UIStatusBarStyleLightContent;
+    }
+    else {
+         self.navigationController.navigationBar.barStyle = UIStatusBarStyleDefault;
+    }
 }
 
 - (void)fetchReportbackItems {

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -13,6 +13,7 @@
 
 @interface DSOCampaign : NSObject
 
+@property (assign, nonatomic, readonly) BOOL isCoverImageDarkBackground;
 @property (strong, nonatomic, readonly) NSArray *tags;
 @property (assign, nonatomic, readonly) NSInteger campaignID;
 @property (strong, nonatomic, readonly) NSString *coverImage;

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -12,6 +12,7 @@
 
 @interface DSOCampaign ()
 
+@property (assign, nonatomic, readwrite) BOOL isCoverImageDarkBackground;
 @property (strong, nonatomic, readwrite) NSArray *tags;
 @property (strong, nonatomic, readwrite) NSDate *endDate;
 @property (assign, nonatomic, readwrite) NSInteger campaignID;
@@ -46,6 +47,7 @@
         self.title = [values valueForKeyAsString:@"title" nullValue:self.title];
         self.tagline = [values valueForKeyAsString:@"tagline" nullValue:self.tagline];
         self.coverImage = [[values valueForKeyPath:@"cover_image.default.sizes.landscape"] valueForKeyAsString:@"uri" nullValue:self.coverImage];
+        self.isCoverImageDarkBackground = [[values valueForKeyPath:@"cover_image.default"] valueForKeyAsBool:@"dark_background" nullValue:NO];
         self.reportbackNoun = [values valueForKeyPath:@"reportback_info.noun"];
         self.reportbackVerb = [values valueForKeyPath:@"reportback_info.verb"];
 


### PR DESCRIPTION
Fixes #563 with ease, thanks to the Phoenix API's Campaign Cover Image `dark_background` property.
![screen shot 2015-11-03 at 12 25 19 pm](https://cloud.githubusercontent.com/assets/1236811/10920852/49d83338-8227-11e5-87dc-02330f286724.png)
![screen shot 2015-11-03 at 12 25 37 pm](https://cloud.githubusercontent.com/assets/1236811/10920853/4c8efa9e-8227-11e5-9483-33a41570a6a5.png)
