### PR TITLE
Custom accessor for DSOReportbackItem.campaign

### DIFF
--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -26,7 +26,7 @@
 @property (strong, nonatomic, readonly) NSString *tagline;
 @property (strong, nonatomic, readonly) NSURL *coverImageURL;
 
-- (instancetype)initWithCampaignID:(NSInteger)campaignID;
+- (instancetype)initWithCampaignID:(NSInteger)campaignID title:(NSString *)title;
 - (instancetype)initWithDict:(NSDictionary*)values;
 - (NSInteger)numberOfDaysLeft;
 

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -30,11 +30,12 @@
 
 @implementation DSOCampaign
 
-- (instancetype)initWithCampaignID:(NSInteger)campaignID {
+- (instancetype)initWithCampaignID:(NSInteger)campaignID title:(id)title {
     self = [super init];
 
     if (self) {
-        self.campaignID = campaignID;
+        _campaignID = campaignID;
+        _title = title;
     }
     return self;
 }

--- a/Lets Do This/Models/DSOCampaignSignup.m
+++ b/Lets Do This/Models/DSOCampaignSignup.m
@@ -29,6 +29,7 @@
         if (dict[@"reportback_data"]) {
             self.campaign = [[DSOCampaign alloc] initWithDict:(NSDictionary *)[dict valueForKeyPath:@"reportback_data.campaign"]];
             NSArray *reportbackItems = [dict[@"reportback_data"] valueForKeyPath:@"reportback_items.data"];
+            // For now, we only support uploading and displaying a single ReportbackItem per Reportback. Future functionality could include uploading multiple ReportbackItems, as per the web.
             NSDictionary *reportbackItemDict = reportbackItems.firstObject;
             self.reportbackItem = [[DSOReportbackItem alloc] initWithCampaign:self.campaign];
             self.reportbackItem.quantity = [[dict valueForKeyPath:@"reportback_data.quantity"] integerValue];
@@ -36,11 +37,12 @@
             self.reportbackItem.imageURL =[NSURL URLWithString:[reportbackItemDict valueForKeyPath:@"media.uri"]];
         }
         else {
-            // @todo API cleanup here. should be campaign id not drupal_id
-            self.campaign = [[DSOCampaign alloc] initWithCampaignID:[dict valueForKeyAsInt:@"drupal_id" nullValue:0]];
+            // If no reportback_data exists, API returns the campaign simply as a drupal_id (corresponding to its campaign ID, no object returned) -- https://github.com/DoSomething/northstar/issues/210
+            _campaign = [[DSOCampaign alloc] initWithCampaignID:[dict valueForKeyAsInt:@"drupal_id" nullValue:0] title:nil];
         }
     }
 
     return self;
 }
+
 @end

--- a/Lets Do This/Models/DSOReportbackItem.m
+++ b/Lets Do This/Models/DSOReportbackItem.m
@@ -47,14 +47,23 @@
         self.imageURL = [NSURL URLWithString:imagePath];
         self.user = [[DSOUser alloc] initWithDict:dict[@"user"]];
         NSInteger campaignID = [[dict valueForKeyPath:@"campaign.id"] intValue];
-        // @todo: If an active DSOCampaign doesn't exist, use the dictionary to create a DSOCampaign to expose the Campaign Title
-		
-#warning Could self.campaign ever be nil?
-        self.campaign = [[DSOUserManager sharedInstance] activeMobileAppCampaignWithId:campaignID];
+        NSString *campaignTitle = [dict[@"campaign"] valueForKeyAsString:@"title" nullValue:nil];
+        _campaign = [[DSOCampaign alloc] initWithCampaignID:campaignID title:campaignTitle];
     }
 
     return self;
 }
+
+- (DSOCampaign *)campaign {
+    // Return fully loaded DSOCampaign if activeMobileAppCampaign.
+    DSOCampaign *activeMobileAppCampaign = [[DSOUserManager sharedInstance] activeMobileAppCampaignWithId:_campaign.campaignID];
+    if (activeMobileAppCampaign) {
+        return activeMobileAppCampaign;
+    }
+    return _campaign;
+}
+
+#pragma mark - DSOReportbackItem
 
 + (NSArray *)sortReportbackItemsAsPromotedFirst:(NSArray *)reportbackItems {
     NSSortDescriptor *promotedSortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"status" ascending:NO];

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -107,6 +107,9 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
             if ([self activeMobileAppCampaignWithId:signup.campaign.campaignID]) {
                 [user addCampaignSignup:signup];
             }
+            else {
+                NSLog(@"Filtering signup for inactive campaign %li.", signup.campaign.campaignID);
+            }
         }
         if (completionHandler) {
             completionHandler();


### PR DESCRIPTION
Resolves the warnings/todo's to close #301:
* When initializing a `DSOReportbackItem` from a given `NSDictionary` -- use whatever `campaign` object we have stored via new `DSOCampaign` method `-(instancetype)initWithCampaignID:title:`. This is a bit forward thinking for if/when we want to display Reportback Items on User Profiles for Campaigns which have since expired. 
* Adds a `-(DSOCampaign *)campaign` getter method which returns the loaded `DSOCampaign` from the `[DSOUserManager sharedInstance].activeMobileAppCampaigns` if it exists. Else provides the minimal `DSOCampaign` object returned by API. Refs #645 - won't work if we set `self.campaign` instead of `_campaign` within the `initWithDict:` method
