### PR TITLE
add userId tracking to crashlytics

### DIFF
--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -9,6 +9,7 @@
 #import "DSOUserManager.h"
 #import <SSKeychain/SSKeychain.h>
 #import "GAI+LDT.h"
+#import <Crashlytics/Crashlytics.h>
 
 NSString *const avatarFileNameString = @"LDTStoredAvatar.jpeg";
 NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
@@ -37,6 +38,16 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 }
 
 #pragma mark - DSOUserManager
+
+- (void)setUser:(DSOUser *)user {
+    _user = user;
+    if (user) {
+        [[Crashlytics sharedInstance] setUserIdentifier:user.userID];
+    }
+    else {
+        [[Crashlytics sharedInstance] setUserIdentifier:nil];
+    }
+}
 
 - (BOOL)userHasCachedSession {
     NSString *sessionToken = [SSKeychain passwordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"Session"];


### PR DESCRIPTION
#### What's this PR do?

Adds userId tracking to crashlytics. 
#### How should this be manually tested?

Tested by [adding crash code](http://support.crashlytics.com/knowledgebase/articles/92522-is-there-a-quick-way-to-force-a-crash) to user profile screen, installing on mobile device, running the app while disconnected from XCode, and forcing the crash. (Simulator will not report crashes, apparently.)
#### What are the relevant tickets?

Closes #583. 
