### PR TITLE
remove falsely logged error "Failed to persist photo data to disk"

### DIFF
--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -89,7 +89,7 @@
 
 - (void)setPhoto:(UIImage *)photo {
     _photo = photo;
-    if ([self isLoggedInUser]) {
+    if ([self isLoggedInUser] && photo) {
         [[DSOUserManager sharedInstance] storeAvatar:photo];
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Previously, we'd see an error logged on signin: "Failed to persist photo data to disk". This indicated that the `[photoData writeToFile:storedAvatarPhotoPath atomically:NO]` was returning a `0` value, meaning that it failed to persist the photo data to disk. 

This was happening when your own user object was initialized within `DSOUser initWithDict`. When `self.photo = nill` is set on line 50, we all `DSOUser setPhoto` which then calls `DSOUserManager storeAvatar`. This returns an error with `[photoData writeToFile:storedAvatarPhotoPath atomically:NO]` because the `photo` param we're attempting to store is `nil`. 

Now, we check within `DSOUser setPhoto` whether the `photo` param is nil before storing it as the user's avatar. 

#### How should this be manually tested?
Tested with two accounts on prod, `tong@x.co` and `don.draper@dosomething.org`. 

Tested by first running the `develop` branch and confirming in both accounts that I see the error when I log in. Then, switched to this branch, rebuilt, and confirmed the error disappeared. 

#### What are the relevant tickets?
Closes #625. 