### PR TITLE
Fixes RB View issues with background image scaling and the text field…

### DIFF
--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -76,6 +76,8 @@
 
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(dismissModalViewControllerAnimated:)];
     [self styleRightBarButton];
+    
+    [self.captionTextField becomeFirstResponder];
 }
 
 - (void)viewDidAppear:(BOOL)animated {


### PR DESCRIPTION
## What does this PR do?

Previous behavior - bg image would stretch all the way across the imageview without respecting the aspect ratio. Now it is set to aspect fill and is masked at the bounds of the view.

Also adds autocapitalization to the caption field and makes it the first responder when the view loads.

Before:
![simulator screen shot nov 12 2015 10 37 47 am](https://cloud.githubusercontent.com/assets/1865372/11122504/80328dbc-8929-11e5-92a0-65c6c48cfcc0.png)

After:
![simulator screen shot nov 12 2015 10 35 40 am](https://cloud.githubusercontent.com/assets/1865372/11122508/845fa0a0-8929-11e5-9452-baa9d2b6d6ba.png)
## How should it be manually tested?

Testing in simulator on 5, 6, 6+
## Relevant tickets & issues

Closes #593 
