### PR TITLE
Dismiss keyboard when posting to API

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -131,6 +131,7 @@
         [LDTMessage displayErrorMessageForString:@"Please enter a valid email."];
         return;
     }
+    [self.view endEditing:YES];
     [SVProgressHUD showWithStatus:@"Signing in..."];
     [[DSOUserManager sharedInstance] createSessionWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
         [SVProgressHUD dismiss];

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -150,6 +150,7 @@
 
 - (IBAction)submitButtonTouchUpInside:(id)sender {
     if ([self validateForm]) {
+        [self.view endEditing:YES];
         [SVProgressHUD showWithStatus:@"Creating account..."];
         [[DSOAPI sharedInstance] createUserWithEmail:self.emailTextField.text password:self.passwordTextField.text firstName:self.firstNameTextField.text mobile:self.mobileTextField.text countryCode:self.countryCode success:^(NSDictionary *response) {
             

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -139,6 +139,7 @@
 }
 
 - (IBAction)submitButtonTouchUpInside:(id)sender {
+    [self.view endEditing:YES];
     [SVProgressHUD showWithStatus:@"Uploading..."];
     self.reportbackItem.caption = self.captionTextField.text;
     self.reportbackItem.quantity = [self.quantityTextField.text integerValue];


### PR DESCRIPTION
Uses `endEditing:` per http://stackoverflow.com/questions/15521508/hiding-the-keyboard-on-button-click to dismiss the keyboard when user submits a login, registration, or reportback POST.
