### PR TITLE
Opened for review - preferredLayoutSizeFittingSize

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -209,6 +209,15 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     reportbackItemDetailView.userDisplayNameButtonTitle = reportbackItem.user.displayName;
 }
 
+- (CGSize)reportbackItemCellSizeForIndexPath:(NSIndexPath *)indexPath {
+    UINib *reportbackItemCellNib = [UINib nibWithNibName:@"LDTCampaignDetailReportbackItemCell" bundle:nil];
+    LDTCampaignDetailReportbackItemCell *sizingCell = [[reportbackItemCellNib instantiateWithOwner:nil options:nil] firstObject];
+    [self configureReportbackItemCell:sizingCell forIndexPath:indexPath];
+    CGFloat width = CGRectGetWidth([UIScreen mainScreen].bounds);
+    CGSize targetSize = CGSizeMake(width, 0);
+    return [sizingCell preferredLayoutSizeFittingSize:targetSize];
+}
+
 -(DSOUser *)user {
 	return [DSOUserManager sharedInstance].user;
 }
@@ -324,8 +333,6 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath{
     CGFloat screenWidth = [[UIScreen mainScreen] bounds].size.width;
-    // Square reportback photo + header height + caption height.
-    CGFloat reportbackItemHeight = screenWidth + 36 + 70 + 8;
 
     if (indexPath.section == LDTCampaignDetailSectionTypeCampaign) {
         if (indexPath.row == LDTCampaignDetailCampaignSectionRowCampaign) {
@@ -342,8 +349,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
         }
         else {
             if ([[self user] hasCompletedCampaign:self.campaign]) {
-                // Add 66 for the Share Photo button.
-                return CGSizeMake(screenWidth, reportbackItemHeight + 66);
+                return [self reportbackItemCellSizeForIndexPath:indexPath];
             }
             else {
                 // Action Button cell:
@@ -353,7 +359,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
         }
     }
 
-    return CGSizeMake(screenWidth, reportbackItemHeight);
+    return [self reportbackItemCellSizeForIndexPath:indexPath];
 }
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section {

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailReportbackItemCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailReportbackItemCell.h
@@ -14,5 +14,7 @@
 // This needs to be public so its delegate can be set.
 @property (weak, nonatomic) IBOutlet LDTReportbackItemDetailView *detailView;
 
+// See http://stackoverflow.com/a/26349770/1470725
+- (CGSize)preferredLayoutSizeFittingSize:(CGSize)targetSize;
 
 @end

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailReportbackItemCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailReportbackItemCell.m
@@ -14,4 +14,8 @@
 
 @implementation LDTCampaignDetailReportbackItemCell
 
+- (CGSize)preferredLayoutSizeFittingSize:(CGSize)targetSize {
+    return [self.detailView preferredLayoutSizeFittingSize:targetSize];
+}
+
 @end

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
@@ -27,6 +27,7 @@
 @property (strong, nonatomic) UIImage *reportbackItemImage;
 @property (strong, nonatomic) UIImage *userAvatarImage;
 
+- (CGSize)preferredLayoutSizeFittingSize:(CGSize)targetSize;
 - (void)sizeForDetailSingleView;
 
 @end

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
@@ -34,8 +34,8 @@
 - (void)awakeFromNib {
     [super awakeFromNib];
 
+    [self setPreferredMaxLayoutWidthForLabels];
     [self styleView];
-
 }
 
 - (void)styleView {
@@ -127,6 +127,41 @@
     if (self.delegate && [self.delegate respondsToSelector:@selector(didClickShareButtonForReportbackItemDetailView:)]) {
         [self.delegate didClickShareButtonForReportbackItemDetailView:self];
     }
+}
+
+- (void)setPreferredMaxLayoutWidthForLabels {
+    CGFloat width = CGRectGetWidth([UIScreen mainScreen].bounds);
+    NSLog(@"setPreferredMaxLayoutWidthForLabels width %f", width);
+    self.reportbackItemCaptionLabel.preferredMaxLayoutWidth = width - 16;
+    self.reportbackItemQuantityLabel.preferredMaxLayoutWidth = width / 3;
+    self.userCountryNameLabel.preferredMaxLayoutWidth = 100;
+}
+
+- (CGSize)preferredLayoutSizeFittingSize:(CGSize)targetSize {
+    CGRect originalFrame = self.frame;
+
+    // step1: set the detailView.frame to use our target width
+    self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, targetSize.width, targetSize.height);
+    NSLog(@"targetSize.width %f", targetSize.width);
+
+    // step2: layout the cell
+    [self setNeedsLayout];
+    [self layoutIfNeeded];
+// Setting this to the desired width always results in the extra caption vertical padding. If we set it to just bounds.size.width like the SO thread suggests, we get vertical padding for first few rows but usually we eventually get the correct padding too.
+//    self.reportbackItemCaptionLabel.preferredMaxLayoutWidth = targetSize.width - 16;
+    self.reportbackItemCaptionLabel.preferredMaxLayoutWidth = self.reportbackItemCaptionLabel.bounds.size.width;
+    NSLog(@"reportbackItemCaptionLabel.preferredMaxLayoutWidth %f: ", self.reportbackItemCaptionLabel.preferredMaxLayoutWidth);
+    self.reportbackItemQuantityLabel.preferredMaxLayoutWidth = self.reportbackItemQuantityLabel.bounds.size.width;
+    self.userCountryNameLabel.preferredMaxLayoutWidth = self.userCountryNameLabel.bounds.size.width;
+
+    // step3: compute how tall the cell needs to be
+    CGSize computedSize = [self systemLayoutSizeFittingSize:targetSize];
+    CGSize newSize = CGSizeMake(targetSize.width, computedSize.height);
+    NSLog(@"computedSize.height %f", computedSize.height);
+    self.frame = originalFrame;
+    [self setPreferredMaxLayoutWidthForLabels];
+
+    return newSize;
 }
 
 @end


### PR DESCRIPTION
Follows the steps in this [SO answer](http://stackoverflow.com/a/26349770/1470725) in an attempt to resolve #676. The author suggests `preferredLayoutAttributesFittingAttributes` is a "red herring" -- only be to used when you set the `estimatedItemSize`, which the author suggests is buggy:
> In practice, I haven't seen any examples that have gotten this to work with multi-line labels. I think this is partly because the self-sizing cell mechanism is still buggy 

What's a teeny bit maddening is that when I first load Barbie Bash (building to prod), everything works great:

![screen shot 2015-12-07 at 8 07 14 pm](https://cloud.githubusercontent.com/assets/1236811/11647559/33958d66-9d1e-11e5-9d5c-9528dd5fd091.png)

When I view the Barbie Bash `LDTCampaignDetailViewController` a second time, I get the extra vertical padding on the Caption label, as I'm seeing in the other branches (#687 and #688)

![screen shot 2015-12-07 at 8 00 43 pm](https://cloud.githubusercontent.com/assets/1236811/11647463/4e5dc844-9d1d-11e5-8725-0fbbb09fdf4a.png)