### PR TITLE
Use CampaignDetailCampaignCell for Campaign Presignup

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -172,17 +172,18 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     cell.staticInstructionLabelText = @"When you’re done, submit a pic of yourself in action. #picsoritdidnthappen";
 
     if ([[self user] hasCompletedCampaign:self.campaign]) {
-        cell.displaySubmitReportbackButton = NO;
+        cell.displayActionButton = NO;
         cell.displayCampaignDetailsView = YES;
     }
     else {
         if ([[self user] isDoingCampaign:self.campaign]) {
-            cell.displaySubmitReportbackButton = YES;
+            cell.displayActionButton = YES;
+            cell.actionButtonLabelText = @"Prove it".uppercaseString;
             cell.displayCampaignDetailsView = YES;
         }
         else {
-            // @todo: Rename this property, since it's the Signup button now
-            cell.displaySubmitReportbackButton = YES;
+            cell.displayActionButton = YES;
+            cell.actionButtonLabelText = @"Do this now".uppercaseString;
             cell.displayCampaignDetailsView = NO;
         }
     }
@@ -229,7 +230,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 #pragma mark - LDTCampaignListCampaignCellDelegate
 
 
-- (void)didClickSubmitReportbackButtonForCell:(LDTCampaignDetailCampaignCell *)cell {
+- (void)didClickActionButtonForCell:(LDTCampaignDetailCampaignCell *)cell {
 
     if (![[self user] isDoingCampaign:self.campaign]) {
         [SVProgressHUD showWithStatus:@"Signing up..."];

--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -168,6 +168,8 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     cell.solutionCopyLabelText = self.campaign.solutionCopy;
     cell.solutionSupportCopyLabelText = self.campaign.solutionSupportCopy;
     cell.coverImageURL = self.campaign.coverImageURL;
+    cell.campaignDetailsHeadingLabelText = @"Do this".uppercaseString;
+    cell.staticInstructionLabelText = @"When you’re done, submit a pic of yourself in action. #picsoritdidnthappen";
 
     if ([[self user] hasCompletedCampaign:self.campaign]) {
         cell.displaySubmitReportbackButton = NO;

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.h
@@ -15,8 +15,12 @@
 @property (nonatomic, assign) BOOL displayCampaignDetailsView;
 @property (assign, nonatomic) BOOL displaySubmitReportbackButton;
 @property (strong, nonatomic) DSOCampaign *campaign;
+
+@property (strong, nonatomic) NSString *actionButtonLabelText;
+@property (strong, nonatomic) NSString *campaignDetailsHeadingLabelText;
 @property (strong, nonatomic) NSString *solutionCopyLabelText;
 @property (strong, nonatomic) NSString *solutionSupportCopyLabelText;
+@property (strong, nonatomic) NSString *staticInstructionLabelText;
 @property (strong, nonatomic) NSString *titleLabelText;
 @property (strong, nonatomic) NSString *taglineLabelText;
 @property (strong, nonatomic) NSURL *coverImageURL;

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.h
@@ -12,6 +12,7 @@
 
 @property (weak, nonatomic) id<LDTCampaignDetailCampaignCellDelegate> delegate;
 
+@property (nonatomic, assign) BOOL displayCampaignDetailsView;
 @property (assign, nonatomic) BOOL displaySubmitReportbackButton;
 @property (strong, nonatomic) DSOCampaign *campaign;
 @property (strong, nonatomic) NSString *solutionCopyLabelText;

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.h
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.h
@@ -13,7 +13,7 @@
 @property (weak, nonatomic) id<LDTCampaignDetailCampaignCellDelegate> delegate;
 
 @property (nonatomic, assign) BOOL displayCampaignDetailsView;
-@property (assign, nonatomic) BOOL displaySubmitReportbackButton;
+@property (assign, nonatomic) BOOL displayActionButton;
 @property (strong, nonatomic) DSOCampaign *campaign;
 
 @property (strong, nonatomic) NSString *actionButtonLabelText;
@@ -30,6 +30,6 @@
 @protocol LDTCampaignDetailCampaignCellDelegate <NSObject>
 
 @required
-- (void)didClickSubmitReportbackButtonForCell:(LDTCampaignDetailCampaignCell *)cell;
+- (void)didClickActionButtonForCell:(LDTCampaignDetailCampaignCell *)cell;
 
 @end

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
@@ -11,6 +11,8 @@
 
 @interface LDTCampaignDetailCampaignCell ()
 
+@property (strong, nonatomic) CAShapeLayer *diagonalShapeLayer;
+
 @property (weak, nonatomic) IBOutlet UIImageView *coverImageView;
 @property (weak, nonatomic) IBOutlet UILabel *campaignDetailsHeadingLabel;
 @property (weak, nonatomic) IBOutlet UILabel *solutionCopyLabel;
@@ -41,6 +43,16 @@
     [super awakeFromNib];
 
     [self styleView];
+
+    self.diagonalShapeLayer = [CAShapeLayer layer];
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0,0)];
+    [path addLineToPoint:CGPointMake(0, 26)];
+    [path addLineToPoint:CGPointMake(CGRectGetWidth([UIScreen mainScreen].bounds), 0)];
+    [path closePath];
+    self.diagonalShapeLayer.path = path.CGPath;
+    self.diagonalShapeLayer.fillColor = UIColor.whiteColor.CGColor;
+    [self.campaignDetailsView.layer addSublayer:self.diagonalShapeLayer];
 }
 
 - (void)layoutSubviews {
@@ -95,32 +107,26 @@
 - (void)setDisplayCampaignDetailsView:(BOOL)displayCampaignDetailsView {
     _displayCampaignDetailsView = displayCampaignDetailsView;
     if (!_displayCampaignDetailsView) {
+        self.diagonalShapeLayer.hidden = YES;
         // Hack to avoid UILabels preventing  campaignDetailsView from fully collapsing.
         self.campaignDetailsHeadingLabel.text = @"";
-        self.campaignDetailsHeadlineTopConstraint.constant = 0;
         self.solutionCopyLabel.text = @"";
-        self.solutionCopyLabelTopConstraint.constant = 0;
         self.solutionSupportCopyLabel.text = @"";
-        self.solutionSupportCopyLabelTopConstraint.constant = 0;
         self.staticInstructionLabel.text = @"";
+        self.campaignDetailsHeadlineTopConstraint.constant = 0;
+        self.solutionCopyLabelTopConstraint.constant = 0;
+        self.solutionSupportCopyLabelTopConstraint.constant = 0;
         self.staticInstructionLabelTopConstraint.constant = 0;
         self.staticInstructionLabelBottomConstraint.constant = 0;
     }
     else {
+        self.diagonalShapeLayer.hidden = NO;
         self.campaignDetailsHeadlineTopConstraint.constant = 41;
         self.solutionCopyLabelTopConstraint.constant = 18;
         self.solutionSupportCopyLabelTopConstraint.constant = 18;
         self.staticInstructionLabelTopConstraint.constant = 18;
         self.staticInstructionLabelBottomConstraint.constant = 12;
-        CAShapeLayer *layer = [CAShapeLayer layer];
-        UIBezierPath *path = [UIBezierPath bezierPath];
-        [path moveToPoint:CGPointMake(0,0)];
-        [path addLineToPoint:CGPointMake(0, 26)];
-        [path addLineToPoint:CGPointMake(CGRectGetWidth([UIScreen mainScreen].bounds), 0)];
-        [path closePath];
-        layer.path = path.CGPath;
-        layer.fillColor = UIColor.whiteColor.CGColor;
-        [self.campaignDetailsView.layer addSublayer:layer];
+
     }
 }
 

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
@@ -85,11 +85,14 @@
     self.staticInstructionLabel.font = LDTTheme.font;
     [self.submitReportbackButton enable:YES];
 
-
     self.coverImageView.layer.masksToBounds = NO;
     self.coverImageView.layer.shadowOffset = CGSizeMake(0, 5);
     self.coverImageView.layer.shadowRadius = 0.8f;
     self.coverImageView.layer.shadowOpacity = 0.3;
+}
+
+- (void)setActionButtonLabelText:(NSString *)actionButtonLabelText {
+    [self.submitReportbackButton setTitle:actionButtonLabelText forState:UIControlStateNormal];
 }
 
 - (void)setCampaignDetailsHeadingLabelText:(NSString *)campaignDetailsHeadingLabelText {
@@ -130,11 +133,9 @@
     }
 }
 
-- (void)setDisplaySubmitReportbackButton:(BOOL)displaySubmitReportbackButton {
-    _displaySubmitReportbackButton = displaySubmitReportbackButton;
-    if (displaySubmitReportbackButton) {
-        // @todo: Create public SubmitReportbackButtonTitle property.
-        [self.submitReportbackButton setTitle:@"Prove it".uppercaseString forState:UIControlStateNormal];
+- (void)setDisplayActionButton:(BOOL)displayActionButton {
+    _displayActionButton = displayActionButton;
+    if (displayActionButton) {
         self.submitReportbackButtonBottomConstraint.constant = 16;
         self.submitReportbackButtonTopConstraint.constant = 16;
         self.submitReportbackButtonHeightConstraint.constant = 50;
@@ -146,7 +147,6 @@
         self.submitReportbackButtonHeightConstraint.constant = 0;
         self.submitReportbackButton.hidden = YES;
     }
-    
 }
 
 - (void)setSolutionCopyLabelText:(NSString *)solutionCopyLabelText {
@@ -170,8 +170,8 @@
 }
 
 - (IBAction)submitReportbackButtonTouchUpInside:(id)sender {
-    if (self.delegate && [self.delegate respondsToSelector:@selector(didClickSubmitReportbackButtonForCell:)]) {
-        [self.delegate didClickSubmitReportbackButtonForCell:self];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(didClickActionButtonForCell:)]) {
+        [self.delegate didClickActionButtonForCell:self];
     }
 }
 

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
@@ -95,6 +95,24 @@
     }];
 }
 
+- (void)setDisplayCampaignDetailsView:(BOOL)displayCampaignDetailsView {
+    _displayCampaignDetailsView = displayCampaignDetailsView;
+    if (!_displayCampaignDetailsView) {
+        self.campaignDetailsHeadingLabel.text = @"";
+        self.solutionCopyLabel.text = @"";
+        self.solutionSupportCopyLabel.text = @"";
+        self.staticInstructionLabel.text = @"";
+        self.campaignDetailsView.hidden = YES;
+    }
+    else {
+        self.campaignDetailsHeadingLabel.hidden = NO;
+        self.solutionCopyLabel.hidden = NO;
+        self.solutionSupportCopyLabel.hidden = NO;
+        self.staticInstructionLabel.hidden = NO;
+        self.campaignDetailsView.hidden = NO;
+    }
+}
+
 - (void)setDisplaySubmitReportbackButton:(BOOL)displaySubmitReportbackButton {
     _displaySubmitReportbackButton = displaySubmitReportbackButton;
     if (displaySubmitReportbackButton) {

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.m
@@ -23,6 +23,11 @@
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *submitReportbackButtonTopConstraint;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *submitReportbackButtonBottomConstraint;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *submitReportbackButtonHeightConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *campaignDetailsHeadlineTopConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *solutionSupportCopyLabelTopConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *solutionCopyLabelTopConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *staticInstructionLabelTopConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *staticInstructionLabelBottomConstraint;
 
 - (IBAction)submitReportbackButtonTouchUpInside:(id)sender;
 
@@ -36,9 +41,6 @@
     [super awakeFromNib];
 
     [self styleView];
-
-    self.campaignDetailsHeadingLabel.text = @"Do this".uppercaseString;
-    self.staticInstructionLabel.text = @"When you’re done, submit a pic of yourself in action. #picsoritdidnthappen";
 }
 
 - (void)layoutSubviews {
@@ -71,20 +73,15 @@
     self.staticInstructionLabel.font = LDTTheme.font;
     [self.submitReportbackButton enable:YES];
 
-    CAShapeLayer *layer = [CAShapeLayer layer];
-    UIBezierPath *path = [UIBezierPath bezierPath];
-    [path moveToPoint:CGPointMake(0,0)];
-    [path addLineToPoint:CGPointMake(0, 26)];
-    [path addLineToPoint:CGPointMake(CGRectGetWidth([UIScreen mainScreen].bounds), 0)];
-    [path closePath];
-    layer.path = path.CGPath;
-    layer.fillColor = UIColor.whiteColor.CGColor;
-    [self.campaignDetailsView.layer addSublayer:layer];
 
     self.coverImageView.layer.masksToBounds = NO;
     self.coverImageView.layer.shadowOffset = CGSizeMake(0, 5);
     self.coverImageView.layer.shadowRadius = 0.8f;
     self.coverImageView.layer.shadowOpacity = 0.3;
+}
+
+- (void)setCampaignDetailsHeadingLabelText:(NSString *)campaignDetailsHeadingLabelText {
+    self.campaignDetailsHeadingLabel.text = campaignDetailsHeadingLabelText;
 }
 
 - (void)setCoverImageURL:(NSURL *)coverImageURL {
@@ -98,18 +95,32 @@
 - (void)setDisplayCampaignDetailsView:(BOOL)displayCampaignDetailsView {
     _displayCampaignDetailsView = displayCampaignDetailsView;
     if (!_displayCampaignDetailsView) {
+        // Hack to avoid UILabels preventing  campaignDetailsView from fully collapsing.
         self.campaignDetailsHeadingLabel.text = @"";
+        self.campaignDetailsHeadlineTopConstraint.constant = 0;
         self.solutionCopyLabel.text = @"";
+        self.solutionCopyLabelTopConstraint.constant = 0;
         self.solutionSupportCopyLabel.text = @"";
+        self.solutionSupportCopyLabelTopConstraint.constant = 0;
         self.staticInstructionLabel.text = @"";
-        self.campaignDetailsView.hidden = YES;
+        self.staticInstructionLabelTopConstraint.constant = 0;
+        self.staticInstructionLabelBottomConstraint.constant = 0;
     }
     else {
-        self.campaignDetailsHeadingLabel.hidden = NO;
-        self.solutionCopyLabel.hidden = NO;
-        self.solutionSupportCopyLabel.hidden = NO;
-        self.staticInstructionLabel.hidden = NO;
-        self.campaignDetailsView.hidden = NO;
+        self.campaignDetailsHeadlineTopConstraint.constant = 41;
+        self.solutionCopyLabelTopConstraint.constant = 18;
+        self.solutionSupportCopyLabelTopConstraint.constant = 18;
+        self.staticInstructionLabelTopConstraint.constant = 18;
+        self.staticInstructionLabelBottomConstraint.constant = 12;
+        CAShapeLayer *layer = [CAShapeLayer layer];
+        UIBezierPath *path = [UIBezierPath bezierPath];
+        [path moveToPoint:CGPointMake(0,0)];
+        [path addLineToPoint:CGPointMake(0, 26)];
+        [path addLineToPoint:CGPointMake(CGRectGetWidth([UIScreen mainScreen].bounds), 0)];
+        [path closePath];
+        layer.path = path.CGPath;
+        layer.fillColor = UIColor.whiteColor.CGColor;
+        [self.campaignDetailsView.layer addSublayer:layer];
     }
 }
 
@@ -138,6 +149,10 @@
 
 - (void)setSolutionSupportCopyLabelText:(NSString *)solutionSupportCopyLabelText {
     self.solutionSupportCopyLabel.text = solutionSupportCopyLabelText;
+}
+
+- (void)setStaticInstructionLabelText:(NSString *)staticInstructionLabelText {
+    self.staticInstructionLabel.text = staticInstructionLabelText;
 }
 
 - (void)setTaglineLabelText:(NSString *)taglineLabelText {

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
@@ -127,11 +127,16 @@
             </variation>
             <connections>
                 <outlet property="campaignDetailsHeadingLabel" destination="Wux-hK-art" id="pkY-Ae-6qR"/>
+                <outlet property="campaignDetailsHeadlineTopConstraint" destination="spp-hp-cK5" id="z5A-WY-lRw"/>
                 <outlet property="campaignDetailsView" destination="jAl-nc-WCh" id="dRP-Ih-jSy"/>
                 <outlet property="coverImageView" destination="SPy-df-4JQ" id="DSJ-E6-E2J"/>
                 <outlet property="solutionCopyLabel" destination="4Es-nC-OvU" id="Ddt-ol-KAI"/>
+                <outlet property="solutionCopyLabelTopConstraint" destination="aHT-xc-8tL" id="IaB-Dk-ONV"/>
                 <outlet property="solutionSupportCopyLabel" destination="2EF-2e-0yi" id="T8D-bW-T4r"/>
+                <outlet property="solutionSupportCopyLabelTopConstraint" destination="geB-jW-LYf" id="8eT-64-FMn"/>
                 <outlet property="staticInstructionLabel" destination="GEn-tp-NCH" id="xyU-Pp-9JC"/>
+                <outlet property="staticInstructionLabelBottomConstraint" destination="lb3-RT-54y" id="Bye-5N-hef"/>
+                <outlet property="staticInstructionLabelTopConstraint" destination="k5O-fU-OUg" id="vPS-yy-fQL"/>
                 <outlet property="submitReportbackButton" destination="9sq-x9-XyP" id="7Co-Jo-DoW"/>
                 <outlet property="submitReportbackButtonBottomConstraint" destination="eXa-aM-Xuw" id="oBK-Sz-Mji"/>
                 <outlet property="submitReportbackButtonHeightConstraint" destination="bjh-IU-c9b" id="b0L-hl-FSm"/>

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
@@ -89,7 +89,7 @@
                             <constraint firstItem="Wux-hK-art" firstAttribute="top" secondItem="jAl-nc-WCh" secondAttribute="top" constant="41" identifier="headingTop" id="spp-hp-cK5"/>
                         </constraints>
                     </view>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9sq-x9-XyP" customClass="LDTButton">
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9sq-x9-XyP" userLabel="Action Button" customClass="LDTButton">
                         <rect key="frame" x="8" y="501" width="369" height="50"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="50" id="bjh-IU-c9b"/>

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
@@ -54,13 +54,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="995" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Static Instructions" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GEn-tp-NCH">
-                                <rect key="frame" x="8" y="158" width="369" height="28"/>
+                                <rect key="frame" x="8" y="165" width="369" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="996" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Solution Support Copy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2EF-2e-0yi">
-                                <rect key="frame" x="8" y="119" width="369" height="21"/>
+                                <rect key="frame" x="8" y="126" width="369" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -83,7 +83,7 @@
                             <constraint firstAttribute="trailing" secondItem="2EF-2e-0yi" secondAttribute="trailing" constant="8" id="b7U-p9-wIL"/>
                             <constraint firstItem="4Es-nC-OvU" firstAttribute="leading" secondItem="jAl-nc-WCh" secondAttribute="leading" constant="8" id="bvR-94-cP7"/>
                             <constraint firstAttribute="trailing" secondItem="GEn-tp-NCH" secondAttribute="trailing" constant="8" id="fTH-XX-WbX"/>
-                            <constraint firstItem="2EF-2e-0yi" firstAttribute="top" secondItem="4Es-nC-OvU" secondAttribute="bottom" constant="18" identifier="solutionSupportTop" id="geB-jW-LYf"/>
+                            <constraint firstItem="2EF-2e-0yi" firstAttribute="top" secondItem="4Es-nC-OvU" secondAttribute="bottom" priority="750" constant="18" identifier="solutionSupportTop" id="geB-jW-LYf"/>
                             <constraint firstItem="GEn-tp-NCH" firstAttribute="top" secondItem="2EF-2e-0yi" secondAttribute="bottom" constant="18" identifier="staticInstructionTop" id="k5O-fU-OUg"/>
                             <constraint firstAttribute="bottom" secondItem="GEn-tp-NCH" secondAttribute="bottom" constant="12" identifier="staticInstructionBottom" id="lb3-RT-54y"/>
                             <constraint firstItem="Wux-hK-art" firstAttribute="top" secondItem="jAl-nc-WCh" secondAttribute="top" constant="41" identifier="headingTop" id="spp-hp-cK5"/>

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -18,17 +18,14 @@
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SPy-df-4JQ" userLabel="Campaign Image">
                                 <rect key="frame" x="0.0" y="0.0" width="385" height="242"/>
-                                <animations/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xzc-iv-ilv" userLabel="Campaign Title">
                                 <rect key="frame" x="21" y="210" width="343" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="SPy-df-4JQ" firstAttribute="top" secondItem="3QF-fG-65U" secondAttribute="top" id="3hw-se-aEQ"/>
@@ -43,7 +40,6 @@
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Tagline" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AS3-o6-YFe">
                         <rect key="frame" x="21" y="258" width="343" height="21"/>
-                        <animations/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
@@ -53,34 +49,29 @@
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="998" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Do It" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wux-hK-art" userLabel="Do It Headline">
                                 <rect key="frame" x="8" y="41" width="369" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="996" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Solution Copy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Es-nC-OvU">
                                 <rect key="frame" x="8" y="80" width="369" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="995" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Static Instructions" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GEn-tp-NCH">
                                 <rect key="frame" x="8" y="158" width="369" height="28"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="996" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Solution Support Copy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2EF-2e-0yi">
                                 <rect key="frame" x="8" y="119" width="369" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="Wux-hK-art" secondAttribute="trailing" constant="8" id="5Iq-PK-V6P"/>
@@ -100,7 +91,6 @@
                     </view>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9sq-x9-XyP" customClass="LDTButton">
                         <rect key="frame" x="8" y="501" width="369" height="50"/>
-                        <animations/>
                         <constraints>
                             <constraint firstAttribute="height" constant="50" id="bjh-IU-c9b"/>
                         </constraints>
@@ -110,10 +100,8 @@
                         </connections>
                     </button>
                 </subviews>
-                <animations/>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
-            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="AS3-o6-YFe" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="21" id="00i-E4-fPE"/>

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
@@ -47,12 +47,6 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jAl-nc-WCh" userLabel="Do It Container View">
                         <rect key="frame" x="0.0" y="287" width="385" height="198"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="998" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Do It" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wux-hK-art" userLabel="Do It Headline">
-                                <rect key="frame" x="8" y="41" width="369" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="996" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Solution Copy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Es-nC-OvU">
                                 <rect key="frame" x="8" y="80" width="369" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -71,6 +65,12 @@
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="998" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Do It" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wux-hK-art" userLabel="Do It Headline">
+                                <rect key="frame" x="8" y="41" width="369" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -79,14 +79,14 @@
                             <constraint firstItem="GEn-tp-NCH" firstAttribute="leading" secondItem="jAl-nc-WCh" secondAttribute="leading" constant="8" id="Vf6-2t-0mu"/>
                             <constraint firstItem="2EF-2e-0yi" firstAttribute="leading" secondItem="jAl-nc-WCh" secondAttribute="leading" constant="8" id="Xgd-Px-DHc"/>
                             <constraint firstAttribute="trailing" secondItem="4Es-nC-OvU" secondAttribute="trailing" constant="8" id="YP0-y1-W9f"/>
-                            <constraint firstItem="4Es-nC-OvU" firstAttribute="top" secondItem="Wux-hK-art" secondAttribute="bottom" constant="18" id="aHT-xc-8tL"/>
+                            <constraint firstItem="4Es-nC-OvU" firstAttribute="top" secondItem="Wux-hK-art" secondAttribute="bottom" constant="18" identifier="solutionCopyTop" id="aHT-xc-8tL"/>
                             <constraint firstAttribute="trailing" secondItem="2EF-2e-0yi" secondAttribute="trailing" constant="8" id="b7U-p9-wIL"/>
                             <constraint firstItem="4Es-nC-OvU" firstAttribute="leading" secondItem="jAl-nc-WCh" secondAttribute="leading" constant="8" id="bvR-94-cP7"/>
                             <constraint firstAttribute="trailing" secondItem="GEn-tp-NCH" secondAttribute="trailing" constant="8" id="fTH-XX-WbX"/>
-                            <constraint firstItem="2EF-2e-0yi" firstAttribute="top" secondItem="4Es-nC-OvU" secondAttribute="bottom" constant="18" id="geB-jW-LYf"/>
-                            <constraint firstItem="GEn-tp-NCH" firstAttribute="top" secondItem="2EF-2e-0yi" secondAttribute="bottom" constant="18" id="k5O-fU-OUg"/>
-                            <constraint firstAttribute="bottom" secondItem="GEn-tp-NCH" secondAttribute="bottom" constant="12" id="lb3-RT-54y"/>
-                            <constraint firstItem="Wux-hK-art" firstAttribute="top" secondItem="jAl-nc-WCh" secondAttribute="top" constant="41" id="spp-hp-cK5"/>
+                            <constraint firstItem="2EF-2e-0yi" firstAttribute="top" secondItem="4Es-nC-OvU" secondAttribute="bottom" constant="18" identifier="solutionSupportTop" id="geB-jW-LYf"/>
+                            <constraint firstItem="GEn-tp-NCH" firstAttribute="top" secondItem="2EF-2e-0yi" secondAttribute="bottom" constant="18" identifier="staticInstructionTop" id="k5O-fU-OUg"/>
+                            <constraint firstAttribute="bottom" secondItem="GEn-tp-NCH" secondAttribute="bottom" constant="12" identifier="staticInstructionBottom" id="lb3-RT-54y"/>
+                            <constraint firstItem="Wux-hK-art" firstAttribute="top" secondItem="jAl-nc-WCh" secondAttribute="top" constant="41" identifier="headingTop" id="spp-hp-cK5"/>
                         </constraints>
                     </view>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9sq-x9-XyP" customClass="LDTButton">


### PR DESCRIPTION
Refs #697: Implements self sizing Campaign Detail presignup cell 

Refs https://github.com/DoSomething/LetsDoThis-iOS/pull/701#issuecomment-166373083 -- Use the `LDTCampaignDetailCampaignCell` (which is currently self sizing) to render the presignup view (by collapsing the Do It Container `UIView`). 

## Update

This is working! Used the ol' priority trick to fix original edge case scenario where constraints break.

## Original description

This seems to work great except I can get the layouts to break with the following steps:

* Navigate to the "Comics to the Rescue" campaign presignup view
* Signup, then reportback - all without leaving the screen. The constraints will break (error pasted below)

Doesn't happen for other campaigns -- Comics to the Rescue has a ton of content. Also the error doesn't happen when you navigate to the Campaign Detail upon already signing up. 

Opening this PR for review / debugging.