### PR TITLE
update LDTMessage usage

### DIFF
--- a/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
@@ -157,7 +157,7 @@
                 [self pushUserConnectViewController];
             }
             else {
-                [LDTMessage displayErrorMessageForError:error];
+                [LDTMessage displayErrorMessageInViewController:self.navigationController error:error];
             }
         }];
     }];


### PR DESCRIPTION
#### What's this PR do?
LDTMessages was changed in #633. In this PR, we update the 
#### How should this be manually tested?
Tested by logging in, turning off connectivity, then attempting to log out, forcing the "Internet is trying to cause drama" error message to appear in the correct view controller. 
#### Any background context you want to provide?
This PR precipitated by a conversation in #635:
>@tongxiang Did you test this? I've just tested and the `LDTMessage` is not visible. This method displays the error in the defaultViewController, which is the TabBarController, which sits underneath the presented Settings controller (since it's pushed modally)
>This is caused by changes introduced in #633 -- which allows us to avoid constantly setting the `LDTMessage defaultViewController`.  The fix here is to use the new method `displayErrorInViewController:error`, displaying the message in `self.navigationController`.