### PR TITLE
[do not merge] add parse registration of parse_installation_id to northstar on session start, remove id upon logout

### DIFF
--- a/Lets Do This/Classes/AppDelegate.m
+++ b/Lets Do This/Classes/AppDelegate.m
@@ -92,6 +92,12 @@
     [currentInstallation setDeviceTokenFromData:deviceToken];
     currentInstallation.channels = @[ @"global" ];
     [currentInstallation saveInBackground];
+    // Store deviceToken to disk
+    NSString *deviceTokenString = [[[NSString stringWithFormat:@"%@", deviceToken] stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"<>"]] stringByReplacingOccurrencesOfString:@" " withString:@""];
+    NSLog(@"***Device Token:*** \n %@", deviceTokenString);
+    
+    [[NSUserDefaults standardUserDefaults] setObject:deviceTokenString forKey:@"deviceToken"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -20,6 +20,7 @@
 @property (nonatomic, strong, readonly) NSString *email;
 @property (nonatomic, strong, readonly) NSString *firstName;
 @property (nonatomic, strong, readonly) NSString *mobile;
+@property (nonatomic, strong, readonly) NSArray *parseInstallationIds;
 @property (nonatomic, strong, readonly) NSString *sessionToken;
 @property (nonatomic, strong, readonly) NSString *userID;
 @property (nonatomic, strong, readonly) UIImage *photo;

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -19,6 +19,7 @@
 @property (nonatomic, strong, readwrite) NSString *email;
 @property (nonatomic, strong, readwrite) NSString *firstName;
 @property (nonatomic, strong, readwrite) NSString *mobile;
+@property (nonatomic, strong, readwrite) NSArray *parseInstallationIds;
 @property (nonatomic, strong, readwrite) NSString *sessionToken;
 @property (nonatomic, strong, readwrite) NSString *userID;
 @property (nonatomic, strong, readwrite) UIImage *photo;
@@ -43,6 +44,7 @@
         }
         _firstName = [dict valueForKeyAsString:@"first_name" nullValue:@"Doer"];
         _email = dict[@"email"];
+        _parseInstallationIds = dict[@"parse_installation_ids"];
         _sessionToken = dict[@"session_token"];
         _mutableCampaignSignups = [[NSMutableArray alloc] init];
 		


### PR DESCRIPTION
#### What's this PR do?
In service of incorporating push notifications in the future, this adds the parse installation id (also known as the device token or device id) to the user's Northstar profile when the user session begins. 

Also removes the parse installation id from the user's Northstar profile when she logs out. 

Note that this PR depends on the `parse_installation_ids` value on the user object returned from Northstar to be an array. While it appears that this is supported, the [`PUT` update user endpoint on Northstar currently doesn't appear to accept an array as a value for the `parse_installation_ids` key.](https://github.com/DoSomething/northstar/issues/250) **Given this, this PR has not yet been tested, and should not be merged in.**

#### How should this be manually tested?
Note that there are two routes for a user's Northstar profile to have her `parse_installation_ids` param be updated. First, when a user first creates an account on the app. Secondly, when a user has created an account on the web, and logs in to her account on the mobile app for the first time. 

In the first case, her profile will include a completed `parse_installation_ids` field when it's first created. 

This functionality has been tested by creating a new user, and it works. (Note that this functionality updates that property by submitting a string, not an array.) 

In the second case, we first check her account for the existence of the `parse_installation_ids` field (attached to the `parseInstallationIds` property on the `DSOUser` object later) when her user information is loaded. If that field doesn't contain the current device's installation ID, we make another call to update her user profile. 

Because the user may have logged onto the app on multiple devices, her `parse_installation_ids` field needs to be able to hold multiple ids. But Northstar doesn't seem to be able to handle that field as an array, just yet. So we haven't been able to test this second case of updating the field. 

#### Any background context you want to provide?
Note that while we're deleting the parse installation ID from Northstar on logout, we're not clearing the `deviceToken` stored on disk, since each `deviceToken` is unique to the app installation. Thus, we can reuse this `deviceToken` across multiple user accounts. 
#### What are the relevant tickets?
Refs #45. 