### PR TITLE
Filter out any closed campaigns returned from API

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -36,7 +36,7 @@ const CGFloat kHeightExpanded = 420;
 @interface LDTCampaignListViewController () <UICollectionViewDataSource, UICollectionViewDelegate, LDTCampaignListCampaignCellDelegate, LDTEpicFailSubmitButtonDelegate>
 
 @property (assign, nonatomic) BOOL isMainFeedLoaded;
-@property (strong, nonatomic) NSArray *allCampaigns;
+@property (strong, nonatomic) NSMutableArray *allCampaigns;
 @property (strong, nonatomic) NSArray *allReportbackItems;
 @property (strong, nonatomic) NSArray *interestGroupIds;
 @property (strong, nonatomic) NSArray *interestGroupButtons;
@@ -164,11 +164,19 @@ const CGFloat kHeightExpanded = 420;
             [self presentEpicFailForNoCampaigns];
             return;
         }
-        [[DSOUserManager sharedInstance] setActiveMobileAppCampaigns:campaigns];
+        self.allCampaigns = [[NSMutableArray alloc] init];
+        for (DSOCampaign *campaign in campaigns) {
+            if ([campaign.status isEqual:@"active"]) {
+                [self.allCampaigns addObject:campaign];
+            }
+            else {
+                NSLog(@"Not displaying Campaign ID %li, its status is set to %@.", (long)campaign.campaignID, campaign.status);
+            }
+        }
+
+        [[DSOUserManager sharedInstance] setActiveMobileAppCampaigns:self.allCampaigns];
         [[DSOUserManager sharedInstance] syncCurrentUserWithCompletionHandler:^ {
             NSLog(@"syncCurrentUserWithCompletionHandler");
-            self.allCampaigns = campaigns;
-            [[DSOUserManager sharedInstance] setActiveMobileAppCampaigns:campaigns];
             [self createInterestGroups];
 			
             // Display loaded campaigns to indicate signs of life.

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -21,6 +21,7 @@
 @property (strong, nonatomic, readonly) NSString *solutionSupportCopy;
 @property (strong, nonatomic, readonly) NSString *reportbackNoun;
 @property (strong, nonatomic, readonly) NSString *reportbackVerb;
+@property (strong, nonatomic, readonly) NSString *status;
 @property (strong, nonatomic, readonly) NSString *title;
 @property (strong, nonatomic, readonly) NSString *tagline;
 @property (strong, nonatomic, readonly) NSURL *coverImageURL;

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -21,6 +21,7 @@
 @property (strong, nonatomic, readwrite) NSString *reportbackVerb;
 @property (strong, nonatomic, readwrite) NSString *solutionCopy;
 @property (strong, nonatomic, readwrite) NSString *solutionSupportCopy;
+@property (strong, nonatomic, readwrite) NSString *status;
 @property (strong, nonatomic, readwrite) NSString *title;
 @property (strong, nonatomic, readwrite) NSString *tagline;
 @property (strong, nonatomic, readwrite) NSURL *coverImageURL;
@@ -45,6 +46,7 @@
         self.campaignID = [values valueForKeyAsInt:@"id" nullValue:self.campaignID];
         self.endDate = [[values valueForKeyPath:@"mobile_app.dates"] valueForKeyAsDate:@"end" nullValue:nil];
         self.title = [values valueForKeyAsString:@"title" nullValue:self.title];
+        self.status = [values valueForKeyAsString:@"status" nullValue:@"closed"];
         self.tagline = [values valueForKeyAsString:@"tagline" nullValue:self.tagline];
         self.coverImage = [[values valueForKeyPath:@"cover_image.default.sizes.landscape"] valueForKeyAsString:@"uri" nullValue:self.coverImage];
         self.isCoverImageDarkBackground = [[values valueForKeyPath:@"cover_image.default"] valueForKeyAsBool:@"dark_background" nullValue:NO];


### PR DESCRIPTION
Fixes #500 by checking for the `status` property returned from the API.

@jonuy -- Ideal fix would be to add a `status` parameter to the campaigns index query: https://github.com/DoSomething/phoenix/wiki/api#optional-query-parameters. A potential gotcha can be where if we have Runscope tests checking for 3 campaigns per tid, the test may pass with 3 records returned but the result may contain a closed campaign (thus the app will only display 2 campaigns).
