### PR TITLE
Adds dictionary to track expanded campaign cell indexpath.

### DIFF
--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
@@ -61,12 +61,14 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
 - (void)setTitleLabelText:(NSString *)titleLabelText {
     self.titleLabel.text = [titleLabelText uppercaseString];
 
-    // Get height of label after dynamic text is set, then set the constraint to center the text
-    CGFloat labelHeight = [self.titleLabel sizeThatFits:CGSizeMake(CGRectGetWidth(self.bounds), NSIntegerMax)].height;
-    self.titleLabelTopLayoutConstraint.constant = CGRectGetMidY(self.bounds) - labelHeight/2;
-
-    // Store that value to use when we animate the cell back to the collapsed state
-    self.collapsedTitleLabelTopLayoutConstraintConstant = self.titleLabelTopLayoutConstraint.constant;
+	if (!self.expanded) {
+		// Get height of label after dynamic text is set, then set the constraint to center the text
+		CGFloat labelHeight = [self.titleLabel sizeThatFits:CGSizeMake(CGRectGetWidth(self.bounds), NSIntegerMax)].height;
+		self.titleLabelTopLayoutConstraint.constant = CGRectGetMidY(self.bounds) - labelHeight/2;
+		
+		// Store that value to use when we animate the cell back to the collapsed state
+		self.collapsedTitleLabelTopLayoutConstraintConstant = self.titleLabelTopLayoutConstraint.constant;
+	}
 }
 
 - (void)setTaglineLabelText:(NSString *)taglineLabelText {


### PR DESCRIPTION
@aaronschachter Your fix was a step in the right direction, but I still saw the same bug occurring because those campaign cells will sometimes get deallocated by the collection view when it's scrolled enough (see comment in #622). The trick is to keep track of the expanded cell's state in an object that's present for the lifetime of the view, like a dictionary. I'm currently just storing one indexpath, since we can only ever have one cell expanded at the same time. Also, when you switch to another interest group, it deletes any expanded campaign index path (since we don't want to preserve expanded state when the user comes back). But if this ever changed and you wanted to keep cells open when switching amongst interest groups you could use this dictionary to track that state.
