### PR TITLE
add char restrictions to input and error messaging to register and submit reportback

### DIFF
--- a/Lets Do This/Controllers/Base/LDTBaseViewController.m
+++ b/Lets Do This/Controllers/Base/LDTBaseViewController.m
@@ -1,5 +1,5 @@
 //
-//  LDTBaseUserLoginViewController.m
+//  LDTBaseViewController.m
 //  Lets Do This
 //
 //  Created by Aaron Schachter on 7/9/15.

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -402,4 +402,25 @@
     [viewController styleRightBarButton];
 }
 
+# pragma mark - UITextFieldControllerDelegate
+
+// If user changes chars in a text field--and that field is the emailTextField--restrict chars from showing up, and display an error message.
+- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+    if ([textField isEqual:self.emailTextField]){
+        // Prevents crashing undo bug: http://stackoverflow.com/questions/433337/set-the-maximum-character-length-of-a-uitextfield
+        if (range.length + range.location > textField.text.length) {
+            return NO;
+        }
+        NSUInteger newLength = [textField.text length] + [string length] - range.length;
+        if (newLength > 60) {
+            [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Your email can't be longer than 60 characters."];
+            return NO;
+        }
+        else {
+            return YES;
+        }
+    }
+    return YES;
+}
+
 @end

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -243,4 +243,25 @@
     [viewController styleBackBarButton];
 }
 
+# pragma mark - UITextFieldControllerDelegate
+
+// If user changes chars in a text field--and that field is the captionTextField--restrict chars from showing up, and display an error message.
+- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+    if ([textField isEqual:self.captionTextField]) {
+        // Prevents crashing undo bug: http://stackoverflow.com/questions/433337/set-the-maximum-character-length-of-a-uitextfield
+        if (range.length + range.location > textField.text.length) {
+            return NO;
+        }
+        NSUInteger newLength = [textField.text length] + [string length] - range.length;
+        if (newLength > 60) {
+            [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Your caption can't be longer than 60 characters."];
+            return NO;
+        }
+        else {
+            return YES;
+        }
+    }
+    return YES;
+}
+
 @end


### PR DESCRIPTION
#### What's this PR do?
1. Adds character restrictions (the text field will not accept any added characters beyond the 60th character added) to the caption field in the submit reportback view, and email field in the register view. 
2. Adds error messages which appear when the user attempts to input more than 60 characters in either field. 

#### How should this be manually tested?
Tested by attempting to add more than 60 characters to both of the text fields above. Also tested the other text fields on the screen, to ensure that they wouldn't be restricted. 

#### Any background context you want to provide?
In order to make sure that the UITextField delegate method only restricts input for the fields we want it to restrict input for, we had to 1) assign tags to each UITextField, 2) create a dictionary of tag-UITextField key-value pairs, and 3) use this dictionary to check for the right UITextField each time the delegate method is called. 

#### What are the relevant tickets?
Closes #693, closes #690. 

#### Questions:
Is there a way to modularize / better place to put the UITextField delegate method so we don't repeat ourselves across two controllers? 