### PR TITLE
cleanup Foundation and UIKit imports

### DIFF
--- a/Lets Do This/Categories/GAI+LDT.h
+++ b/Lets Do This/Categories/GAI+LDT.h
@@ -6,7 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
 #import <GoogleAnalytics/GAI.h>
 
 @interface GAI (LDT)

--- a/Lets Do This/Categories/NSDate+DSO.h
+++ b/Lets Do This/Categories/NSDate+DSO.h
@@ -6,8 +6,6 @@
 //
 //
 
-#import <Foundation/Foundation.h>
-
 @interface NSDate (DSO)
 
 + (NSDate *)dateFromISO8601String:(NSString *)dateString;

--- a/Lets Do This/Categories/NSDictionary+DSOJsonHelper.h
+++ b/Lets Do This/Categories/NSDictionary+DSOJsonHelper.h
@@ -6,8 +6,6 @@
 //
 //
 
-#import <Foundation/Foundation.h>
-
 @interface NSDictionary (DSOJsonHelper)
 
 - (id)valueForJSONKey:(NSString *)key;

--- a/Lets Do This/Categories/NSError+LDT.h
+++ b/Lets Do This/Categories/NSError+LDT.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 @interface NSError (LDT)
 
 - (NSString *)readableTitle;

--- a/Lets Do This/Categories/UIImageView+LDT.h
+++ b/Lets Do This/Categories/UIImageView+LDT.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 @interface UIImageView (LDT)
 
 - (void)addCircleFrame;

--- a/Lets Do This/Categories/UINavigationController+LDT.h
+++ b/Lets Do This/Categories/UINavigationController+LDT.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 typedef NS_ENUM(NSInteger, LDTNavigationBarStyle) {
     LDTNavigationBarStyleNormal,
     LDTNavigationBarStyleClear

--- a/Lets Do This/Categories/UITextField+LDT.h
+++ b/Lets Do This/Categories/UITextField+LDT.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 @interface UITextField (LDT)
 
 - (void)setBorderColor:(UIColor *)color;

--- a/Lets Do This/Categories/UIViewController+LDT.h
+++ b/Lets Do This/Categories/UIViewController+LDT.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 @interface UIViewController (LDT)
 
 - (void)styleBackBarButton;

--- a/Lets Do This/Classes/AppDelegate.h
+++ b/Lets Do This/Classes/AppDelegate.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;

--- a/Lets Do This/Controllers/Base/LDTBaseViewController.h
+++ b/Lets Do This/Controllers/Base/LDTBaseViewController.h
@@ -14,8 +14,6 @@
     By having LDTUserLoginViewController, LDTUserRegisterViewController, and others subclass this controller, we're able to keep separate all of the text field logic from other business logic, as well as help keep text field logic DRY.
 */
 
-#import <UIKit/UIKit.h>
-
 @interface LDTBaseViewController : UIViewController<UITextFieldDelegate>
 
 @property (strong, nonatomic) NSArray *textFields;

--- a/Lets Do This/Controllers/Base/LDTTabBarController.h
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTTabBarController : UITabBarController
 
 -(void)loadMainFeed;

--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.h
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "DSOCampaign.h"
 
 @interface LDTCampaignDetailViewController : UIViewController

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.h
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTCampaignListViewController : UIViewController
 
 - (void)loadMainFeed;

--- a/Lets Do This/Controllers/LDTActivityViewController.h
+++ b/Lets Do This/Controllers/LDTActivityViewController.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTActivityViewController : UIActivityViewController
 
 - (instancetype)initWithReportbackItem:(DSOReportbackItem *)reportbackItem image:(UIImage *)image;

--- a/Lets Do This/Controllers/LDTEpicFailViewController.h
+++ b/Lets Do This/Controllers/LDTEpicFailViewController.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @protocol LDTEpicFailSubmitButtonDelegate;
 
 @interface LDTEpicFailViewController : UIViewController

--- a/Lets Do This/Controllers/Login/LDTUserConnectViewController.h
+++ b/Lets Do This/Controllers/Login/LDTUserConnectViewController.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTUserConnectViewController : UIViewController
 
 @end

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.h
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import <CoreLocation/CoreLocation.h>
 #import "LDTBaseViewController.h"
 

--- a/Lets Do This/Controllers/Onboarding/LDTOnboardingPageViewController.h
+++ b/Lets Do This/Controllers/Onboarding/LDTOnboardingPageViewController.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTOnboardingPageViewController : UIViewController
 
 - (instancetype)initWithHeadlineText:(NSString *)headlineText descriptionText:(NSString *)descriptionText primaryImage:(UIImage *)primaryImage gaiScreenName:(NSString *)gaiScreenName nextViewController:(UIViewController *)nextViewController isFirstPage:(BOOL)isFirstPage;

--- a/Lets Do This/Controllers/Profile/LDTProfileViewController.h
+++ b/Lets Do This/Controllers/Profile/LDTProfileViewController.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "DSOUser.h"
 
 @interface LDTProfileViewController : UIViewController

--- a/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.h
+++ b/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTReportbackItemDetailSingleViewController : UIViewController
 
 -(instancetype)initWithReportbackItem:(DSOReportbackItem *)reportbackItem;

--- a/Lets Do This/Controllers/Settings/LDTSettingsViewController.h
+++ b/Lets Do This/Controllers/Settings/LDTSettingsViewController.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTSettingsViewController : UIViewController 
 
 @end

--- a/Lets Do This/LetsDoThis.pch
+++ b/Lets Do This/LetsDoThis.pch
@@ -12,6 +12,10 @@
 // Include any system framework and library headers here that should be included in all compilation units.
 // You will also need to set the Prefix Header build setting of one or more of your targets to reference this file.
 
+// Removing the Foundation and UIKit headers from here does not break the app; they're imported somewhere else. (Perhaps through Cocoapods?)
+// @TODO: determine where and how the Foundation and UIKit headers are being imported from elsewhere.
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "DSOUserManager.h"
 #import "NSError+LDT.h"
 #import <SVProgressHUD.h>

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -6,9 +6,6 @@
 //
 //
 
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
-
 @class DSOCampaign;
 
 @interface DSOCampaign : NSObject

--- a/Lets Do This/Models/DSOCampaignSignup.h
+++ b/Lets Do This/Models/DSOCampaignSignup.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 @class DSOUser;
 @class DSOReportbackItem;
 

--- a/Lets Do This/Models/DSOReportbackItem.h
+++ b/Lets Do This/Models/DSOReportbackItem.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 @interface DSOReportbackItem : NSObject
 
 @property (nonatomic, strong, readonly) DSOCampaign *campaign;

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -6,7 +6,6 @@
 //
 //
 
-#import <Foundation/Foundation.h>
 #import "DSOCampaign.h"
 
 @class DSOCampaignSignup;

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
 #import "DSOAPI.h"
 
 @interface DSOUserManager : NSObject

--- a/Lets Do This/Views/Base/InterfaceBuilderView.h
+++ b/Lets Do This/Views/Base/InterfaceBuilderView.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface InterfaceBuilderView : UIView
 
 @end

--- a/Lets Do This/Views/Base/LDTButton.h
+++ b/Lets Do This/Views/Base/LDTButton.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTButton : UIButton
 
 -(void)enable:(BOOL)enabled;

--- a/Lets Do This/Views/Base/LDTTheme.h
+++ b/Lets Do This/Views/Base/LDTTheme.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
 #import "UIImageView+LDT.h"
 #import "UINavigationController+LDT.h"
 #import "UIViewController+LDT.h"

--- a/Lets Do This/Views/Campaign/LDTCampaignCollectionViewCellContainer.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignCollectionViewCellContainer.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTCampaignCollectionViewCellContainer : UICollectionViewCell
 
 @property (nonatomic, strong) UICollectionView *innerCollectionView;

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailActionButtonCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailActionButtonCell.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @protocol LDTCampaignDetailActionButtonCellDelegate;
 
 @interface LDTCampaignDetailActionButtonCell : UICollectionViewCell

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTCampaignDetailCampaignCell : UICollectionViewCell
 
 @property (strong, nonatomic) DSOCampaign *campaign;

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailReportbackItemCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailReportbackItemCell.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "LDTReportbackItemDetailView.h"
 
 @interface LDTCampaignDetailReportbackItemCell : UICollectionViewCell

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "LDTTheme.h"
 
 @protocol LDTCampaignListCampaignCellDelegate;

--- a/Lets Do This/Views/Campaign/LDTCampaignListReportbackItemCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignListReportbackItemCell.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTCampaignListReportbackItemCell : UICollectionViewCell
 
 @property (strong, nonatomic) DSOReportbackItem *reportbackItem;

--- a/Lets Do This/Views/LDTHeaderCollectionReusableView.h
+++ b/Lets Do This/Views/LDTHeaderCollectionReusableView.h
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTHeaderCollectionReusableView : UICollectionReusableView
 
 @property (weak, nonatomic) IBOutlet UILabel *titleLabel;

--- a/Lets Do This/Views/Profile/LDTProfileCampaignTableViewCell.h
+++ b/Lets Do This/Views/Profile/LDTProfileCampaignTableViewCell.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @protocol LDTProfileCampaignTableViewCellDelegate;
 
 @interface LDTProfileCampaignTableViewCell : UITableViewCell

--- a/Lets Do This/Views/Profile/LDTProfileHeaderTableViewCell.h
+++ b/Lets Do This/Views/Profile/LDTProfileHeaderTableViewCell.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @protocol LDTProfileHeaderTableViewCellDelegate;
 
 @interface LDTProfileHeaderTableViewCell : UITableViewCell

--- a/Lets Do This/Views/Profile/LDTProfileNoSignupsTableViewCell.h
+++ b/Lets Do This/Views/Profile/LDTProfileNoSignupsTableViewCell.h
@@ -6,8 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface LDTProfileNoSignupsTableViewCell : UITableViewCell
 
 @property (strong, nonatomic) NSString *subtitleLabelText;

--- a/Lets Do This/Views/Profile/LDTProfileReportbackItemTableViewCell.h
+++ b/Lets Do This/Views/Profile/LDTProfileReportbackItemTableViewCell.h
@@ -6,7 +6,6 @@
 //  Copyright © 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "LDTReportbackItemDetailView.h"
 
 @interface LDTProfileReportbackItemTableViewCell : UITableViewCell

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "InterfaceBuilderView.h"
 
 @protocol LDTReportbackItemDetailViewDelegate;

--- a/Lets Do This/main.m
+++ b/Lets Do This/main.m
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "AppDelegate.h"
 
 int main(int argc, char * argv[]) {

--- a/Lets Do ThisTests/Lets_Do_ThisTests.m
+++ b/Lets Do ThisTests/Lets_Do_ThisTests.m
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
 @interface Lets_Do_ThisTests : XCTestCase


### PR DESCRIPTION
#### What's this PR do?
Removes `Foundation` and `UIKit` imports, and requires those in the `LetsDoThis.pch` header. 
#### How should this be manually tested?
Tested by running app and walking through normal user functionality: signing in and registering, signing up for a campaign, reporting back, viewing profile/settings view. 
#### What are the relevant tickets?
#429. 
#### Questions:
As observed in #429, I noticed that the app did run after removing the imports and without adding them into the header, indicating that they were required some other method (perhaps cocoapods.) Still added them to `LetsDoThis.pch` for clarity. 

Will spend some time trying to figure out where the other import comes from, but I feel like for clarity and our future selves' sake it's worth keeping the imports in the `LetsDoThis.pch` header--thoughts?