### PR TITLE
add check for reportback quantity numbers greater than 2147483647 in submission controller

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -12,6 +12,7 @@
 #import "LDTUserLoginViewController.h"
 #import "UITextField+LDT.h"
 #import "GAI+LDT.h"
+#import "NSString+RemoveEmoji.h"
 
 @interface LDTUserRegisterViewController () <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
@@ -297,6 +298,8 @@
 - (BOOL)validateForm {
     NSMutableArray *errorMessages = [[NSMutableArray alloc] init];
 
+    // add new validation here for [self.captionTextField.text isIncludingEmoji]
+    
     if (![self validateName:self.firstNameTextField.text]) {
         [self.firstNameTextField setBorderColor:UIColor.redColor];
         [errorMessages addObject:@"We need your first name."];

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -295,7 +295,7 @@
 }
 
 - (BOOL)validateForm {
-    NSMutableArray *errorMessages = [[NSMutableArray alloc] init];;
+    NSMutableArray *errorMessages = [[NSMutableArray alloc] init];
 
     if (![self validateName:self.firstNameTextField.text]) {
         [self.firstNameTextField setBorderColor:UIColor.redColor];

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -297,25 +297,41 @@
 
 - (BOOL)validateForm {
     NSMutableArray *errorMessages = [[NSMutableArray alloc] init];
-
-    // add new validation here for [self.captionTextField.text isIncludingEmoji]
     
-    if (![self validateName:self.firstNameTextField.text]) {
+    // Emoji presence check and other validations placed in if/else if blocks
+    // so user won't receive two redundant error messages.
+    if ([self.firstNameTextField.text isIncludingEmoji]) {
+        [self.firstNameTextField setBorderColor:UIColor.redColor];
+        [errorMessages addObject:@"No emoji allowed in your name."];
+    }
+    else if (![self validateName:self.firstNameTextField.text]) {
         [self.firstNameTextField setBorderColor:UIColor.redColor];
         [errorMessages addObject:@"We need your first name."];
     }
-    if (![self validateEmailForCandidate:self.emailTextField.text]) {
+    
+    if ([self.emailTextField.text isIncludingEmoji]) {
+        [self.emailTextField setBorderColor:UIColor.redColor];
+        [errorMessages addObject:@"No emoji allowed in your email."];
+    }
+    else if (![self validateEmailForCandidate:self.emailTextField.text]) {
         [self.emailTextField setBorderColor:UIColor.redColor];
         [errorMessages addObject:@"We need a valid email."];
     }
+    
     if (![self validateMobile:self.mobileTextField.text]) {
         [self.mobileTextField setBorderColor:UIColor.redColor];
         [errorMessages addObject:@"Enter a valid telephone number."];
     }
-    if (![self validatePassword:self.passwordTextField.text]) {
+    
+    if ([self.passwordTextField.text isIncludingEmoji]) {
+        [self.passwordTextField setBorderColor:UIColor.redColor];
+        [errorMessages addObject:@"No emoji allowed in your password."];
+    }
+    else if (![self validatePassword:self.passwordTextField.text]) {
         [self.passwordTextField setBorderColor:UIColor.redColor];
         [errorMessages addObject:@"Password must be 6+ characters."];
     }
+    
     if (errorMessages.count > 0) {
         NSString *errorMessage = [[errorMessages copy] componentsJoinedByString:@"\n"];
         [LDTMessage displayErrorMessageInViewController:self.navigationController title:errorMessage];

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -25,7 +25,6 @@
 @property (assign, nonatomic) BOOL quantityTextIsValid;
 @property (assign, nonatomic) BOOL captionTextIsValid;
 
-
 - (IBAction)changePhotoButtonTouchUpInside:(id)sender;
 - (IBAction)submitButtonTouchUpInside:(id)sender;
 - (IBAction)quantityTextFieldEditingChanged:(id)sender;
@@ -194,7 +193,7 @@
     [SVProgressHUD showWithStatus:@"Uploading..."];
     self.reportbackItem.caption = self.captionTextField.text;
     self.reportbackItem.quantity = [self.quantityTextField.text integerValue];
-        
+
     LDTTabBarController *rootVC = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
     [[DSOUserManager sharedInstance] postUserReportbackItem:self.reportbackItem completionHandler:^(NSDictionary *response) {
         [SVProgressHUD dismiss];

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -11,6 +11,7 @@
 #import "LDTTabBarController.h"
 #import "UITextField+LDT.h"
 #import "GAI+LDT.h"
+#import "NSString+RemoveEmoji.h"
 
 @interface LDTSubmitReportbackViewController() <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
@@ -124,13 +125,17 @@
         [self.captionTextField setBorderColor:UIColor.redColor];
         [errorMessages addObject:@"Your caption needs to be 60 characters or less."];
     }
+    if ([self.captionTextField.text isIncludingEmoji]) {
+        [self.captionTextField setBorderColor:UIColor.redColor];
+        [errorMessages addObject:@"No emoji in the caption, please."];
+    }
     if (quantityValue <= 0) {
         [self.quantityTextField setBorderColor:UIColor.redColor];
         [errorMessages addObject:@"We need a positive number quantity."];
     }
     if (quantityValue > oneGreaterThanLargest32BitNumber) {
         [self.quantityTextField setBorderColor:UIColor.redColor];
-        [errorMessages addObject:@"Hmm, that's a big number. Let's try bringing it back down to Earth. :)"];
+        [errorMessages addObject:@"Hmm, that's a big number. Let's try bringing it back down to Earth."];
     }
     if (errorMessages.count > 0) {
         NSString *errorMessage = [[errorMessages copy] componentsJoinedByString:@"\n"];

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -106,7 +106,8 @@
 }
 
 - (void)updateSubmitButton {
-    if (self.captionTextField.text.length > 0 && self.captionTextField.text.length < 61 && self.quantityTextField.text.length > 0 && self.quantityTextField.text.intValue > 0) {
+    long long oneGreaterThanLargest32BitNumber = 2147483648;
+    if (self.captionTextField.text.length > 0 && self.captionTextField.text.length < 61 && self.quantityTextField.text.length > 0 && self.quantityTextField.text.longLongValue > 0 && self.quantityTextField.text.longLongValue < oneGreaterThanLargest32BitNumber) {
         [self.submitButton enable:YES];
     }
     else {

--- a/Lets Do This/Views/Reportback/LDTSubmitReportbackView.xib
+++ b/Lets Do This/Views/Reportback/LDTSubmitReportbackView.xib
@@ -76,7 +76,6 @@
                                     <connections>
                                         <action selector="captionTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="Mdm-3a-o57"/>
                                         <action selector="captionTextFieldEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="56g-Ek-uht"/>
-                                        <action selector="captionTextFieldEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="oml-KD-67w"/>
                                     </connections>
                                 </textField>
                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Number of nouns verbed" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="z5z-3H-aUv" userLabel="Quantity Text Field">
@@ -87,7 +86,6 @@
                                     <connections>
                                         <action selector="quantityTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="ht6-pZ-PPT"/>
                                         <action selector="quantityTextFieldEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="47u-ly-jbF"/>
-                                        <action selector="quantityTextFieldEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="sFY-4U-8Oh"/>
                                     </connections>
                                 </textField>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g7X-Cr-BiL" userLabel="Submit Button" customClass="LDTButton">

--- a/Lets Do This/Views/Reportback/LDTSubmitReportbackView.xib
+++ b/Lets Do This/Views/Reportback/LDTSubmitReportbackView.xib
@@ -75,6 +75,7 @@
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
                                         <action selector="captionTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="Mdm-3a-o57"/>
+                                        <action selector="captionTextFieldEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="56g-Ek-uht"/>
                                         <action selector="captionTextFieldEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="oml-KD-67w"/>
                                     </connections>
                                 </textField>
@@ -85,6 +86,7 @@
                                     <textInputTraits key="textInputTraits"/>
                                     <connections>
                                         <action selector="quantityTextFieldEditingChanged:" destination="-1" eventType="editingChanged" id="ht6-pZ-PPT"/>
+                                        <action selector="quantityTextFieldEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="47u-ly-jbF"/>
                                         <action selector="quantityTextFieldEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="sFY-4U-8Oh"/>
                                     </connections>
                                 </textField>

--- a/Podfile
+++ b/Podfile
@@ -14,6 +14,7 @@ target 'Lets Do This' do
     pod 'SVProgressHUD', '1.1.3'
     pod 'GoogleAnalytics', '3.13.0'
     pod 'NewRelicAgent', '5.3.4'
+    pod 'NSString+RemoveEmoji', '0.1.0'
 end
 
 xcodeproj 'Lets Do This', 'Thor' => :release, 'Debug' => :debug, 'Release' => :release


### PR DESCRIPTION
#### What's this PR do? 
Adds a check to make sure that the reportback quantity submitted is less than or equal to `2147483647`, the largest 32 bit integer. If the user inputs a number greater than that value, the "submit" button will be deactivated. Also checks to make sure emoji haven't been input in the caption text fields. 

Also adds similar form validation as `LDTUserRegisterViewController.m`. 
#### How should this be manually tested?
Tested the limits of the reportback quantity validation--adding a caption that's greater than 60 characters, no caption, a quantity greater than `2147483647`, or a quantity less than 1. 

Tested the emoji validations by entering emoji in the requisite text fields. 
#### Any background context you want to provide?
The largest reportback integer which can be handled by Phoenix is `2147483647`. By adding this check to the reportback submission controller, we prevent the reportback submission API call from having being made. 

Added two new `BOOL` properties: `quantityTextIsValid` and `captionTextIsValid` to `LDTSubmitReportbackViewController` to allow for two separate validation methods. By having a method for validating quantity, and another method for validating the caption, a user first editing the caption (the top-most field) will trigger **only** the caption validations, **not** the quantity validations. 

Otherwise, when the user first edits the caption without making it to the quantity field, and all validations run, the quantity field will be found invalid and the red boundary drawn on it. This seems to me to be a bad user experience, since that user will get an error message for a field she hasn't made it to yet. 


#### What are the relevant tickets?
Closes #668. 