### PR TITLE
Present Onboarding/Login VC from TabBar

### DIFF
--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -9,6 +9,8 @@
 #import "LDTTabBarController.h"
 #import "LDTUserProfileViewController.h"
 #import "LDTCampaignListViewController.h"
+#import "LDTOnboardingPageViewController.h"
+#import "LDTUserConnectViewController.h"
 #import "LDTTheme.h"
 
 @interface LDTTabBarController ()
@@ -39,6 +41,27 @@
     }
 	
     return self;
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:YES];
+
+    if (![DSOUserManager sharedInstance].userHasCachedSession) {
+        LDTUserConnectViewController *userConnectVC  = [[LDTUserConnectViewController alloc] initWithNibName:@"LDTUserConnectView" bundle:nil];
+        UINavigationController *destNavVC;
+
+        if (![[NSUserDefaults standardUserDefaults] boolForKey:@"hasCompletedOnboarding"]) {
+            LDTOnboardingPageViewController *secondOnboardingVC = [[LDTOnboardingPageViewController alloc] initWithHeadlineText:@"Prove it".uppercaseString descriptionText:@"Submit and share photos of yourself in action -- and see other people’s photos too. #picsoritdidnthappen" primaryImage:[UIImage imageNamed:@"Onboarding_ProveIt"] gaiScreenName:@"onboarding-second" nextViewController:userConnectVC isFirstPage:NO];
+            LDTOnboardingPageViewController *firstOnboardingVC =[[LDTOnboardingPageViewController alloc] initWithHeadlineText:@"Stop being bored".uppercaseString descriptionText:@"Are you into sports? Crafting? Whatever your interests, you can do fun stuff and social good at the same time." primaryImage:[UIImage imageNamed:@"Onboarding_StopBeingBored"] gaiScreenName:@"onboarding-first" nextViewController:secondOnboardingVC isFirstPage:YES];
+            destNavVC = [[UINavigationController alloc] initWithRootViewController:firstOnboardingVC];
+        }
+        else {
+            destNavVC = [[UINavigationController alloc] initWithRootViewController:userConnectVC];
+        }
+        [destNavVC styleNavigationBar:LDTNavigationBarStyleClear];
+        [self presentViewController:destNavVC animated:YES completion:nil];
+        [TSMessage setDefaultViewController:destNavVC];
+    }
 }
 
 # pragma mark - LDTTabBarController

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -90,25 +90,6 @@ const CGFloat kHeightExpanded = 420;
     if ([DSOUserManager sharedInstance].userHasCachedSession) {
         [self loadMainFeed];
     }
-    else {
-        // Use dispatch_async to avoid "Unbalanced calls to begin/end appearance transitions for <LDTTabBarController>" warning.
-        dispatch_async(dispatch_get_main_queue(), ^(void){
-            LDTUserConnectViewController *userConnectVC  = [[LDTUserConnectViewController alloc] initWithNibName:@"LDTUserConnectView" bundle:nil];
-            UINavigationController *destNavVC;
-
-            if (![[NSUserDefaults standardUserDefaults] boolForKey:@"hasCompletedOnboarding"]) {
-                LDTOnboardingPageViewController *secondOnboardingVC = [[LDTOnboardingPageViewController alloc] initWithHeadlineText:@"Prove it".uppercaseString descriptionText:@"Submit and share photos of yourself in action -- and see other people’s photos too. #picsoritdidnthappen" primaryImage:[UIImage imageNamed:@"Onboarding_ProveIt"] gaiScreenName:@"onboarding-second" nextViewController:userConnectVC isFirstPage:NO];
-                LDTOnboardingPageViewController *firstOnboardingVC =[[LDTOnboardingPageViewController alloc] initWithHeadlineText:@"Stop being bored".uppercaseString descriptionText:@"Are you into sports? Crafting? Whatever your interests, you can do fun stuff and social good at the same time." primaryImage:[UIImage imageNamed:@"Onboarding_StopBeingBored"] gaiScreenName:@"onboarding-first" nextViewController:secondOnboardingVC isFirstPage:YES];
-                destNavVC = [[UINavigationController alloc] initWithRootViewController:firstOnboardingVC];
-            }
-            else {
-                destNavVC = [[UINavigationController alloc] initWithRootViewController:userConnectVC];
-            }
-            [destNavVC styleNavigationBar:LDTNavigationBarStyleClear];
-            [self presentViewController:destNavVC animated:YES completion:nil];
-            [TSMessage setDefaultViewController:destNavVC];
-        });
-    }
 }
 
 - (void)viewDidAppear:(BOOL)animated {


### PR DESCRIPTION
Yahh so I did this already in #513 .. but then thought I somehow got rid of the errors with that `dispatch_async` in #557 -- which seemed like a way to DRY all logic. 
#189 came back, so this fixes #189 again, in the same way it seems. Makes sense to init all of the Onboarding / Login VC's in the TabBar instead of the CampaignList anyway...

![bailey-computer1](https://cloud.githubusercontent.com/assets/1236811/10956149/1c5c7b70-830e-11e5-93ae-7d6a37e36fe3.png)
