### PR TITLE
Removes unnecessary preferredLayoutAttributesFittingAttributes

### DIFF
--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
@@ -41,19 +41,6 @@
     self.staticInstructionLabel.text = @"When you’re done, submit a pic of yourself in action. #picsoritdidnthappen";
 }
 
-- (UICollectionViewLayoutAttributes *)preferredLayoutAttributesFittingAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes {
-    UICollectionViewLayoutAttributes *attributes = [[super preferredLayoutAttributesFittingAttributes:layoutAttributes] copy];
-
-    [self setNeedsLayout];
-    [self layoutIfNeeded];
-
-    CGRect newFrame = attributes.frame;
-    newFrame.size.width = CGRectGetWidth([UIScreen mainScreen].bounds);
-    newFrame.size.height = [self.contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
-    attributes.frame = newFrame;
-    return attributes;
-}
-
 - (void)layoutSubviews {
     [super layoutSubviews];
 


### PR DESCRIPTION
Per http://stackoverflow.com/a/26349770/1470725 which suggests that `preferredLayoutAttributesFittingAttributes` is red herring... seems like it is. If I remove it completely, the Campaign Detail Campaign Cell still self sizes. Looked into this while reading up and troubleshooting #701. 

refs #480 which introduced the method based on other threads (links in its description)