### PR TITLE
Fix tagline for iPhone 6+

### DIFF
--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
@@ -83,7 +83,7 @@
     UIBezierPath *path = [UIBezierPath bezierPath];
     [path moveToPoint:CGPointMake(0,0)];
     [path addLineToPoint:CGPointMake(0, 26)];
-    [path addLineToPoint:CGPointMake(self.campaignDetailsView.frame.size.width, 0)];
+    [path addLineToPoint:CGPointMake(CGRectGetWidth([UIScreen mainScreen].bounds), 0)];
     [path closePath];
     layer.path = path.CGPath;
     layer.fillColor = [UIColor whiteColor].CGColor;


### PR DESCRIPTION
Fixes #591 -- bug was caused by the xib margins not matching the math done in `layoutSubviews` for dynamic height magic (missed this in #480)

Also fixes the truncated diagonal, which I believe is happening for the same reason the tint layers weren't full screen in #504 
