### PR TITLE
Self sizing Main Feed / Campaign List

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -341,13 +341,9 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
                 LDTCampaignListCampaignCell *sizingCell =  [[campaignCellNib instantiateWithOwner:nil options:nil] firstObject];
                 [self configureCampaignPitchCell:sizingCell];
                 sizingCell.frame = CGRectMake(0, 0, CGRectGetWidth(self.collectionView.bounds), CGRectGetHeight(sizingCell.frame));
-                NSLog(@"sizingCell.frame.height %f", CGRectGetHeight(sizingCell.frame));
                 [sizingCell setNeedsLayout];
                 [sizingCell layoutIfNeeded];
-                // This is returning 0
-//                CGFloat campaignCellHeight = [sizingCell.contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
-//                NSLog(@"campaignCellHeight %f", campaignCellHeight);
-                CGFloat campaignCellHeight = CGRectGetHeight(sizingCell.frame);
+                CGFloat campaignCellHeight = [sizingCell.contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
                 return CGSizeMake(screenWidth, campaignCellHeight);
             }
 

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSInteger, LDTLoadError) {
 };
 
 const CGFloat kHeightCollapsed = 150;
-const CGFloat kHeightExpanded = 382;
+const CGFloat kHeightExpanded = 400;
 
 @interface LDTCampaignListViewController () <UICollectionViewDataSource, UICollectionViewDelegate, LDTCampaignListCampaignCellDelegate, LDTEpicFailSubmitButtonDelegate>
 

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
@@ -133,19 +133,6 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
     }
 }
 
-- (UICollectionViewLayoutAttributes *)preferredLayoutAttributesFittingAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes {
-    UICollectionViewLayoutAttributes *attributes = [[super preferredLayoutAttributesFittingAttributes:layoutAttributes] copy];
-
-    [self setNeedsLayout];
-    [self layoutIfNeeded];
-
-    CGRect newFrame = attributes.frame;
-    newFrame.size.width = CGRectGetWidth([UIScreen mainScreen].bounds);
-    newFrame.size.height = [self.contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
-    attributes.frame = newFrame;
-    return attributes;
-}
-
 - (void)layoutSubviews {
     [super layoutSubviews];
 

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
@@ -23,6 +23,11 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *imageViewBottom;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *imageViewTop;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *titleLabelTopLayoutConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *imageViewHeight;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *taglineTop;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *actionButtonHeight;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *actionButtonTop;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *actionButtonBottom;
 
 - (IBAction)actionButtonTouchUpInside:(id)sender;
 
@@ -34,7 +39,8 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
     [super awakeFromNib];
 
     [self styleView];
-    self.actionButton.hidden = YES;
+    // Collapse by default to keep actionButton hidden.
+    self.expanded = NO;
 }
 
 - (void)styleView {
@@ -90,16 +96,29 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
 		self.titleLabelTopLayoutConstraint.constant = CGRectGetHeight(self.imageView.bounds)-CGRectGetHeight(self.titleLabel.bounds)-10; // -10 for padding
 		self.imageViewTop.constant = kCampaignImageViewConstantExpanded;
 		self.imageViewBottom.constant = kCampaignImageViewConstantExpanded;
+        self.imageViewHeight.constant = 242;
+        self.actionButtonHeight.constant = 50;
+        self.actionButtonTop.constant = 16;
+        self.actionButtonBottom.constant = 16;
 		[self.actionButton enable:YES];
         self.actionButton.hidden = NO;
+        self.taglineTop.constant = 16;
+        self.taglineLabel.hidden = NO;
 
 		[self layoutIfNeeded];
 	}
 	else {
 		self.imageViewTop.constant = kCampaignImageViewConstantCollapsed;
 		self.imageViewBottom.constant = kCampaignImageViewConstantCollapsed;
+        // Desired height is 150, but need 25 with the imageView constant.
+        self.imageViewHeight.constant = 175;
 		self.titleLabelTopLayoutConstraint.constant = self.collapsedTitleLabelTopLayoutConstraintConstant;
         self.actionButton.hidden = YES;
+        self.actionButtonHeight.constant = 0;
+        self.actionButtonTop.constant = 0;
+        self.actionButtonBottom.constant = 0;
+        self.taglineTop.constant = 0;
+        self.taglineLabel.hidden = YES;
 		
 		[self layoutIfNeeded];
 	}

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.m
@@ -34,13 +34,13 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
     [super awakeFromNib];
 
     [self styleView];
+    self.actionButton.hidden = YES;
 }
 
 - (void)styleView {
     self.titleLabel.font = LDTTheme.fontTitle;
     self.taglineLabel.font = LDTTheme.font;;
     self.titleLabel.textColor = UIColor.whiteColor;
-    [self.actionButton enable:YES];
     [self.imageView addGrayTintForFullScreenWidthImageView];
 	
 	self.imageViewTop.constant = kCampaignImageViewConstantCollapsed;
@@ -90,13 +90,16 @@ const CGFloat kCampaignImageViewConstantExpanded = 0;
 		self.titleLabelTopLayoutConstraint.constant = CGRectGetHeight(self.imageView.bounds)-CGRectGetHeight(self.titleLabel.bounds)-10; // -10 for padding
 		self.imageViewTop.constant = kCampaignImageViewConstantExpanded;
 		self.imageViewBottom.constant = kCampaignImageViewConstantExpanded;
-		
+		[self.actionButton enable:YES];
+        self.actionButton.hidden = NO;
+
 		[self layoutIfNeeded];
 	}
 	else {
 		self.imageViewTop.constant = kCampaignImageViewConstantCollapsed;
 		self.imageViewBottom.constant = kCampaignImageViewConstantCollapsed;
 		self.titleLabelTopLayoutConstraint.constant = self.collapsedTitleLabelTopLayoutConstraintConstant;
+        self.actionButton.hidden = YES;
 		
 		[self layoutIfNeeded];
 	}

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
@@ -8,10 +8,10 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="LDTCampaignListCampaignCell">
-            <rect key="frame" x="0.0" y="0.0" width="385" height="400"/>
+            <rect key="frame" x="0.0" y="0.0" width="385" height="361"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="385" height="400"/>
+                <rect key="frame" x="0.0" y="0.0" width="385" height="361"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YLY-38-HRb" userLabel="Campaign Image">
                         <rect key="frame" x="0.0" y="0.0" width="385" height="242"/>
@@ -35,7 +35,7 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rcw-DX-Omy" userLabel="Action Container View">
-                        <rect key="frame" x="0.0" y="242" width="385" height="158"/>
+                        <rect key="frame" x="0.0" y="242" width="385" height="119"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vEa-dR-bea" userLabel="Campaign Tagline">
                                 <rect key="frame" x="21" y="16" width="343" height="21"/>
@@ -65,7 +65,7 @@
                             <constraint firstItem="vEa-dR-bea" firstAttribute="leading" secondItem="rcw-DX-Omy" secondAttribute="leading" constant="21" id="Ex3-iC-1aV"/>
                             <constraint firstAttribute="trailing" secondItem="vEa-dR-bea" secondAttribute="trailing" constant="21" id="Gb4-2Y-Xxh"/>
                             <constraint firstAttribute="trailing" secondItem="D5G-Kr-aLa" secondAttribute="trailing" constant="8" id="Hsz-p7-JNi"/>
-                            <constraint firstAttribute="height" constant="158" id="P2i-IF-zNH"/>
+                            <constraint firstAttribute="bottom" secondItem="D5G-Kr-aLa" secondAttribute="bottom" constant="16" id="bpD-f1-oCi"/>
                             <constraint firstItem="vEa-dR-bea" firstAttribute="top" secondItem="rcw-DX-Omy" secondAttribute="top" constant="16" id="eep-p8-Gtj"/>
                             <constraint firstItem="D5G-Kr-aLa" firstAttribute="leading" secondItem="rcw-DX-Omy" secondAttribute="leading" constant="8" id="rjk-3x-f5A"/>
                         </constraints>
@@ -91,7 +91,7 @@
                 <constraint firstItem="4Ct-iF-EqI" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="32" id="rkg-tR-MYb"/>
                 <constraint firstItem="YLY-38-HRb" firstAttribute="height" secondItem="Gec-if-FXG" secondAttribute="height" id="s0L-zL-92e"/>
             </constraints>
-            <size key="customSize" width="385" height="400"/>
+            <size key="customSize" width="385" height="361"/>
             <variation key="default">
                 <mask key="constraints">
                     <exclude reference="s0L-zL-92e"/>
@@ -109,7 +109,7 @@
                 <outlet property="titleLabel" destination="4Ct-iF-EqI" id="dO4-rM-JHV"/>
                 <outlet property="titleLabelTopLayoutConstraint" destination="rkg-tR-MYb" id="ulH-6g-kk7"/>
             </connections>
-            <point key="canvasLocation" x="378.5" y="265"/>
+            <point key="canvasLocation" x="382.5" y="220.5"/>
         </collectionViewCell>
     </objects>
 </document>

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -15,21 +15,18 @@
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YLY-38-HRb" userLabel="Campaign Image">
                         <rect key="frame" x="0.0" y="0.0" width="385" height="242"/>
-                        <animations/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="242" id="9iE-zQ-Mqv"/>
+                            <constraint firstAttribute="height" priority="750" constant="999" id="9iE-zQ-Mqv"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ct-iF-EqI" userLabel="Campaign Title">
                         <rect key="frame" x="8" y="32" width="369" height="21"/>
-                        <animations/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gec-if-FXG" userLabel="Signup Indicator View">
                         <rect key="frame" x="0.0" y="0.0" width="8" height="242"/>
-                        <animations/>
                         <constraints>
                             <constraint firstAttribute="width" constant="8" id="dgE-ab-Byo"/>
                         </constraints>
@@ -39,14 +36,12 @@
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vEa-dR-bea" userLabel="Campaign Tagline">
                                 <rect key="frame" x="21" y="16" width="343" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D5G-Kr-aLa" userLabel="Action Button" customClass="LDTButton">
                                 <rect key="frame" x="8" y="53" width="369" height="50"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="vfe-nB-oVK"/>
                                 </constraints>
@@ -58,7 +53,6 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
                         <constraints>
                             <constraint firstItem="D5G-Kr-aLa" firstAttribute="top" secondItem="vEa-dR-bea" secondAttribute="bottom" constant="16" id="DCM-TH-Ls5"/>
                             <constraint firstItem="vEa-dR-bea" firstAttribute="leading" secondItem="rcw-DX-Omy" secondAttribute="leading" constant="21" id="Ex3-iC-1aV"/>
@@ -70,10 +64,8 @@
                         </constraints>
                     </view>
                 </subviews>
-                <animations/>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
-            <animations/>
             <constraints>
                 <constraint firstItem="YLY-38-HRb" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="5Ak-wS-aSM"/>
                 <constraint firstItem="YLY-38-HRb" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="E0W-T1-ySj"/>

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
@@ -28,7 +28,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gec-if-FXG" userLabel="Signup Indicator View">
-                        <rect key="frame" x="0.0" y="0.0" width="8" height="400"/>
+                        <rect key="frame" x="0.0" y="0.0" width="8" height="242"/>
                         <animations/>
                         <constraints>
                             <constraint firstAttribute="width" constant="8" id="dgE-ab-Byo"/>
@@ -79,7 +79,7 @@
                 <constraint firstItem="YLY-38-HRb" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="E0W-T1-ySj"/>
                 <constraint firstAttribute="trailing" secondItem="rcw-DX-Omy" secondAttribute="trailing" id="Fpi-jV-LHi"/>
                 <constraint firstItem="Gec-if-FXG" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="JTj-R3-fys"/>
-                <constraint firstItem="YLY-38-HRb" firstAttribute="bottom" secondItem="Gec-if-FXG" secondAttribute="bottom" constant="-158" id="MPW-P0-qG7"/>
+                <constraint firstItem="YLY-38-HRb" firstAttribute="bottom" secondItem="Gec-if-FXG" secondAttribute="bottom" id="MPW-P0-qG7"/>
                 <constraint firstItem="rcw-DX-Omy" firstAttribute="top" secondItem="YLY-38-HRb" secondAttribute="bottom" id="Rmg-UZ-qQD"/>
                 <constraint firstAttribute="trailing" secondItem="4Ct-iF-EqI" secondAttribute="trailing" constant="8" id="Y5T-wc-J5D"/>
                 <constraint firstItem="4Ct-iF-EqI" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="8" id="ZSF-wd-D7m"/>

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
@@ -85,6 +85,7 @@
                 <constraint firstAttribute="trailing" secondItem="4Ct-iF-EqI" secondAttribute="trailing" constant="8" id="Y5T-wc-J5D"/>
                 <constraint firstItem="4Ct-iF-EqI" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="8" id="ZSF-wd-D7m"/>
                 <constraint firstItem="rcw-DX-Omy" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="cw8-5F-SFb"/>
+                <constraint firstAttribute="bottom" secondItem="rcw-DX-Omy" secondAttribute="bottom" id="g9N-QR-BuW"/>
                 <constraint firstItem="YLY-38-HRb" firstAttribute="top" secondItem="Gec-if-FXG" secondAttribute="top" id="jGi-ji-nBx"/>
                 <constraint firstAttribute="trailing" secondItem="YLY-38-HRb" secondAttribute="trailing" id="pfC-BV-Xsl"/>
                 <constraint firstAttribute="bottom" secondItem="4Ct-iF-EqI" secondAttribute="bottom" constant="8" id="qlO-On-fsP"/>

--- a/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignListCampaignCell.xib
@@ -59,7 +59,6 @@
                             </button>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="D5G-Kr-aLa" firstAttribute="top" secondItem="vEa-dR-bea" secondAttribute="bottom" constant="16" id="DCM-TH-Ls5"/>
                             <constraint firstItem="vEa-dR-bea" firstAttribute="leading" secondItem="rcw-DX-Omy" secondAttribute="leading" constant="21" id="Ex3-iC-1aV"/>
@@ -101,12 +100,17 @@
             </variation>
             <connections>
                 <outlet property="actionButton" destination="D5G-Kr-aLa" id="8Mp-o4-dfK"/>
+                <outlet property="actionButtonBottom" destination="bpD-f1-oCi" id="uRa-rO-6Xy"/>
+                <outlet property="actionButtonHeight" destination="vfe-nB-oVK" id="fVC-if-2HR"/>
+                <outlet property="actionButtonTop" destination="DCM-TH-Ls5" id="hNc-a7-r7M"/>
                 <outlet property="actionView" destination="rcw-DX-Omy" id="aWI-gS-8u3"/>
                 <outlet property="imageView" destination="YLY-38-HRb" id="cKD-59-2BH"/>
                 <outlet property="imageViewBottom" destination="Rmg-UZ-qQD" id="qpG-BT-Ojb"/>
+                <outlet property="imageViewHeight" destination="9iE-zQ-Mqv" id="Yg7-bl-eUr"/>
                 <outlet property="imageViewTop" destination="5Ak-wS-aSM" id="7uL-K5-Q5X"/>
                 <outlet property="signupIndicatorView" destination="Gec-if-FXG" id="Ajc-CY-1j6"/>
                 <outlet property="taglineLabel" destination="vEa-dR-bea" id="BVl-yC-mfz"/>
+                <outlet property="taglineTop" destination="eep-p8-Gtj" id="VRY-Gw-Xfb"/>
                 <outlet property="titleLabel" destination="4Ct-iF-EqI" id="dO4-rM-JHV"/>
                 <outlet property="titleLabelTopLayoutConstraint" destination="rkg-tR-MYb" id="ulH-6g-kk7"/>
             </connections>

--- a/Lets Do This/Views/Campaign/LDTCampaignListView.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignListView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LDTCampaignListViewController">
@@ -25,6 +25,7 @@
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9NV-HW-kIE" customClass="LDTButton">
                             <rect key="frame" x="0.0" y="0.0" width="133" height="44"/>
+                            <animations/>
                             <state key="normal" title="Group 1">
                                 <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
@@ -34,6 +35,7 @@
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y7O-yd-n6h" customClass="LDTButton">
                             <rect key="frame" x="452" y="0.0" width="132" height="44"/>
+                            <animations/>
                             <state key="normal" title="Group 4">
                                 <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
@@ -43,6 +45,7 @@
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uUv-u7-Eog" customClass="LDTButton">
                             <rect key="frame" x="151" y="0.0" width="132" height="44"/>
+                            <animations/>
                             <state key="normal" title="Group 2">
                                 <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
@@ -52,6 +55,7 @@
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3D0-ba-8Ss" customClass="LDTButton">
                             <rect key="frame" x="301" y="0.0" width="133" height="44"/>
+                            <animations/>
                             <state key="normal" title="Group 3">
                                 <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
@@ -60,6 +64,7 @@
                             </connections>
                         </button>
                     </subviews>
+                    <animations/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="y7O-yd-n6h" secondAttribute="bottom" id="03M-HU-FB0"/>
@@ -83,6 +88,7 @@
                 </view>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="410-82-MGm">
                     <rect key="frame" x="0.0" y="60" width="600" height="540"/>
+                    <animations/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="5Ha-gu-PSJ">
                         <size key="itemSize" width="50" height="50"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -95,6 +101,7 @@
                     </connections>
                 </collectionView>
             </subviews>
+            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="410-82-MGm" firstAttribute="top" secondItem="0PZ-vh-TRG" secondAttribute="bottom" constant="8" id="1TE-em-6t8"/>


### PR DESCRIPTION
This gets reaaally close to getting self sizing cells on the `LDTCampaignListController` -- it's buggy for an expanded cells, and throws a bunch of conflicting constraint warnings. Maybe because it's better to store the sizingCells as properties (https://github.com/DoSomething/LetsDoThis-iOS/pull/694#discussion_r47173825)

Does get the Campaign Presignup to be self sizing without any warnings in #697 (sweet!). Began work on getting the `LDTCampaignListCampaignCell` self sizing within the Campaign Detail VC instead of the `LDTCampaignDetailReportbackItemCell` since i've been feeling pretty stuck there (boo! #687, #688, #694) and was hoping this could help shed some light. So far, sort of.  It's at least encouraging to see it work nicely on the Campaign Detail (this PR adds the missing constraint mentioned to the xib file in https://github.com/DoSomething/LetsDoThis-iOS/pull/696#discussion_r47170360)

Opening for now to document work done so far -- still need to fix the expanded cell view / warnings before merging this in. 
