### PR TITLE
Filter public profile for active mobile app campaigns

### DIFF
--- a/Lets Do This/Controllers/Profile/LDTUserProfileViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTUserProfileViewController.m
@@ -62,8 +62,7 @@ static NSString *cellIdentifier = @"rowCell";
         self.navigationItem.rightBarButtonItem = settingsButton;
     }
     else {
-        [[DSOAPI sharedInstance] loadCampaignSignupsForUser:self.user completionHandler:^(NSArray *campaignSignups) {
-            self.user.campaignSignups = (NSMutableArray *)campaignSignups;
+        [[DSOUserManager sharedInstance] loadActiveMobileAppCampaignSignupsForUser:self.user completionHandler:^{
             [self.tableView reloadData];
         } errorHandler:^(NSError *error) {
             [LDTMessage displayErrorMessageForError:error];

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -34,6 +34,9 @@
 // Fetches the current user from API and updates the user property. Called when user is first logged in, when app opens with a saved session, or when user posts Campaign activity (signup/reportback).
 - (void)syncCurrentUserWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+// Gets the campaignSignups for given user for all activeMobileAppCampaigns.
+- (void)loadActiveMobileAppCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+
 // Logs out the user and deletes the saved session tokens. Called when User logs out from Settings screen.
 - (void)endSessionWithCompletionHandler:(void(^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -74,22 +74,35 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     [[DSOAPI sharedInstance] setHTTPHeaderFieldSession:sessionToken];
 
     NSString *userID = [SSKeychain passwordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"UserID"];
+
     [[DSOAPI sharedInstance] loadUserWithUserId:userID completionHandler:^(DSOUser *user) {
         self.user = user;
-        [[DSOAPI sharedInstance] loadCampaignSignupsForUser:self.user completionHandler:^(NSArray *campaignSignups) {
-            self.user.campaignSignups = [[NSMutableArray alloc] init];
-            for (DSOCampaignSignup *signup in campaignSignups) {
-                if ([self activeMobileAppCampaignWithId:signup.campaign.campaignID]) {
-                    [self.user.campaignSignups addObject:signup];
-                }
-            }
+        [self loadActiveMobileAppCampaignSignupsForUser:self.user completionHandler:^{
             self.isCurrentUserSync = YES;
             if (completionHandler) {
                 completionHandler();
             }
         } errorHandler:^(NSError *error) {
-            // nada
+            errorHandler(error);
         }];
+    } errorHandler:^(NSError *error) {
+        if (errorHandler) {
+            errorHandler(error);
+        }
+    }];
+}
+
+- (void)loadActiveMobileAppCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    [[DSOAPI sharedInstance] loadCampaignSignupsForUser:user completionHandler:^(NSArray *campaignSignups) {
+        user.campaignSignups = [[NSMutableArray alloc] init];
+        for (DSOCampaignSignup *signup in campaignSignups) {
+            if ([self activeMobileAppCampaignWithId:signup.campaign.campaignID]) {
+                [user.campaignSignups addObject:signup];
+            }
+        }
+        if (completionHandler) {
+            completionHandler();
+        }
     } errorHandler:^(NSError *error) {
         if (errorHandler) {
             errorHandler(error);


### PR DESCRIPTION
Fixes #478 by filtering inactive campaigns from the Public Profile (was only filtering for the current User's profile). 

Adds `DSOUserManager -loadActiveMobileAppCampaignSignupsForUser` to make the call to the API and filter the result by active mobile app campaigns.
