### PR TITLE
update emailRegex

### DIFF
--- a/Lets Do This/Controllers/Base/LDTBaseViewController.m
+++ b/Lets Do This/Controllers/Base/LDTBaseViewController.m
@@ -51,7 +51,7 @@
         return NO;
     }
 	
-    NSString *emailRegex = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}";
+    NSString *emailRegex = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9-]+[.]{1}[A-Za-z0-9-]{2,6}([.]{1}[A-Za-z0-9-]{1,6}){0,9}";
     NSPredicate *emailTest = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", emailRegex];
 	
     return [emailTest evaluateWithObject:candidate];


### PR DESCRIPTION
#### What's this PR do?

Modifies the regular expression validating emails. 

Previously, the `validateEmailForCandidate` function incorrectly returned `YES` for an email like `big.sloth@google...com`. Now, it will correctly return `NO` for that email. 

Additionally, previously the function incorrectly returned `FALSE` for an email like `big.sloth@google.co.uk`. (A multiple-part top-level-domain.) Now, it will correctly return `YES` for that email. 
#### How should this be manually tested?

Tested [with this regular expression tool](http://regexr.com/3c4mr), as well as with the simulator. 
#### What are the relevant tickets?

Closes #544. 
