### PR TITLE
Refactor Profile header, start on No Campaigns view

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		B2A136601B3D1AEF00D20273 /* LDTUserRegisterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2A1365F1B3D1AEF00D20273 /* LDTUserRegisterView.xib */; };
 		B2A136631B3D9BC600D20273 /* LDTUserRegisterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2A136621B3D9BC600D20273 /* LDTUserRegisterViewController.m */; };
 		B2A41A051B5DCC5300C6C1A6 /* LDTSettingsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2A41A041B5DCC5300C6C1A6 /* LDTSettingsView.xib */; };
+		B2C1ADA51C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C1ADA31C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.m */; };
+		B2C1ADA61C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2C1ADA41C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.xib */; };
 		B2C3054B1BE142AE0046CD10 /* NSError+LDT.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C3054A1BE142AE0046CD10 /* NSError+LDT.m */; };
 		B2DB71991B754E3F00915A18 /* LDTCampaignListCampaignCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DB71971B754E3F00915A18 /* LDTCampaignListCampaignCell.m */; };
 		B2DB719A1B754E3F00915A18 /* LDTCampaignListCampaignCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2DB71981B754E3F00915A18 /* LDTCampaignListCampaignCell.xib */; };
@@ -178,6 +180,9 @@
 		B2A136611B3D9BC600D20273 /* LDTUserRegisterViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTUserRegisterViewController.h; path = Login/LDTUserRegisterViewController.h; sourceTree = "<group>"; };
 		B2A136621B3D9BC600D20273 /* LDTUserRegisterViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTUserRegisterViewController.m; path = Login/LDTUserRegisterViewController.m; sourceTree = "<group>"; };
 		B2A41A041B5DCC5300C6C1A6 /* LDTSettingsView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTSettingsView.xib; path = Profile/LDTSettingsView.xib; sourceTree = "<group>"; };
+		B2C1ADA21C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTProfileNoSignupsTableViewCell.h; path = Profile/LDTProfileNoSignupsTableViewCell.h; sourceTree = "<group>"; };
+		B2C1ADA31C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTProfileNoSignupsTableViewCell.m; path = Profile/LDTProfileNoSignupsTableViewCell.m; sourceTree = "<group>"; };
+		B2C1ADA41C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTProfileNoSignupsTableViewCell.xib; path = Profile/LDTProfileNoSignupsTableViewCell.xib; sourceTree = "<group>"; };
 		B2C305491BE142AE0046CD10 /* NSError+LDT.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+LDT.h"; sourceTree = "<group>"; };
 		B2C3054A1BE142AE0046CD10 /* NSError+LDT.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+LDT.m"; sourceTree = "<group>"; };
 		B2DB71961B754E3F00915A18 /* LDTCampaignListCampaignCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTCampaignListCampaignCell.h; path = Campaign/LDTCampaignListCampaignCell.h; sourceTree = "<group>"; };
@@ -352,6 +357,9 @@
 				B21107351C04E94E00282619 /* LDTProfileCampaignTableViewCell.h */,
 				B21107361C04E94E00282619 /* LDTProfileCampaignTableViewCell.m */,
 				B21107371C04E94E00282619 /* LDTProfileCampaignTableViewCell.xib */,
+				B2C1ADA21C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.h */,
+				B2C1ADA31C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.m */,
+				B2C1ADA41C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.xib */,
 			);
 			name = Profile;
 			sourceTree = "<group>";
@@ -694,6 +702,7 @@
 				564F20CF1BB78EB000A97FED /* LDTCampaignCollectionViewCellContainer.xib in Resources */,
 				B21996B21B7CFEDA0054EADC /* LDTHeaderCollectionReusableView.xib in Resources */,
 				B21107341C04CFBF00282619 /* LDTProfileHeaderTableViewCell.xib in Resources */,
+				B2C1ADA61C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.xib in Resources */,
 				B2963E071BD83CC700D2B6EE /* LDTOnboardingPageView.xib in Resources */,
 				B2E75D7F1B87B1610015BE4A /* LDTReportbackItemDetailView.xib in Resources */,
 				B20881A11B0B9B0F00E697B2 /* keys.plist in Resources */,
@@ -811,6 +820,7 @@
 				B27FD03F1BBD99FF00A44952 /* LDTEpicFailViewController.m in Sources */,
 				C20BA28E1AF3DCAB00E9886F /* NSDictionary+DSOJsonHelper.m in Sources */,
 				EA5C9F1B1B694712001D3EEA /* UITextField+LDT.m in Sources */,
+				B2C1ADA51C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.m in Sources */,
 				B2399FD41BB4A00D00314F39 /* LDTCampaignDetailSelfReportbackCell.m in Sources */,
 				B2A1365E1B3CA4B100D20273 /* LDTUserConnectViewController.m in Sources */,
 				B29A657F1BB60F0B008C0E2A /* DSOCampaignSignup.m in Sources */,

--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		569AA55E1B4085A000D8C8C9 /* InterfaceBuilderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 569AA55D1B4085A000D8C8C9 /* InterfaceBuilderView.m */; };
 		B20881A11B0B9B0F00E697B2 /* keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = B20881A01B0B9B0F00E697B2 /* keys.plist */; };
 		B20D06D11B3A58F40053D3B6 /* LDTMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B20D06D01B3A58F40053D3B6 /* LDTMessage.m */; };
+		B21107331C04CFBF00282619 /* LDTProfileHeaderTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B21107311C04CFBF00282619 /* LDTProfileHeaderTableViewCell.m */; };
+		B21107341C04CFBF00282619 /* LDTProfileHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B21107321C04CFBF00282619 /* LDTProfileHeaderTableViewCell.xib */; };
+		B21107381C04E94E00282619 /* LDTProfileCampaignTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B21107361C04E94E00282619 /* LDTProfileCampaignTableViewCell.m */; };
+		B21107391C04E94E00282619 /* LDTProfileCampaignTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B21107371C04E94E00282619 /* LDTProfileCampaignTableViewCell.xib */; };
 		B21126271B618038009128E7 /* DSOUserManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B21126261B618038009128E7 /* DSOUserManager.m */; };
 		B212C2621B4ED6F300376BB1 /* LDTBaseViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B212C2611B4ED6F300376BB1 /* LDTBaseViewController.m */; };
 		B216CFC61B685EE8007E1914 /* UIImageView+LDT.m in Sources */ = {isa = PBXBuildFile; fileRef = B216CFC51B685EE8007E1914 /* UIImageView+LDT.m */; };
@@ -100,6 +104,12 @@
 		B20881A01B0B9B0F00E697B2 /* keys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = keys.plist; sourceTree = "<group>"; };
 		B20D06CF1B3A58F40053D3B6 /* LDTMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LDTMessage.h; sourceTree = "<group>"; };
 		B20D06D01B3A58F40053D3B6 /* LDTMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LDTMessage.m; sourceTree = "<group>"; };
+		B21107301C04CFBF00282619 /* LDTProfileHeaderTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTProfileHeaderTableViewCell.h; path = Profile/LDTProfileHeaderTableViewCell.h; sourceTree = "<group>"; };
+		B21107311C04CFBF00282619 /* LDTProfileHeaderTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTProfileHeaderTableViewCell.m; path = Profile/LDTProfileHeaderTableViewCell.m; sourceTree = "<group>"; };
+		B21107321C04CFBF00282619 /* LDTProfileHeaderTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTProfileHeaderTableViewCell.xib; path = Profile/LDTProfileHeaderTableViewCell.xib; sourceTree = "<group>"; };
+		B21107351C04E94E00282619 /* LDTProfileCampaignTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTProfileCampaignTableViewCell.h; path = Profile/LDTProfileCampaignTableViewCell.h; sourceTree = "<group>"; };
+		B21107361C04E94E00282619 /* LDTProfileCampaignTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTProfileCampaignTableViewCell.m; path = Profile/LDTProfileCampaignTableViewCell.m; sourceTree = "<group>"; };
+		B21107371C04E94E00282619 /* LDTProfileCampaignTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTProfileCampaignTableViewCell.xib; path = Profile/LDTProfileCampaignTableViewCell.xib; sourceTree = "<group>"; };
 		B21126251B618038009128E7 /* DSOUserManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DSOUserManager.h; path = Networking/DSOUserManager.h; sourceTree = "<group>"; };
 		B21126261B618038009128E7 /* DSOUserManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DSOUserManager.m; path = Networking/DSOUserManager.m; sourceTree = "<group>"; };
 		B212C2601B4ED6F300376BB1 /* LDTBaseViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTBaseViewController.h; path = Base/LDTBaseViewController.h; sourceTree = "<group>"; };
@@ -336,6 +346,12 @@
 			isa = PBXGroup;
 			children = (
 				B27AF0E61B4F493D00164926 /* LDTUserProfileView.xib */,
+				B21107301C04CFBF00282619 /* LDTProfileHeaderTableViewCell.h */,
+				B21107311C04CFBF00282619 /* LDTProfileHeaderTableViewCell.m */,
+				B21107321C04CFBF00282619 /* LDTProfileHeaderTableViewCell.xib */,
+				B21107351C04E94E00282619 /* LDTProfileCampaignTableViewCell.h */,
+				B21107361C04E94E00282619 /* LDTProfileCampaignTableViewCell.m */,
+				B21107371C04E94E00282619 /* LDTProfileCampaignTableViewCell.xib */,
 			);
 			name = Profile;
 			sourceTree = "<group>";
@@ -677,6 +693,7 @@
 				B27F49EA1B6ADB68005CFC35 /* LDTCampaignDetailView.xib in Resources */,
 				564F20CF1BB78EB000A97FED /* LDTCampaignCollectionViewCellContainer.xib in Resources */,
 				B21996B21B7CFEDA0054EADC /* LDTHeaderCollectionReusableView.xib in Resources */,
+				B21107341C04CFBF00282619 /* LDTProfileHeaderTableViewCell.xib in Resources */,
 				B2963E071BD83CC700D2B6EE /* LDTOnboardingPageView.xib in Resources */,
 				B2E75D7F1B87B1610015BE4A /* LDTReportbackItemDetailView.xib in Resources */,
 				B20881A11B0B9B0F00E697B2 /* keys.plist in Resources */,
@@ -684,6 +701,7 @@
 				B273A7681B459BB700CBD4E1 /* Brandon_med.otf in Resources */,
 				B27FD0401BBD99FF00A44952 /* LDTEpicFailView.xib in Resources */,
 				B258EB331B8E696100B298C0 /* LDTReportbackItemDetailSingleView.xib in Resources */,
+				B21107391C04E94E00282619 /* LDTProfileCampaignTableViewCell.xib in Resources */,
 				B2A136601B3D1AEF00D20273 /* LDTUserRegisterView.xib in Resources */,
 				B22274011B5879B3005C896D /* LDTCampaignListView.xib in Resources */,
 				B2399FD51BB4A00D00314F39 /* LDTCampaignDetailSelfReportbackCell.xib in Resources */,
@@ -814,6 +832,7 @@
 				B2DB71991B754E3F00915A18 /* LDTCampaignListCampaignCell.m in Sources */,
 				B23E68211B8FC728005BFB5E /* LDTCampaignDetailCampaignCell.m in Sources */,
 				B27F49ED1B6ADB93005CFC35 /* LDTCampaignDetailViewController.m in Sources */,
+				B21107381C04E94E00282619 /* LDTProfileCampaignTableViewCell.m in Sources */,
 				B2E75D831B87B1920015BE4A /* LDTReportbackItemDetailSingleViewController.m in Sources */,
 				B240DD321B73DA4D00CA6C6E /* LDTTabBarController.m in Sources */,
 				B21996B11B7CFEDA0054EADC /* LDTHeaderCollectionReusableView.m in Sources */,
@@ -823,6 +842,7 @@
 				B216CFC61B685EE8007E1914 /* UIImageView+LDT.m in Sources */,
 				C2B151EF1ACE04C30028C336 /* main.m in Sources */,
 				B21126271B618038009128E7 /* DSOUserManager.m in Sources */,
+				B21107331C04CFBF00282619 /* LDTProfileHeaderTableViewCell.m in Sources */,
 				569AA55E1B4085A000D8C8C9 /* InterfaceBuilderView.m in Sources */,
 				B2E652DF1B4380AD00EF9D69 /* LDTTheme.m in Sources */,
 				B20D06D11B3A58F40053D3B6 /* LDTMessage.m in Sources */,

--- a/Lets Do This/Views/Profile/LDTProfileCampaignTableViewCell.h
+++ b/Lets Do This/Views/Profile/LDTProfileCampaignTableViewCell.h
@@ -1,0 +1,15 @@
+//
+//  LDTProfileCampaignTableViewCell.h
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 11/24/15.
+//  Copyright © 2015 Do Something. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface LDTProfileCampaignTableViewCell : UITableViewCell
+
+@property (strong, nonatomic) NSString *campaignTitleText;
+
+@end

--- a/Lets Do This/Views/Profile/LDTProfileCampaignTableViewCell.m
+++ b/Lets Do This/Views/Profile/LDTProfileCampaignTableViewCell.m
@@ -1,0 +1,36 @@
+//
+//  LDTProfileCampaignTableViewCell.m
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 11/24/15.
+//  Copyright © 2015 Do Something. All rights reserved.
+//
+
+#import "LDTProfileCampaignTableViewCell.h"
+#import "LDTTheme.h"
+
+@interface LDTProfileCampaignTableViewCell ()
+
+@property (weak, nonatomic) IBOutlet UILabel *campaignTitleLabel;
+
+@end
+
+@implementation LDTProfileCampaignTableViewCell
+
+#pragma mark - UITableViewCell
+
+- (void)awakeFromNib {
+    [self styleView];
+}
+
+#pragma mark - LDTProfileCampaignTableViewCell
+
+- (void)styleView {
+    self.campaignTitleLabel.font = LDTTheme.fontBold;
+}
+
+- (void)setCampaignTitleText:(NSString *)campaignTitleText {
+    self.campaignTitleLabel.text = campaignTitleText;
+}
+
+@end

--- a/Lets Do This/Views/Profile/LDTProfileCampaignTableViewCell.xib
+++ b/Lets Do This/Views/Profile/LDTProfileCampaignTableViewCell.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="68" id="KGk-i7-Jjw" customClass="LDTProfileCampaignTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="68"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="67"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Campaign Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Zf-Of-AZw">
+                        <rect key="frame" x="16" y="16" width="288" height="35"/>
+                        <animations/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <animations/>
+                <constraints>
+                    <constraint firstItem="7Zf-Of-AZw" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="8" id="cTS-g7-15J"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="7Zf-Of-AZw" secondAttribute="trailing" constant="8" id="jtI-fJ-osw"/>
+                    <constraint firstItem="7Zf-Of-AZw" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="8" id="wTa-bO-lkg"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="7Zf-Of-AZw" secondAttribute="bottom" constant="8" id="zCK-Il-VdI"/>
+                </constraints>
+            </tableViewCellContentView>
+            <animations/>
+            <connections>
+                <outlet property="campaignTitleLabel" destination="7Zf-Of-AZw" id="zuS-Dl-tB2"/>
+            </connections>
+            <point key="canvasLocation" x="224" y="260"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Lets Do This/Views/Profile/LDTProfileHeaderTableViewCell.h
+++ b/Lets Do This/Views/Profile/LDTProfileHeaderTableViewCell.h
@@ -1,0 +1,27 @@
+//
+//  LDTProfileHeaderTableViewCell.h
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 11/24/15.
+//  Copyright © 2015 Do Something. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@protocol LDTProfileHeaderTableViewCellDelegate;
+
+@interface LDTProfileHeaderTableViewCell : UITableViewCell
+
+@property (weak, nonatomic) id<LDTProfileHeaderTableViewCellDelegate> delegate;
+@property (strong, nonatomic) NSString *userCountryNameText;
+@property (strong, nonatomic) NSString *userDisplayNameText;
+@property (strong, nonatomic) UIImage *userAvatarImage;
+
+@end
+
+@protocol LDTProfileHeaderTableViewCellDelegate <NSObject>
+
+@required
+- (void)didClickUserAvatarButtonForCell:(LDTProfileHeaderTableViewCell *)cell;
+
+@end

--- a/Lets Do This/Views/Profile/LDTProfileHeaderTableViewCell.m
+++ b/Lets Do This/Views/Profile/LDTProfileHeaderTableViewCell.m
@@ -1,0 +1,61 @@
+//
+//  LDTProfileHeaderTableViewCell.m
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 11/24/15.
+//  Copyright © 2015 Do Something. All rights reserved.
+//
+
+#import "LDTProfileHeaderTableViewCell.h"
+#import "LDTTheme.h"
+
+@interface LDTProfileHeaderTableViewCell ()
+
+@property (weak, nonatomic) IBOutlet UIImageView *userAvatarImageView;
+@property (weak, nonatomic) IBOutlet UILabel *userDisplayNameLabel;
+@property (weak, nonatomic) IBOutlet UILabel *userCountryNameLabel;
+@property (weak, nonatomic) IBOutlet UIView *userAvatarButtonView;
+
+@end
+
+
+@implementation LDTProfileHeaderTableViewCell
+
+#pragma mark - UITableViewCell
+
+- (void)awakeFromNib {
+    [self styleView];
+    UITapGestureRecognizer *avatarTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleAvatarTap:)];
+    [self.userAvatarButtonView addGestureRecognizer:avatarTap];
+}
+
+#pragma mark - LDTProfileHeaderTableViewCell
+
+- (void)styleView {
+    self.backgroundColor = UIColor.clearColor;
+    self.userDisplayNameLabel.font = [LDTTheme fontTitle];
+    self.userDisplayNameLabel.textColor = UIColor.whiteColor;
+    self.userCountryNameLabel.font = [LDTTheme fontHeadingBold];
+    self.userCountryNameLabel.textColor = UIColor.whiteColor;
+}
+
+- (void)setUserAvatarImage:(UIImage *)userAvatarImage {
+    self.userAvatarImageView.image = userAvatarImage;
+    [self.userAvatarImageView addCircleFrame];
+}
+
+- (void)setUserCountryNameText:(NSString *)userCountryNameText {
+    self.userCountryNameLabel.text = userCountryNameText;
+}
+
+- (void)setUserDisplayNameText:(NSString *)userDisplayNameText {
+    self.userDisplayNameLabel.text = userDisplayNameText;
+}
+
+- (void)handleAvatarTap:(UITapGestureRecognizer *)recognizer {
+    if (self.delegate && [self.delegate respondsToSelector:@selector(didClickUserAvatarButtonForCell:)]) {
+        [self.delegate didClickUserAvatarButtonForCell:self];
+    }
+}
+
+@end

--- a/Lets Do This/Views/Profile/LDTProfileHeaderTableViewCell.xib
+++ b/Lets Do This/Views/Profile/LDTProfileHeaderTableViewCell.xib
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="174" id="KGk-i7-Jjw" customClass="LDTProfileHeaderTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="390" height="174"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="390" height="173"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rh6-Az-hDI" userLabel="User Avatar Button View">
+                        <rect key="frame" x="148" y="22" width="95" height="95"/>
+                        <animations/>
+                    </view>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Mkf-PK-9cQ" userLabel="User Avatar Image">
+                        <rect key="frame" x="158" y="32" width="75" height="75"/>
+                        <animations/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="75" id="8S8-iz-eHT"/>
+                            <constraint firstAttribute="height" constant="75" id="MlD-iJ-WmU"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q98-iC-Krz" userLabel="User Display Name">
+                        <rect key="frame" x="16" y="115" width="358" height="21"/>
+                        <animations/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kR2-hN-lmE" userLabel="User Country Name">
+                        <rect key="frame" x="16" y="136" width="358" height="23"/>
+                        <animations/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <animations/>
+                <constraints>
+                    <constraint firstItem="q98-iC-Krz" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="8" id="EbS-a3-EOt"/>
+                    <constraint firstAttribute="topMargin" secondItem="Mkf-PK-9cQ" secondAttribute="top" constant="-24" id="IYu-lh-u2I"/>
+                    <constraint firstItem="Rh6-Az-hDI" firstAttribute="width" secondItem="Mkf-PK-9cQ" secondAttribute="width" constant="20" id="PDV-tv-hf1"/>
+                    <constraint firstItem="q98-iC-Krz" firstAttribute="top" secondItem="Mkf-PK-9cQ" secondAttribute="bottom" constant="8" id="PVM-nA-ffu"/>
+                    <constraint firstItem="Rh6-Az-hDI" firstAttribute="leading" secondItem="Mkf-PK-9cQ" secondAttribute="leading" constant="-10" id="PwE-dG-OIh"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="kR2-hN-lmE" secondAttribute="bottom" constant="6" id="RdY-b3-HZu"/>
+                    <constraint firstItem="Rh6-Az-hDI" firstAttribute="top" secondItem="Mkf-PK-9cQ" secondAttribute="top" constant="-10" id="VWm-1g-flZ"/>
+                    <constraint firstItem="Mkf-PK-9cQ" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="VaA-79-S05"/>
+                    <constraint firstItem="kR2-hN-lmE" firstAttribute="top" secondItem="q98-iC-Krz" secondAttribute="bottom" id="b0B-zh-vdo"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="q98-iC-Krz" secondAttribute="trailing" constant="8" id="m0Y-oo-WcT"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="kR2-hN-lmE" secondAttribute="trailing" constant="8" id="mNK-zN-1b1"/>
+                    <constraint firstItem="Rh6-Az-hDI" firstAttribute="height" secondItem="Mkf-PK-9cQ" secondAttribute="height" constant="20" id="rOB-u8-fbj"/>
+                    <constraint firstItem="kR2-hN-lmE" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="8" id="vhc-FP-DXH"/>
+                </constraints>
+            </tableViewCellContentView>
+            <animations/>
+            <connections>
+                <outlet property="userAvatarButtonView" destination="Rh6-Az-hDI" id="n2O-Zg-SnH"/>
+                <outlet property="userAvatarImageView" destination="Mkf-PK-9cQ" id="c1d-Lu-fnM"/>
+                <outlet property="userCountryNameLabel" destination="kR2-hN-lmE" id="yfG-lK-TUC"/>
+                <outlet property="userDisplayNameLabel" destination="q98-iC-Krz" id="A1c-J0-FLx"/>
+            </connections>
+            <point key="canvasLocation" x="210" y="418"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Lets Do This/Views/Profile/LDTProfileNoSignupsTableViewCell.h
+++ b/Lets Do This/Views/Profile/LDTProfileNoSignupsTableViewCell.h
@@ -1,0 +1,16 @@
+//
+//  LDTProfileNoSignupsTableViewCell.h
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 11/24/15.
+//  Copyright © 2015 Do Something. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface LDTProfileNoSignupsTableViewCell : UITableViewCell
+
+@property (strong, nonatomic) NSString *subtitleLabelText;
+@property (strong, nonatomic) NSString *titleLabelText;
+
+@end

--- a/Lets Do This/Views/Profile/LDTProfileNoSignupsTableViewCell.m
+++ b/Lets Do This/Views/Profile/LDTProfileNoSignupsTableViewCell.m
@@ -1,0 +1,38 @@
+//
+//  LDTProfileNoSignupsTableViewCell.m
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 11/24/15.
+//  Copyright © 2015 Do Something. All rights reserved.
+//
+
+#import "LDTProfileNoSignupsTableViewCell.h"
+#import "LDTTheme.h"
+
+@interface  LDTProfileNoSignupsTableViewCell()
+
+@property (weak, nonatomic) IBOutlet UILabel *titleLabel;
+@property (weak, nonatomic) IBOutlet UILabel *subTitleLabel;
+
+@end
+
+@implementation LDTProfileNoSignupsTableViewCell
+
+- (void)awakeFromNib {
+    [self styleView];
+}
+
+- (void)styleView {
+    self.titleLabel.font = LDTTheme.fontHeading;
+    self.subTitleLabel.font = LDTTheme.font;
+}
+
+- (void)setSubtitleLabelText:(NSString *)subtitleLabelText {
+    self.subTitleLabel.text = subtitleLabelText;
+}
+
+- (void)setTitleLabelText:(NSString *)titleLabelText {
+    self.titleLabel.text = titleLabelText;
+}
+
+@end

--- a/Lets Do This/Views/Profile/LDTProfileNoSignupsTableViewCell.xib
+++ b/Lets Do This/Views/Profile/LDTProfileNoSignupsTableViewCell.xib
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="212" id="KGk-i7-Jjw" customClass="LDTProfileNoSignupsTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="212"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="211"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s67-fR-8Fb" userLabel="Container View">
+                        <rect key="frame" x="10" y="34" width="300" height="143"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NVk-LJ-CoZ">
+                                <rect key="frame" x="20" y="122" width="260" height="21"/>
+                                <animations/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Default Avatar" translatesAutoresizingMaskIntoConstraints="NO" id="89v-dA-Ksq">
+                                <rect key="frame" x="107" y="0.0" width="85" height="85"/>
+                                <animations/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="85" id="KOa-vo-sHH"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="85" id="R7y-kC-aK7"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="85" id="dq9-Jn-6Q4"/>
+                                    <constraint firstAttribute="height" constant="85" id="pj3-VA-beQ"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nk7-LF-Zwp">
+                                <rect key="frame" x="20" y="93" width="260" height="21"/>
+                                <animations/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <animations/>
+                        <constraints>
+                            <constraint firstItem="89v-dA-Ksq" firstAttribute="top" secondItem="s67-fR-8Fb" secondAttribute="top" id="33n-tt-BQs"/>
+                            <constraint firstAttribute="width" constant="300" id="601-N9-e6f"/>
+                            <constraint firstItem="nk7-LF-Zwp" firstAttribute="leading" secondItem="s67-fR-8Fb" secondAttribute="leading" constant="20" id="AzQ-th-r3Z"/>
+                            <constraint firstAttribute="bottom" secondItem="NVk-LJ-CoZ" secondAttribute="bottom" id="FZv-Ww-Udr"/>
+                            <constraint firstAttribute="trailing" secondItem="NVk-LJ-CoZ" secondAttribute="trailing" constant="20" id="Jk7-Ji-HTo"/>
+                            <constraint firstAttribute="trailing" secondItem="nk7-LF-Zwp" secondAttribute="trailing" constant="20" id="V8Q-cj-2ua"/>
+                            <constraint firstItem="NVk-LJ-CoZ" firstAttribute="top" secondItem="nk7-LF-Zwp" secondAttribute="bottom" constant="8" id="ZaS-QJ-lJP"/>
+                            <constraint firstItem="89v-dA-Ksq" firstAttribute="centerX" secondItem="s67-fR-8Fb" secondAttribute="centerX" id="eBM-hi-dQz"/>
+                            <constraint firstItem="NVk-LJ-CoZ" firstAttribute="leading" secondItem="s67-fR-8Fb" secondAttribute="leading" constant="20" id="soT-vg-bTh"/>
+                            <constraint firstItem="nk7-LF-Zwp" firstAttribute="top" secondItem="89v-dA-Ksq" secondAttribute="bottom" constant="8" id="x7O-PG-2Zh"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <animations/>
+                <constraints>
+                    <constraint firstItem="s67-fR-8Fb" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="UGo-JK-mwQ"/>
+                    <constraint firstItem="s67-fR-8Fb" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="gKy-Xa-86X"/>
+                </constraints>
+            </tableViewCellContentView>
+            <animations/>
+            <connections>
+                <outlet property="subTitleLabel" destination="NVk-LJ-CoZ" id="5VR-05-d2t"/>
+                <outlet property="titleLabel" destination="nk7-LF-Zwp" id="7lw-TN-JFi"/>
+            </connections>
+            <point key="canvasLocation" x="183" y="504"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="Default Avatar" width="86" height="86"/>
+    </resources>
+</document>

--- a/Lets Do This/Views/Profile/LDTUserProfileView.xib
+++ b/Lets Do This/Views/Profile/LDTUserProfileView.xib
@@ -7,11 +7,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LDTUserProfileViewController">
             <connections>
-                <outlet property="avatarImageView" destination="ZTn-ki-kwg" id="Xsu-YT-3Bs"/>
-                <outlet property="headerView" destination="PsE-uh-AxY" id="oKI-hs-1o3"/>
-                <outlet property="nameLabel" destination="O39-w4-qp5" id="rUF-79-a3D"/>
                 <outlet property="tableView" destination="dZd-rn-Ulf" id="Qf6-js-ieG"/>
-                <outlet property="uploadAvatarButton" destination="fef-pX-RO2" id="nct-Qc-nWn"/>
                 <outlet property="view" destination="iN0-l3-epB" id="try-AF-3Wj"/>
             </connections>
         </placeholder>
@@ -20,50 +16,8 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PsE-uh-AxY" userLabel="Header View">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="174"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fef-pX-RO2" userLabel="Upload Avatar Button">
-                            <rect key="frame" x="263" y="44" width="75" height="75"/>
-                            <animations/>
-                            <state key="normal" title="Button"/>
-                            <connections>
-                                <action selector="uploadAvatarButtonTouchUpInside:" destination="-1" eventType="touchUpInside" id="Dal-Pe-BY2"/>
-                            </connections>
-                        </button>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZTn-ki-kwg" userLabel="User Avatar">
-                            <rect key="frame" x="263" y="44" width="75" height="75"/>
-                            <animations/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="75" id="m7Q-I7-WIq"/>
-                                <constraint firstAttribute="width" constant="75" id="nwk-rj-PI3"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O39-w4-qp5" userLabel="User Display Name">
-                            <rect key="frame" x="8" y="129" width="584" height="21"/>
-                            <animations/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <animations/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                    <constraints>
-                        <constraint firstAttribute="trailing" secondItem="O39-w4-qp5" secondAttribute="trailing" constant="8" id="7pr-3Z-Bz8"/>
-                        <constraint firstAttribute="bottom" secondItem="O39-w4-qp5" secondAttribute="bottom" constant="24" id="D49-3e-zH4"/>
-                        <constraint firstAttribute="centerX" secondItem="ZTn-ki-kwg" secondAttribute="centerX" id="L2z-D9-cT1"/>
-                        <constraint firstItem="O39-w4-qp5" firstAttribute="leading" secondItem="PsE-uh-AxY" secondAttribute="leading" constant="8" id="QfD-Mf-UlP"/>
-                        <constraint firstItem="fef-pX-RO2" firstAttribute="height" secondItem="ZTn-ki-kwg" secondAttribute="height" id="T9T-YQ-njh"/>
-                        <constraint firstItem="fef-pX-RO2" firstAttribute="width" secondItem="ZTn-ki-kwg" secondAttribute="width" id="jwa-kV-s2d"/>
-                        <constraint firstItem="O39-w4-qp5" firstAttribute="top" secondItem="ZTn-ki-kwg" secondAttribute="bottom" constant="10" id="nDz-o0-WeS"/>
-                        <constraint firstItem="fef-pX-RO2" firstAttribute="centerX" secondItem="ZTn-ki-kwg" secondAttribute="centerX" id="sI5-XW-fMX"/>
-                        <constraint firstItem="ZTn-ki-kwg" firstAttribute="top" secondItem="PsE-uh-AxY" secondAttribute="top" constant="44" id="tZM-WZ-DmY"/>
-                        <constraint firstItem="fef-pX-RO2" firstAttribute="centerY" secondItem="ZTn-ki-kwg" secondAttribute="centerY" id="xqS-1e-W7B"/>
-                    </constraints>
-                </view>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="dZd-rn-Ulf" userLabel="Campaigns TableView">
-                    <rect key="frame" x="0.0" y="174" width="600" height="426"/>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="dZd-rn-Ulf" userLabel="tableView">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                     <animations/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <connections>
@@ -75,12 +29,9 @@
             <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="PsE-uh-AxY" secondAttribute="trailing" id="7cd-Vf-cwM"/>
-                <constraint firstItem="PsE-uh-AxY" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Dx9-Q9-L32"/>
                 <constraint firstItem="dZd-rn-Ulf" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="NCq-Jw-bjR"/>
-                <constraint firstItem="PsE-uh-AxY" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="d4z-fL-HEe"/>
                 <constraint firstAttribute="bottom" secondItem="dZd-rn-Ulf" secondAttribute="bottom" id="f4x-cB-j83"/>
-                <constraint firstItem="dZd-rn-Ulf" firstAttribute="top" secondItem="PsE-uh-AxY" secondAttribute="bottom" id="ti5-E4-m92"/>
+                <constraint firstItem="dZd-rn-Ulf" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="lfi-Eo-Tx3"/>
                 <constraint firstAttribute="trailing" secondItem="dZd-rn-Ulf" secondAttribute="trailing" id="uhD-jm-3ZG"/>
             </constraints>
             <point key="canvasLocation" x="326" y="342"/>


### PR DESCRIPTION
Closes #418 
* Renders existing User Profile header, using `UITableViewCell` instead of a `UIView`. This makes the header scrollable (was previously static on top of the screen)
* Fixes profile design by moving it up vertically, behind the navigation bar.  This makes it a little more difficult to click with the changes we made in #636 - only the bottom half of the avatar is clikcable (cc @lkpttn )
* Adds user country to the header
* Starts on the No Campaigns view -- button not added yet and styles not finished. Debating on refactoring the `LDTEpicFailView` to be reusable, so we can use here and in handling Campaign Detail edge cases as well

## Screenshots

### No campaigns - Self 
Missing a "Take me there" button to open the first Actions tab

![simulator screen shot nov 25 2015 10 28 40 am](https://cloud.githubusercontent.com/assets/1236811/11405911/af1dd042-935f-11e5-9e39-e2e962ab4c64.png)

### No campaigns - Public profile
Missing a "Go back" button to pop back to previous screen. This will occur when the User's Northstar campaigns are not in sync with their Phoenix campaigns.

![simulator screen shot nov 25 2015 10 28 47 am](https://cloud.githubusercontent.com/assets/1236811/11405947/d373c668-935f-11e5-971c-e4885403f1bf.png)

### Public profile
![simulator screen shot nov 24 2015 2 38 47 pm](https://cloud.githubusercontent.com/assets/1236811/11405976/0e295df4-9360-11e5-8296-2369d4ce5c38.png)

