### PR TITLE
Set DSOUser.campaignSignups as readonly

### DIFF
--- a/Lets Do This/Controllers/Profile/LDTUserProfileViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTUserProfileViewController.m
@@ -99,7 +99,6 @@ static NSString *cellIdentifier = @"rowCell";
     if ([self.user isLoggedInUser]) {
         [self updateUserDetails];
         // Logged in user may have signed up or reported back since this VC was first loaded.
-        self.user.campaignSignups = [DSOUserManager sharedInstance].user.campaignSignups;
         [self.tableView reloadData];
         trackingString = @"self";
     }

--- a/Lets Do This/Models/DSOCampaignSignup.h
+++ b/Lets Do This/Models/DSOCampaignSignup.h
@@ -8,6 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
+@class DSOUser;
+@class DSOReportbackItem;
+
 @interface DSOCampaignSignup : NSObject
 
 @property (strong, nonatomic) DSOCampaign *campaign;

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -9,10 +9,12 @@
 #import <Foundation/Foundation.h>
 #import "DSOCampaign.h"
 
+@class DSOCampaignSignup;
 @class DSOUser;
 
 @interface DSOUser : NSObject
 
+@property (nonatomic, strong, readonly) NSArray *campaignSignups;
 @property (nonatomic, strong, readonly) NSString *countryCode;
 @property (nonatomic, strong, readonly) NSString *countryName;
 @property (nonatomic, strong, readonly) NSString *displayName;
@@ -22,10 +24,15 @@
 @property (nonatomic, strong, readonly) NSString *sessionToken;
 @property (nonatomic, strong, readonly) NSString *userID;
 @property (nonatomic, strong, readonly) UIImage *photo;
-@property (nonatomic, strong) NSMutableArray *campaignSignups;
 
 - (instancetype)initWithDict:(NSDictionary *)dict;
 - (void)setPhoto:(UIImage *)image;
+
+// Removes all the user's campaignSignups, used when syncing.
+- (void)removeAllCampaignSignups;
+// Adds given campaignSignup to the user's campaignSignups.
+- (void)addCampaignSignup:(DSOCampaignSignup *)campaignSignup;
+
 // Checks if the User is the logged-in User.
 - (BOOL)isLoggedInUser;
 - (BOOL)isDoingCampaign:(DSOCampaign *)campaign;

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -13,6 +13,7 @@
 
 @interface DSOUser()
 
+@property (nonatomic, strong, readwrite) NSMutableArray *mutableCampaignSignups;
 @property (nonatomic, strong, readwrite) NSString *countryCode;
 @property (nonatomic, strong, readwrite) NSString *displayName;
 @property (nonatomic, strong, readwrite) NSString *email;
@@ -43,7 +44,7 @@
         self.firstName = [dict valueForKeyAsString:@"first_name" nullValue:@"Doer"];
         self.email = dict[@"email"];
         self.sessionToken = dict[@"session_token"];
-        self.campaignSignups = [[NSMutableArray alloc] init];
+        self.mutableCampaignSignups = [[NSMutableArray alloc] init];
 		
         if (dict[@"photo"]) {
             self.photo = nil;
@@ -76,6 +77,14 @@
 	}
 	
 	return _photo;
+}
+
+- (NSArray *)campaignSignups {
+    return [self.mutableCampaignSignups copy];
+}
+
+- (void)removeAllCampaignSignups {
+    [self.mutableCampaignSignups removeAllObjects];
 }
 
 - (void)setPhoto:(UIImage *)photo {
@@ -116,6 +125,10 @@
     }
 
     return self.userID;
+}
+
+- (void)addCampaignSignup:(DSOCampaignSignup *)campaignSignup {
+    [self.mutableCampaignSignups addObject:campaignSignup];
 }
 
 - (BOOL)isLoggedInUser {

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -102,10 +102,10 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 
 - (void)loadActiveMobileAppCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     [[DSOAPI sharedInstance] loadCampaignSignupsForUser:user completionHandler:^(NSArray *campaignSignups) {
-        user.campaignSignups = [[NSMutableArray alloc] init];
+        [user removeAllCampaignSignups];
         for (DSOCampaignSignup *signup in campaignSignups) {
             if ([self activeMobileAppCampaignWithId:signup.campaign.campaignID]) {
-                [user.campaignSignups addObject:signup];
+                [user addCampaignSignup:signup];
             }
         }
         if (completionHandler) {
@@ -137,7 +137,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 
 - (void)signupUserForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     [[DSOAPI sharedInstance] createCampaignSignupForCampaign:campaign completionHandler:^(DSOCampaignSignup *signup) {
-        [self.user.campaignSignups addObject:signup];
+        [self.user addCampaignSignup:signup];
         [[GAI sharedInstance] trackEventWithCategory:@"campaign" action:@"submit signup" label:[NSString stringWithFormat:@"%li", (long)campaign.campaignID] value:nil];
         if (completionHandler) {
             completionHandler(signup);


### PR DESCRIPTION
Closes #385 - The `campaignSignups` should not be a public `NSMutableArray` that any class could add any object into.

* Refactors `campaignSignups` as a readonly `NSArray`. which returns a copy of a new private `NSMutableArray` property, `mutableCampaignSignups` 
* Adds a `removeAllCampaignSignups` method used for scenarios when we want to sync a user's signups (so remove all of them first)
* Adds a `addCampaignSignup:(DSOCampaignSignup *)campaignSignup` method which adds the given Signup to the user's `campaignSignups` array, via `[self.mutableCampaignSignups addObject] `