### PR TITLE
Hide navigationBar when scrolling on Campaign Detail

### DIFF
--- a/Lets Do This/Categories/UINavigationController+LDT.m
+++ b/Lets Do This/Categories/UINavigationController+LDT.m
@@ -21,7 +21,6 @@
     if (style == LDTNavigationBarStyleNormal) {
         [self.navigationBar setBackgroundImage:[UIImage imageNamed:@"Header Background"] forBarMetrics:UIBarMetricsDefault];
         self.navigationBar.translucent = NO;
-        self.navigationBar.barStyle = UIStatusBarStyleLightContent;
     }
     else if (style == LDTNavigationBarStyleClear) {
         [self.navigationBar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];

--- a/Lets Do This/Classes/AppDelegate.m
+++ b/Lets Do This/Classes/AppDelegate.m
@@ -54,6 +54,9 @@
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     [self.window makeKeyAndVisible];
     self.window.rootViewController = [[LDTTabBarController alloc] init];
+    UIView *customStatusBarView = [[UIView alloc] initWithFrame:CGRectMake(0, 0,[UIScreen mainScreen].bounds.size.width, 20)];
+    customStatusBarView.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"Header Background"]];
+    [self.window.rootViewController.view addSubview:customStatusBarView];
 
     return YES;
 }

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -33,12 +33,10 @@
         profileVC.title = @"Me";
         UINavigationController *profileNavVC = [[UINavigationController alloc] initWithRootViewController:profileVC];
         profileNavVC.tabBarItem.image = [UIImage imageNamed:@"Me Icon"];
-        [profileNavVC addCustomStatusBarView:NO];
 
         self.campaignListViewController = [[LDTCampaignListViewController alloc] initWithNibName:@"LDTCampaignListView" bundle:nil];
         self.campaignListNavigationController = [[UINavigationController alloc] initWithRootViewController:self.campaignListViewController];
         self.campaignListNavigationController.tabBarItem.image = [UIImage imageNamed:@"Actions Icon"];
-        [self.campaignListNavigationController addCustomStatusBarView:NO];
 
         self.viewControllers = [NSArray arrayWithObjects:self.campaignListNavigationController, profileNavVC, nil];
     }

--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     self.flowLayout.minimumInteritemSpacing = 0.0f;
     self.flowLayout.minimumLineSpacing = 0.0f;
     [self.collectionView setCollectionViewLayout:self.flowLayout];
-    
+
     self.imagePickerController = [[UIImagePickerController alloc] init];
     self.imagePickerController.delegate = self;
     self.imagePickerController.allowsEditing = YES;
@@ -102,7 +102,10 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-        
+
+    self.navigationController.hidesBarsOnSwipe = YES;
+    [self.navigationController.barHideOnSwipeGestureRecognizer addTarget:self action:@selector(handleSwipeGestureRecognizer:)];
+
     NSString *screenStatus;
     if ([[self user] hasCompletedCampaign:self.campaign]) {
         screenStatus = @"completed";
@@ -128,11 +131,21 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     }
 }
 
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    // Without this, iOS kindly changes toolbar to UIStatusBarStyleDefault when we scroll and hide the navigationBar (because we set self.navigationController.hidesBarsOnSwipe to YES).
+    return UIStatusBarStyleLightContent;
+}
+
 #pragma mark - LDTCampaignDetailViewController
 
 - (void)styleView {
     [self styleBackBarButton];
     self.collectionView.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"Full Background"]];
+}
+
+- (void)handleSwipeGestureRecognizer:(UISwipeGestureRecognizer *)recognizer {
+    // @see -(UIStatusBarStyle)preferredStatusBarStyle.
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)fetchReportbackItems {

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -116,6 +116,7 @@ const CGFloat kHeightExpanded = 420;
     [super viewWillAppear:animated];
 
     [self.navigationController styleNavigationBar:LDTNavigationBarStyleNormal];
+    [self.navigationController setNavigationBarHidden:NO animated:YES];
 }
 
 #pragma mark - LDTCampaignListViewController

--- a/Lets Do This/Controllers/Profile/LDTUserProfileViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTUserProfileViewController.m
@@ -75,6 +75,7 @@ static NSString *cellIdentifier = @"rowCell";
     [super viewWillAppear:animated];
 
     [self.navigationController styleNavigationBar:LDTNavigationBarStyleClear];
+    [self.navigationController setNavigationBarHidden:NO animated:YES];
 }
 
 - (void)viewDidAppear:(BOOL)animated {

--- a/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.m
@@ -52,6 +52,7 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
+    self.navigationController.hidesBarsOnSwipe = NO;
     [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"reportback-item/%ld", (long)self.reportbackItem.reportbackItemID]];
 }
 


### PR DESCRIPTION
Sets the UINavigationController `hideBarsOnSwipe` property to `YES` for the Campaign Detail to resolve #611.
- Adds a target to the `barHideOnSwipeGestureRecognizer` to avoid the transparent status bar behavior caused by `hideBarsOnSwipe` as described in http://stackoverflow.com/questions/25870382/how-to-prevent-status-bar-from-overlapping-content-with-hidesbarsonswipe-set-on. That thread hides the status bar, we want to display it, but keep the barStyle as `UIStatusBarStyleLightContent` which is why we use `barHideOnSwipeGestureRecognizer` to call `setNeedsStatusBarAppearanceUpdate`
- Adds the custom status bar `UIView` in `AppDelegate` to also avoid weird `hideBarsOnSwipe` behavior. Since we want this status bar all the time on all controllers in the TabBarController, we can just add it to the root controller. Without this, the status bar would appear transparent when we scroll (more fun default behavior when `hideBarsOnSwipe` is set to `YES`)
- Adds call to `setNavigationBarHidden:animated` to avoid unwanted hiding on other controllers we can navigate to, as described in https://github.com/DoSomething/LetsDoThis-iOS/issues/611#issuecomment-156278180

**NOTE** Didn't implement this using a `UIButton` on the `LDTCampaignDetailCampaignCell` because its desired placement makes it unclickable (sitting under the transparent `UINavigationController`. I'm sure there's workarounds for this, but it also seems like more trouble than it's worth since the `hideBarsOnSwipe` gets us pretty close ... just needs all of these additional calls in other VC's :expressionless: )

![hide](https://cloud.githubusercontent.com/assets/1236811/11139066/6f55389a-897f-11e5-9532-20534bd0d61b.gif)
