### PR TITLE
add clarifying import comment to LetsDoThis.pch

### DIFF
--- a/Lets Do This/LetsDoThis.pch
+++ b/Lets Do This/LetsDoThis.pch
@@ -12,8 +12,9 @@
 // Include any system framework and library headers here that should be included in all compilation units.
 // You will also need to set the Prefix Header build setting of one or more of your targets to reference this file.
 
-// Removing the Foundation and UIKit headers from here does not break the app; they're imported somewhere else. (Perhaps through Cocoapods?)
-// @TODO: determine where and how the Foundation and UIKit headers are being imported from elsewhere.
+// Note that removing the Foundation and UIKit headers from here may not break the app--those headers are also imported through CocoaPods.
+// The #import directive only #include(s) a file when that file has not been included before, and it replaces that directive with the
+// entire content of the specified header. We keep the Foundation and UIKit headers here for safety and clarity. 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "DSOUserManager.h"


### PR DESCRIPTION
#### What's this PR do?
Adds a clarifying comment to the `LetsDoThis.pch` file about where frameworks are being imported from. #### What are the relevant tickets?
Closes #429. 