### PR TITLE
Fixes message placement on Reportback confirmation

### DIFF
--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -8,6 +8,7 @@
 
 #import "LDTSubmitReportbackViewController.h"
 #import "LDTTheme.h"
+#import "LDTTabBarController.h"
 #import "GAI+LDT.h"
 
 @interface LDTSubmitReportbackViewController() <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
@@ -150,9 +151,11 @@
     self.reportbackItem.caption = self.captionTextField.text;
     self.reportbackItem.quantity = [self.quantityTextField.text integerValue];
 
+    LDTTabBarController *rootVC = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
     [[DSOUserManager sharedInstance] postUserReportbackItem:self.reportbackItem completionHandler:^(NSDictionary *response) {
         [SVProgressHUD dismiss];
-        [[[[[UIApplication sharedApplication] delegate] window] rootViewController] dismissViewControllerAnimated:YES completion:^{
+        [LDTMessage setDefaultViewController:rootVC];
+        [rootVC dismissViewControllerAnimated:YES completion:^{
             [LDTMessage displaySuccessMessageWithTitle:@"Stunning!" subtitle:[NSString stringWithFormat:@"You submitted your %@ photo for approval.", self.reportbackItem.campaign.title]];
         }];
 


### PR DESCRIPTION
Fixes #602 to keep messaging layout consistent with other screens.

![simulator screen shot nov 12 2015 10 19 16 am](https://cloud.githubusercontent.com/assets/1236811/11127334/b85adf88-8928-11e5-9be5-66481abe3f2c.png)
