### PR TITLE
Reportback item cell size - opened for review

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -216,6 +216,12 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 - (CGSize)reportbackItemCellSizeForIndexPath:(NSIndexPath *)indexPath {
 
     [self configureReportbackItemCell:self.reportbackItemSizingCell forIndexPath:indexPath];
+
+    // Attempt with bounds (per https://github.com/honghaoz/Dynamic-Collection-View-Cell-With-Auto-Layout-Demo)
+//    self.reportbackItemSizingCell.bounds = CGRectMake(0, 0, CGRectGetWidth(self.collectionView.bounds), CGRectGetHeight(self.reportbackItemSizingCell.bounds));
+//    self.reportbackItemSizingCell.contentView.bounds = self.reportbackItemSizingCell.bounds;
+
+    // Attempt with frame:
     self.reportbackItemSizingCell.frame = CGRectMake(0, 0, CGRectGetWidth(self.collectionView.bounds), CGRectGetHeight(self.reportbackItemSizingCell.frame));
 //    self.reportbackItemSizingCell.contentView.frame = self.reportbackItemSizingCell.frame;
     NSLog(@"sizingCell height beforeLayoutIfNeeded %f", CGRectGetHeight(self.reportbackItemSizingCell.frame));
@@ -339,6 +345,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 #pragma mark - UICollectionViewDelegate
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath{
+    NSLog(@"sizeForItemAtIndexPath %@", indexPath);
     CGFloat screenWidth = [[UIScreen mainScreen] bounds].size.width;
 
     if (indexPath.section == LDTCampaignDetailSectionTypeCampaign) {
@@ -367,9 +374,12 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
             }
         }
     }
-    CGSize size = [self reportbackItemCellSizeForIndexPath:indexPath];
-    NSLog(@"reportback row %li height %f", indexPath.row, size.height);
-    return size;
+    if (indexPath.section == LDTCampaignDetailSectionTypeReportback) {
+        CGSize size = [self reportbackItemCellSizeForIndexPath:indexPath];
+        NSLog(@"reportback row %li height %f", indexPath.row, size.height);
+        return size;
+    }
+    return CGSizeMake(0, 0);
 }
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section {

--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -70,8 +70,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     self.flowLayout.minimumInteritemSpacing = 0.0f;
     self.flowLayout.minimumLineSpacing = 0.0f;
     [self.collectionView setCollectionViewLayout:self.flowLayout];
-    UINib *reportbackItemCellNib = [UINib nibWithNibName:@"LDTCampaignDetailReportbackItemCell" bundle:nil];
-    self.reportbackItemSizingCell = [[reportbackItemCellNib instantiateWithOwner:nil options:nil] firstObject];
+
 
     self.imagePickerController = [[UIImagePickerController alloc] init];
     self.imagePickerController.delegate = self;
@@ -179,6 +178,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 }
 
 - (void)configureReportbackItemCell:(LDTCampaignDetailReportbackItemCell *)reportbackItemCell forIndexPath:(NSIndexPath *)indexPath {
+    NSLog(@"reportbackItemCellSizeForIndexPath:%@", indexPath);
     LDTReportbackItemDetailView *reportbackItemDetailView = reportbackItemCell.detailView;
     reportbackItemDetailView.delegate = self;
     DSOReportbackItem *reportbackItem;
@@ -188,6 +188,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     if (indexPath.section == LDTCampaignDetailSectionTypeCampaign) {
         reportbackItem = self.currentUserReportback;
         reportbackItemDetailView.displayShareButton = YES;
+        NSLog(@"displayShareButton YES");
         reportbackItemDetailView.shareButtonTitle = @"Share your photo".uppercaseString;
         // If reportbackItem was just submitted, photo may be available.
         if (reportbackItem.image) {
@@ -196,6 +197,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
         }
     }
     else {
+        NSLog(@"displayShareButton NO");
         reportbackItem = self.reportbackItems[indexPath.row];
         reportbackItemDetailView.displayShareButton = NO;
     }
@@ -214,7 +216,8 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
 
 - (CGSize)reportbackItemCellSizeForIndexPath:(NSIndexPath *)indexPath {
-
+    UINib *reportbackItemCellNib = [UINib nibWithNibName:@"LDTCampaignDetailReportbackItemCell" bundle:nil];
+    self.reportbackItemSizingCell = [[reportbackItemCellNib instantiateWithOwner:nil options:nil] firstObject];
     [self configureReportbackItemCell:self.reportbackItemSizingCell forIndexPath:indexPath];
 
     // Attempt with bounds (per https://github.com/honghaoz/Dynamic-Collection-View-Cell-With-Auto-Layout-Demo)

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailReportbackItemCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailReportbackItemCell.m
@@ -14,4 +14,11 @@
 
 @implementation LDTCampaignDetailReportbackItemCell
 
+-(void)layoutSubviews {
+    [super layoutSubviews];
+
+    NSLog(@"layoutSubviews");
+    [self.detailView setPreferredMaxLayoutWidth];
+}
+
 @end

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
@@ -27,6 +27,7 @@
 @property (strong, nonatomic) UIImage *reportbackItemImage;
 @property (strong, nonatomic) UIImage *userAvatarImage;
 
+- (void)setPreferredMaxLayoutWidth;
 - (void)sizeForDetailSingleView;
 
 @end

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
@@ -37,11 +37,7 @@
     [self styleView];
 }
 
-- (void)layoutSubviews {
-    [super layoutSubviews];
-
-    NSLog(@"layoutSubviews");
-
+- (void)setPreferredMaxLayoutWidth {
     CGFloat width = CGRectGetWidth([UIScreen mainScreen].bounds) - 16;
     self.reportbackItemCaptionLabel.preferredMaxLayoutWidth = width;
     self.reportbackItemQuantityLabel.preferredMaxLayoutWidth = width / 3;

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
@@ -35,7 +35,17 @@
     [super awakeFromNib];
 
     [self styleView];
+}
 
+- (void)layoutSubviews {
+    [super layoutSubviews];
+
+    NSLog(@"layoutSubviews");
+
+    CGFloat width = CGRectGetWidth([UIScreen mainScreen].bounds) - 16;
+    self.reportbackItemCaptionLabel.preferredMaxLayoutWidth = width;
+    self.reportbackItemQuantityLabel.preferredMaxLayoutWidth = width / 3;
+    self.userCountryNameLabel.preferredMaxLayoutWidth = 100;
 }
 
 - (void)styleView {


### PR DESCRIPTION
Attempts self sizing Reportback Item cells on the Campaign Detail screen, like in #480. Refs https://github.com/DoSomething/LetsDoThis-iOS/issues/676#issuecomment-161445114

The cell size returned is too large for most of these cells. The craziest thing I'ms eeing when I'm debugging is the first time `reportbackItemCellSizeForIndexPath` is called -- it returns the correct size for the Self Reportback (547.5). It gets called a second time which then sets the size too large (652), causing the Reportback caption  `UILabel` to stretch:

> 2015-12-03 14:11:43.188 Lets Do This[9152:1767831] sizeForItemAtIndexPath <NSIndexPath: 0xc000000000000016> {length = 2, path = 0 - 0}
2015-12-03 14:11:43.222 Lets Do This[9152:1767831] sizeForItemAtIndexPath <NSIndexPath: 0xc000000000200016> {length = 2, path = 0 - 1}
2015-12-03 14:11:43.248 Lets Do This[9152:1767831] reportbackItemCellSizeForIndexPath:<NSIndexPath: 0xc000000000200016> {length = 2, path = 0 - 1}
2015-12-03 14:11:43.249 Lets Do This[9152:1767831] displayShareButton YES
2015-12-03 14:11:43.252 Lets Do This[9152:1767831] sizingCell height beforeLayoutIfNeeded 247.000000
2015-12-03 14:11:43.255 Lets Do This[9152:1767831] layoutSubviews
2015-12-03 14:11:43.257 Lets Do This[9152:1767831] self reportback height 547.500000
2015-12-03 14:11:43.269 Lets Do This[9152:1767831] reportbackItemCellSizeForIndexPath:<NSIndexPath: 0xc000000000200016> {length = 2, path = 0 - 1}
2015-12-03 14:11:43.269 Lets Do This[9152:1767831] displayShareButton YES
2015-12-03 14:11:43.276 Lets Do This[9152:1767831] layoutSubviews
2015-12-03 14:11:43.282 Lets Do This[9152:1767831] layoutSubviews
2015-12-03 14:11:43.295 Lets Do This[9152:1767831] layoutSubviews
2015-12-03 14:11:43.458 Lets Do This[9152:1767831] layoutSubviews
2015-12-03 14:11:43.598 Lets Do This[9152:1767831] sizeForItemAtIndexPath <NSIndexPath: 0xc000000000000016> {length = 2, path = 0 - 0}
2015-12-03 14:11:43.606 Lets Do This[9152:1767831] sizeForItemAtIndexPath <NSIndexPath: 0xc000000000200016> {length = 2, path = 0 - 1}
2015-12-03 14:11:43.609 Lets Do This[9152:1767831] reportbackItemCellSizeForIndexPath:<NSIndexPath: 0xc000000000200016> {length = 2, path = 0 - 1}
2015-12-03 14:11:43.609 Lets Do This[9152:1767831] displayShareButton YES
2015-12-03 14:11:43.612 Lets Do This[9152:1767831] sizingCell height beforeLayoutIfNeeded 247.000000
2015-12-03 14:11:43.615 Lets Do This[9152:1767831] layoutSubviews
2015-12-03 14:11:43.617 Lets Do This[9152:1767831] self reportback height 652.500000

![screen shot 2015-12-03 at 2 14 49 pm](https://cloud.githubusercontent.com/assets/1236811/11575897/4778bf1e-99c8-11e5-9900-3a2b6af24d11.png)
