### PR TITLE
user tapping logout will always logout, even if error is returned by API

### DIFF
--- a/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
@@ -163,8 +163,14 @@
             LDTTabBarController *tabBar = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
             [tabBar setSelectedIndex:0];
         } errorHandler:^(NSError *error) {
+            // Performs normal logout functionality even if we are presented with an error.
             [SVProgressHUD dismiss];
             [LDTMessage displayErrorMessageForError:error];
+            [self.navigationController pushViewController:[[LDTUserConnectViewController alloc] init] animated:YES];
+            [self.navigationController styleNavigationBar:LDTNavigationBarStyleClear];
+            [LDTMessage setDefaultViewController:self.navigationController];
+            LDTTabBarController *tabBar = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
+            [tabBar setSelectedIndex:0];
         }];
     }];
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {

--- a/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
@@ -157,20 +157,17 @@
 
         [[DSOUserManager sharedInstance] endSessionWithCompletionHandler:^ {
             [SVProgressHUD dismiss];
-            [self.navigationController pushViewController:[[LDTUserConnectViewController alloc] init] animated:YES];
-            [self.navigationController styleNavigationBar:LDTNavigationBarStyleClear];
-            // Now that tabBar is hidden, select the first tab, so it will be the first tab selected upon next login.
-            LDTTabBarController *tabBar = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-            [tabBar setSelectedIndex:0];
+            [self pushUserConnectViewController];
         } errorHandler:^(NSError *error) {
-            // Performs normal logout functionality even if we are presented with an error.
             [SVProgressHUD dismiss];
-            [LDTMessage displayErrorMessageForError:error];
-            [self.navigationController pushViewController:[[LDTUserConnectViewController alloc] init] animated:YES];
-            [self.navigationController styleNavigationBar:LDTNavigationBarStyleClear];
-            [LDTMessage setDefaultViewController:self.navigationController];
-            LDTTabBarController *tabBar = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-            [tabBar setSelectedIndex:0];
+            // Performs normal logout functionality even if we are presented with an error,
+            // but only if error is not a lack of connectivity. 
+            if (error.code != -1009) {
+                [self pushUserConnectViewController];
+            }
+            else {
+                [LDTMessage displayErrorMessageForError:error];
+            }
         }];
     }];
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
@@ -179,6 +176,14 @@
     [logoutAlertController addAction:confirmLogoutAction];
     [logoutAlertController addAction:cancelAction];
     [self presentViewController:logoutAlertController animated:YES completion:nil];
+}
+
+- (void)pushUserConnectViewController {
+    [self.navigationController pushViewController:[[LDTUserConnectViewController alloc] init] animated:YES];
+    [self.navigationController styleNavigationBar:LDTNavigationBarStyleClear];
+    // Now that tabBar is hidden, select the first tab, so it will be the first tab selected upon next login.
+    LDTTabBarController *tabBar = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    [tabBar setSelectedIndex:0];
 }
 
 - (void)handleFeedbackTap:(UITapGestureRecognizer *)recognizer {

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -132,6 +132,10 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
             completionHandler();
         }
     } errorHandler:^(NSError *error) {
+        [SSKeychain deletePasswordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"Session"];
+        [SSKeychain deletePasswordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"UserID"];
+        [self deleteAvatar];
+        self.user = nil;
         if (errorHandler) {
             errorHandler(error);
         }


### PR DESCRIPTION
#### What's this PR do?
#505 documented an issue where a user was unable to logout because the logout API call returned an error. 

Now, if the user hits the "logout" button, she'll always be logged out--even if an error is returned by the API. 

#### How should this be manually tested?
Tested by logging in with user A, turning off the wifi (to produce an error for the API, which previously would've prevented logout), and then logging out. Then turning on wifi, logging in user B, and confirming that the user account data belongs to user B. 

Then turning off wifi, logging out, turning on wifi, and logging in with user A again. 

Also tested by logging in with user A, turning off wifi, logging out. Then turning on wifi, logging in with user A again, and confirming that user account data belongs to user A. 

#### What are the relevant tickets?
refers to #505. 