### PR TITLE
add new relic monitoring

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -601,6 +601,7 @@
 				57A97D3FE5F4843F35259D92 /* Copy Pods Resources */,
 				568131DF1B730BA700FF9854 /* ShellScript */,
 				4235F3E4912DA954769AFE43 /* Embed Pods Frameworks */,
+				EA1F559F1BFF7D0D00AD98D8 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -743,7 +744,7 @@
 		};
 		568131DF1B730BA700FF9854 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 12;
 			files = (
 			);
 			inputPaths = (
@@ -768,6 +769,19 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Lets Do This/Pods-Lets Do This-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		EA1F559F1BFF7D0D00AD98D8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "SCRIPT=`/usr/bin/find \"${SRCROOT}\" -name newrelic_postbuild.sh | head -n 1`\nNEWRELICAPPTOKEN=`defaults read \"$PWD\"/Lets\\ Do\\ This/keys.plist newRelicAppToken`\n\n/bin/sh \"${SCRIPT}\" \"${NEWRELICAPPTOKEN}\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Lets Do This/Classes/AppDelegate.m
+++ b/Lets Do This/Classes/AppDelegate.m
@@ -24,6 +24,8 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
     NSDictionary *keysDict = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"keys" ofType:@"plist"]];
+    
+    [NewRelicAgent startWithApplicationToken:keysDict[@"newRelicAppToken"]];
 
     NSString *GAItrackingID = keysDict[@"googleAnalyticsLiveTrackingID"];
 #ifdef DEBUG

--- a/Lets Do This/LetsDoThis.pch
+++ b/Lets Do This/LetsDoThis.pch
@@ -15,4 +15,5 @@
 #import "DSOUserManager.h"
 #import "NSError+LDT.h"
 #import <SVProgressHUD.h>
+#import <NewRelicAgent/NewRelic.h>
 #endif

--- a/Podfile
+++ b/Podfile
@@ -13,6 +13,7 @@ target 'Lets Do This' do
 	pod 'Crashlytics', '3.4.0'
     pod 'SVProgressHUD', '1.1.3'
     pod 'GoogleAnalytics', '3.13.0'
+    pod 'NewRelicAgent', '5.3.4'
 end
 
 xcodeproj 'Lets Do This', 'Thor' => :release, 'Debug' => :debug, 'Release' => :release


### PR DESCRIPTION
#### What's this PR do?
Followed [these](https://rpm.newrelic.com/accounts/108038/mobile/setup#tab-ios_tabs=cocoapods) directions to get New Relic reporting for the app up and running. 

Added a new key-value pair to `keys.plist`, `newRelicAppToken`. Will email out the new `keys.plist` file. 

#### How should this be manually tested?
New Relic is able to report from the simulator. Tested by running on multiple devices on the simulator, each which counts as a unique device to New Relic. Checked [this panel](https://rpm.newrelic.com/accounts/108038/mobile?) to make sure the hits showed up. 

#### What are the relevant tickets?
Closes #568. 