### PR TITLE
fix incomplete gray tint

### DIFF
--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
@@ -1,31 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="LDTCampaignDetailCampaignCell">
-            <rect key="frame" x="0.0" y="0.0" width="385" height="478"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="478"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="385" height="478"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="478"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3QF-fG-65U" userLabel="Header Container View">
-                        <rect key="frame" x="0.0" y="0.0" width="385" height="242"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="242"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SPy-df-4JQ" userLabel="Campaign Image">
-                                <rect key="frame" x="0.0" y="0.0" width="385" height="242"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="242"/>
+                                <animations/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xzc-iv-ilv" userLabel="Campaign Title">
-                                <rect key="frame" x="21" y="210" width="343" height="21"/>
+                                <rect key="frame" x="21" y="210" width="372" height="21"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="SPy-df-4JQ" firstAttribute="top" secondItem="3QF-fG-65U" secondAttribute="top" id="3hw-se-aEQ"/>
@@ -39,39 +42,45 @@
                         </constraints>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Tagline" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AS3-o6-YFe">
-                        <rect key="frame" x="21" y="258" width="343" height="21"/>
+                        <rect key="frame" x="21" y="258" width="372" height="21"/>
+                        <animations/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jAl-nc-WCh" userLabel="Do It Container View">
-                        <rect key="frame" x="0.0" y="287" width="385" height="191"/>
+                        <rect key="frame" x="0.0" y="287" width="414" height="191"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="998" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Do It" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wux-hK-art" userLabel="Do It Headline">
-                                <rect key="frame" x="8" y="41" width="369" height="21"/>
+                                <rect key="frame" x="8" y="41" width="398" height="21"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="996" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Solution Copy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Es-nC-OvU">
-                                <rect key="frame" x="8" y="80" width="369" height="21"/>
+                                <rect key="frame" x="8" y="80" width="398" height="21"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="995" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Static Instructions" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GEn-tp-NCH">
-                                <rect key="frame" x="8" y="158" width="369" height="21"/>
+                                <rect key="frame" x="8" y="158" width="398" height="21"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="996" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Solution Support Copy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2EF-2e-0yi">
-                                <rect key="frame" x="8" y="119" width="369" height="21"/>
+                                <rect key="frame" x="8" y="119" width="398" height="21"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="Wux-hK-art" secondAttribute="trailing" constant="8" id="5Iq-PK-V6P"/>
@@ -90,8 +99,10 @@
                         </constraints>
                     </view>
                 </subviews>
+                <animations/>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
+            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="AS3-o6-YFe" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="21" id="00i-E4-fPE"/>

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
@@ -1,48 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="LDTCampaignListCampaignCell">
-            <rect key="frame" x="0.0" y="0.0" width="385" height="400"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="385" height="400"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YLY-38-HRb" userLabel="Campaign Image">
-                        <rect key="frame" x="0.0" y="0.0" width="385" height="242"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="242" id="9iE-zQ-Mqv"/>
-                        </constraints>
-                    </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ct-iF-EqI" userLabel="Campaign Title">
-                        <rect key="frame" x="8" y="32" width="369" height="21"/>
+                        <rect key="frame" x="8" y="32" width="398" height="21"/>
+                        <animations/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gec-if-FXG" userLabel="Signup Indicator View">
                         <rect key="frame" x="0.0" y="0.0" width="8" height="400"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="8" id="dgE-ab-Byo"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rcw-DX-Omy" userLabel="Action Container View">
-                        <rect key="frame" x="0.0" y="242" width="385" height="158"/>
+                        <rect key="frame" x="0.0" y="242" width="414" height="158"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vEa-dR-bea" userLabel="Campaign Tagline">
-                                <rect key="frame" x="8" y="16" width="369" height="21"/>
+                                <rect key="frame" x="8" y="16" width="398" height="21"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D5G-Kr-aLa" userLabel="Action Button" customClass="LDTButton">
-                                <rect key="frame" x="8" y="53" width="369" height="50"/>
+                                <rect key="frame" x="8" y="53" width="398" height="50"/>
+                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="vfe-nB-oVK"/>
                                 </constraints>
@@ -54,10 +52,11 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m7T-oO-0JI" userLabel="Expires Container View">
-                                <rect key="frame" x="108" y="119" width="168" height="21"/>
+                                <rect key="frame" x="123" y="119" width="168" height="21"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="x Days" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VbD-83-6o3" userLabel="Expires Days">
                                         <rect key="frame" x="99" y="0.0" width="69" height="21"/>
+                                        <animations/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="69" id="KEI-nw-HAr"/>
                                         </constraints>
@@ -67,6 +66,7 @@
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Expires Prefix" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AoE-fr-CS1">
                                         <rect key="frame" x="0.0" y="0.0" width="95" height="21"/>
+                                        <animations/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="95" id="gO5-xB-caG"/>
                                         </constraints>
@@ -75,6 +75,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
+                                <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstItem="AoE-fr-CS1" firstAttribute="top" secondItem="m7T-oO-0JI" secondAttribute="top" id="3DC-4l-3dv"/>
@@ -90,6 +91,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="D5G-Kr-aLa" firstAttribute="top" secondItem="vEa-dR-bea" secondAttribute="bottom" constant="16" id="DCM-TH-Ls5"/>
@@ -103,9 +105,18 @@
                             <constraint firstAttribute="centerX" secondItem="m7T-oO-0JI" secondAttribute="centerX" id="sub-54-gGA"/>
                         </constraints>
                     </view>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YLY-38-HRb" userLabel="Campaign Image">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="242"/>
+                        <animations/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="242" id="9iE-zQ-Mqv"/>
+                        </constraints>
+                    </imageView>
                 </subviews>
+                <animations/>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
+            <animations/>
             <constraints>
                 <constraint firstItem="YLY-38-HRb" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="5Ak-wS-aSM"/>
                 <constraint firstItem="YLY-38-HRb" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="E0W-T1-ySj"/>


### PR DESCRIPTION
#### What's this PR do?

Previously, the gray tint on campaign banner photos didn't extend all the way to the right on the iPhone 6. 
![](https://cloud.githubusercontent.com/assets/1236811/10625726/68c3cff4-775b-11e5-8477-dc288cc309de.png)

After too much fuddling around, we discovered this was because the gray tint would be added when the UIImageView was first initialized (at 318px width). Only later would the UIImageView stretch to fill the entire 414 px screen. 

Fuddled around trying to figure out the timing of the UIImageView size change, when in fact the simplest and best solution was just to initialize the UIImageView at the 414px size. I enlarged the initial width of the `LDTCampaignDetailCampaignCell.xib` and `LDTCampaignListCampaignCell.xib` from 385px to 414px, and all the tint issues were resolved. 
#### How should this be manually tested?

Tested on simulator screens: 4s, 5s, 6s, 6+. 
#### What are the relevant tickets?

Closes #504. 
