### PR TITLE
fix 'could not delete file' error showing up if user never uploads avatar photo

### DIFF
--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -210,11 +210,14 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
     NSString *filePath = [documentsDirectory stringByAppendingPathComponent:avatarFileNameString];
     NSError *error;
-    if ([fileManager removeItemAtPath:filePath error:&error]) {
-        NSLog(@"Successfully deleted file: %@ ", avatarFileNameString);
-    }
-    else {
-        NSLog(@"Could not delete file: %@ ",[error localizedDescription]);
+    
+    if ([fileManager fileExistsAtPath:filePath]) {
+        if ([fileManager removeItemAtPath:filePath error:&error]) {
+            NSLog(@"Successfully deleted file: %@ ", avatarFileNameString);
+        }
+        else {
+            NSLog(@"Could not delete file: %@ ",[error localizedDescription]);
+        }
     }
 }
 


### PR DESCRIPTION
#### What's this PR do?

Whenever the user logs out, we run the `deleteAvatar` function to remove the disk-stored avatar photo. 
Previously, we'd attempt to delete even if the user didn't have an avatar stored. Now, we check to make sure a file is present at the filepath before deleting. 
#### How should this be manually tested?

Tested by logging out a user who has not uploaded an avatar. 
#### What are the relevant tickets?

Closes #490. 
