### PR TITLE
ReportbackItemDetailView -(CGFloat)heightForWidth:width

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 @property (strong, nonatomic) DSOCampaign *campaign;
 @property (strong, nonatomic) DSOReportbackItem *currentUserReportback;
 @property (strong, nonatomic) LDTCampaignDetailCampaignCell *campaignSizingCell;
+@property (strong, nonatomic) LDTCampaignDetailReportbackItemCell *reportbackItemSizingCell;
 @property (strong, nonatomic) NSMutableArray *reportbackItems;
 @property (strong, nonatomic) UICollectionViewFlowLayout *flowLayout;
 @property (strong, nonatomic) UIImagePickerController *imagePickerController;
@@ -64,9 +65,12 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     [self.collectionView registerNib:[UINib nibWithNibName:@"LDTCampaignDetailCampaignCell" bundle:nil] forCellWithReuseIdentifier:@"CampaignCell"];
     [self.collectionView registerNib:[UINib nibWithNibName:@"LDTCampaignDetailReportbackItemCell" bundle:nil] forCellWithReuseIdentifier:@"ReportbackItemCell"];
     [self.collectionView registerNib:[UINib nibWithNibName:@"LDTHeaderCollectionReusableView" bundle:nil] forSupplementaryViewOfKind:UICollectionElementKindSectionHeader withReuseIdentifier:@"ReusableView"];
-    // Create a dummy sizing cell to determine dynamic CampaignCell height.
+
+    // Create dummy sizing cells to determine dynamic  heights.
     UINib *campaignCellNib = [UINib nibWithNibName:@"LDTCampaignDetailCampaignCell" bundle:nil];
     self.campaignSizingCell = [[campaignCellNib instantiateWithOwner:nil options:nil] firstObject];
+    UINib *reportbackItemCellNib = [UINib nibWithNibName:@"LDTCampaignDetailReportbackItemCell" bundle:nil];
+    self.reportbackItemSizingCell = [[reportbackItemCellNib instantiateWithOwner:nil options:nil] firstObject];
 
     self.flowLayout = [[UICollectionViewFlowLayout alloc] init];
     self.flowLayout.minimumInteritemSpacing = 0.0f;
@@ -330,9 +334,6 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath{
     CGFloat screenWidth = [[UIScreen mainScreen] bounds].size.width;
-    // Square reportback photo + header height + caption height.
-    CGFloat reportbackItemHeight = screenWidth + 36 + 70 + 8;
-
     if (indexPath.section == LDTCampaignDetailSectionTypeCampaign) {
         if (indexPath.row == LDTCampaignDetailCampaignSectionRowCampaign) {
             [self configureCampaignCell:self.campaignSizingCell];
@@ -342,18 +343,9 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
             CGFloat campaignCellHeight = [self.campaignSizingCell.contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
             return CGSizeMake(screenWidth, campaignCellHeight);
         }
-        else {
-            if ([[self user] hasCompletedCampaign:self.campaign]) {
-                // Add 66 for the Share Photo button.
-                return CGSizeMake(screenWidth, reportbackItemHeight + 66);
-            }
-            else {
-                // Action Button cell:
-                // Button height (50) + top and bottom margins (2 * 16) = 82
-                return CGSizeMake(screenWidth, 82);
-            }
-        }
     }
+    [self configureReportbackItemCell:self.reportbackItemSizingCell forIndexPath:indexPath];
+    CGFloat reportbackItemHeight = [self.reportbackItemSizingCell.detailView heightForWidth:screenWidth];
 
     return CGSizeMake(screenWidth, reportbackItemHeight);
 }

--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -156,8 +156,8 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     NSArray *statusValues = @[@"promoted", @"approved"];
     for (NSString *status in statusValues) {
         [[DSOAPI sharedInstance] loadReportbackItemsForCampaigns:@[self.campaign] status:status completionHandler:^(NSArray *rbItems) {
-		[self.reportbackItems addObjectsFromArray:rbItems];
-        [self.collectionView reloadData];
+            [self.reportbackItems addObjectsFromArray:rbItems];
+            [self.collectionView reloadData];
         } errorHandler:^(NSError *error) {
             [LDTMessage displayErrorMessageForError:error];
         }];
@@ -334,19 +334,17 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath{
     CGFloat screenWidth = [[UIScreen mainScreen] bounds].size.width;
-    if (indexPath.section == LDTCampaignDetailSectionTypeCampaign) {
-        if (indexPath.row == LDTCampaignDetailCampaignSectionRowCampaign) {
-            [self configureCampaignCell:self.campaignSizingCell];
-            self.campaignSizingCell.frame = CGRectMake(0, 0, CGRectGetWidth(self.collectionView.bounds), CGRectGetHeight(self.campaignSizingCell.frame));
-            [self.campaignSizingCell setNeedsLayout];
-            [self.campaignSizingCell layoutIfNeeded];
-            CGFloat campaignCellHeight = [self.campaignSizingCell.contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
-            return CGSizeMake(screenWidth, campaignCellHeight);
-        }
+    if (indexPath.section == LDTCampaignDetailSectionTypeCampaign && indexPath.row == LDTCampaignDetailCampaignSectionRowCampaign) {
+        [self configureCampaignCell:self.campaignSizingCell];
+        self.campaignSizingCell.frame = CGRectMake(0, 0, CGRectGetWidth(self.collectionView.bounds), CGRectGetHeight(self.campaignSizingCell.frame));
+        [self.campaignSizingCell setNeedsLayout];
+        [self.campaignSizingCell layoutIfNeeded];
+        CGFloat campaignCellHeight = [self.campaignSizingCell.contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
+        return CGSizeMake(screenWidth, campaignCellHeight);
     }
+
     [self configureReportbackItemCell:self.reportbackItemSizingCell forIndexPath:indexPath];
     CGFloat reportbackItemHeight = [self.reportbackItemSizingCell.detailView heightForWidth:screenWidth];
-
     return CGSizeMake(screenWidth, reportbackItemHeight);
 }
 

--- a/Lets Do This/Controllers/Profile/LDTProfileViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTProfileViewController.m
@@ -22,6 +22,7 @@
 
 @property (assign, nonatomic) BOOL isCurrentUserProfile;
 @property (assign, nonatomic) BOOL isProfileLoaded;
+@property (strong, nonatomic) LDTProfileReportbackItemTableViewCell *reportbackItemSizingCell;
 @property (strong, nonatomic) NSMutableArray *campaignsDoing;
 @property (strong, nonatomic) NSMutableArray *campaignsCompleted;
 @property (strong, nonatomic) UIImagePickerController *imagePickerController;
@@ -69,6 +70,9 @@ typedef NS_ENUM(NSInteger, LDTProfileSectionType) {
     [self.tableView registerNib:[UINib nibWithNibName:@"LDTProfileCampaignTableViewCell" bundle:nil] forCellReuseIdentifier:@"campaignCell"];
     [self.tableView registerNib:[UINib nibWithNibName:@"LDTProfileReportbackItemTableViewCell" bundle:nil] forCellReuseIdentifier:@"reportbackItemCell"];
     [self.tableView registerNib:[UINib nibWithNibName:@"LDTProfileNoSignupsTableViewCell" bundle:nil] forCellReuseIdentifier:@"noSignupsCell"];
+    UINib *reportbackItemCellNib = [UINib nibWithNibName:@"LDTProfileReportbackItemTableViewCell" bundle:nil];
+    self.reportbackItemSizingCell = [[reportbackItemCellNib instantiateWithOwner:nil options:nil] firstObject];
+
     self.tableView.estimatedRowHeight = 400.0;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
 
@@ -360,13 +364,19 @@ typedef NS_ENUM(NSInteger, LDTProfileSectionType) {
 
 #pragma mark -- UITableViewDelegate
 
-- (CGFloat)tableView:(UITableView *)tableView
-heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.section == LDTProfileSectionTypeCampaign) {
         if (self.isProfileLoaded && self.user.campaignSignups.count == 0) {
             // Render noSignupsCell as full height of remaining tableView.
             // @todo: Real math here, this is a guestimate.
             return self.tableView.bounds.size.height - 180;
+        }
+        DSOCampaignSignup *signup = self.user.campaignSignups[indexPath.row];
+        if (signup.reportbackItem) {
+            [self configureReportbackItemCell:self.reportbackItemSizingCell indexPath:indexPath];
+            CGFloat detailViewHeight = [self.reportbackItemSizingCell.detailView heightForWidth:self.tableView.frame.size.width];
+            // Add bottom padding / border UIView:
+            return detailViewHeight + 16;
         }
     }
     return UITableViewAutomaticDimension;

--- a/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.m
@@ -56,11 +56,6 @@
     [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"reportback-item/%ld", (long)self.reportbackItem.reportbackItemID]];
 }
 
-- (void)viewDidLayoutSubviews {
-    // Prevents vertically centered Caption UILabel http://stackoverflow.com/a/1054681/1470725
-    [self.reportbackItemDetailView sizeForDetailSingleView];
-}
-
 #pragma mark - LDTReportbackItemDetailSingleViewController
 
 

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
@@ -26,6 +26,7 @@
 @property (strong, nonatomic) UIImage *reportbackItemImage;
 @property (strong, nonatomic) UIImage *userAvatarImage;
 
+- (CGFloat)heightForWidth:(CGFloat)width;
 - (void)sizeForDetailSingleView;
 
 @end

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
@@ -26,8 +26,8 @@
 @property (strong, nonatomic) UIImage *reportbackItemImage;
 @property (strong, nonatomic) UIImage *userAvatarImage;
 
+// Returns the height to render the configured ReportbackItemDetailView for the given width, based on values the IBOutlets have been configured for.
 - (CGFloat)heightForWidth:(CGFloat)width;
-- (void)sizeForDetailSingleView;
 
 @end
 

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
@@ -129,4 +129,22 @@
     }
 }
 
+
+- (CGFloat)heightForWidth:(CGFloat)width {
+    // Reportback image should be square, so start with the width for rendering the image height.
+    // UserName button is 34 + 6 top constraint - 1 bottom constraint.
+    CGFloat height = width + 39;
+    // Campaign title button has a height constraint of 22 + top/bottom constraints of 8.
+    height += 22 + 8 + 8;
+    // Calculate captionSize height + bottom constraint of 8
+    CGRect captionSize = [self.reportbackItemCaptionLabel.text  boundingRectWithSize:CGSizeMake(width, 100) options:NSStringDrawingUsesLineFragmentOrigin attributes:@{NSFontAttributeName:self.reportbackItemCaptionLabel.font} context:nil];
+    height += captionSize.size.height + 8;
+    if (self.displayShareButton) {
+        // Share Button height is 50 + bottom constraint of 16
+        height += 50 + 16;
+    }
+
+    return height;
+}
+
 @end

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
@@ -56,10 +56,6 @@
     return self.reportbackItemImageView.image;
 }
 
-- (void)sizeForDetailSingleView {
-    [self.reportbackItemCaptionLabel sizeToFit];
-}
-
 - (void)setDisplayShareButton:(BOOL)displayShareButton {
     _displayShareButton = displayShareButton;
     if (!_displayShareButton) {

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.xib
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -13,7 +13,6 @@
                 <outlet property="reportbackItemImageView" destination="Msq-pA-qPX" id="TZZ-GR-l6k"/>
                 <outlet property="reportbackItemQuantityLabel" destination="oiQ-oe-SbM" id="I6W-5D-q6b"/>
                 <outlet property="shareButton" destination="VtQ-cH-UJE" id="2Eo-eY-fvh"/>
-                <outlet property="shareButtonBottomConstraint" destination="gxd-IF-1XT" id="WcV-Of-O7I"/>
                 <outlet property="shareButtonHeightConstraint" destination="Oaj-Kc-sQB" id="v8Z-cf-phj"/>
                 <outlet property="userAvatarImageView" destination="roJ-Pk-kPs" id="BFh-9f-Vdv"/>
                 <outlet property="userCountryNameLabel" destination="4AL-Sc-b9W" id="U3m-nA-WvY"/>
@@ -22,19 +21,20 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="804"/>
+            <rect key="frame" x="0.0" y="0.0" width="600" height="776"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Msq-pA-qPX" userLabel="ReportbackItem Image">
                     <rect key="frame" x="0.0" y="39" width="600" height="600"/>
-                    <animations/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="Msq-pA-qPX" secondAttribute="height" multiplier="1:1" id="aDt-iZ-Rb5"/>
                     </constraints>
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NhW-LK-kVz" userLabel="User Name Button">
                     <rect key="frame" x="63" y="6" width="421" height="34"/>
-                    <animations/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="34" id="ldD-jK-UsF"/>
+                    </constraints>
                     <state key="normal" title="User">
                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                     </state>
@@ -44,7 +44,6 @@
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cYz-Gq-gFn" userLabel="Campaign Title Button">
                     <rect key="frame" x="8" y="647" width="70" height="22"/>
-                    <animations/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="pBB-NJ-nXS"/>
                     </constraints>
@@ -57,7 +56,6 @@
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CountryName" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4AL-Sc-b9W" userLabel="User Country Name">
                     <rect key="frame" x="492" y="15" width="100" height="21"/>
-                    <animations/>
                     <constraints>
                         <constraint firstAttribute="width" constant="100" id="EqQ-bI-tav"/>
                         <constraint firstAttribute="height" constant="100" id="toa-OK-deD"/>
@@ -73,7 +71,6 @@
                 </label>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="roJ-Pk-kPs" userLabel="User Avatar Image">
                     <rect key="frame" x="8" y="8" width="50" height="50"/>
-                    <animations/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="IdX-HH-vVR"/>
                         <constraint firstAttribute="width" constant="50" id="cCJ-8F-uCk"/>
@@ -81,7 +78,6 @@
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Quantity Nouns Verbed" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oiQ-oe-SbM" userLabel="Reportback Quantity">
                     <rect key="frame" x="413" y="645" width="179" height="30"/>
-                    <animations/>
                     <constraints>
                         <constraint firstAttribute="height" constant="30" id="BK3-EE-fpv"/>
                     </constraints>
@@ -90,8 +86,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VtQ-cH-UJE" customClass="LDTButton">
-                    <rect key="frame" x="8" y="738" width="584" height="50"/>
-                    <animations/>
+                    <rect key="frame" x="8" y="706" width="584" height="50"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="Oaj-Kc-sQB"/>
                     </constraints>
@@ -101,14 +96,12 @@
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Caption" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uEZ-BR-iUW" userLabel="ReportbackItem Caption">
-                    <rect key="frame" x="8" y="677" width="584" height="53"/>
-                    <animations/>
+                    <rect key="frame" x="8" y="677" width="584" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="Msq-pA-qPX" firstAttribute="top" secondItem="NhW-LK-kVz" secondAttribute="bottom" constant="-1" id="13n-Q6-ZBN"/>
@@ -127,7 +120,6 @@
                 <constraint firstItem="roJ-Pk-kPs" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="ZgB-Tx-f2B"/>
                 <constraint firstItem="Msq-pA-qPX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="aDy-7E-nBS"/>
                 <constraint firstAttribute="trailing" secondItem="oiQ-oe-SbM" secondAttribute="trailing" constant="8" id="aOw-PB-RMJ"/>
-                <constraint firstAttribute="bottom" secondItem="VtQ-cH-UJE" secondAttribute="bottom" constant="16" id="gxd-IF-1XT"/>
                 <constraint firstItem="roJ-Pk-kPs" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="qp5-AW-wf0"/>
                 <constraint firstItem="NhW-LK-kVz" firstAttribute="leading" secondItem="roJ-Pk-kPs" secondAttribute="trailing" constant="5" id="qwY-wK-x0i"/>
                 <constraint firstItem="NhW-LK-kVz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="6" id="rQQ-Df-ewl"/>
@@ -141,7 +133,7 @@
                     <exclude reference="7ix-qC-6fK"/>
                 </mask>
             </variation>
-            <point key="canvasLocation" x="267" y="-397"/>
+            <point key="canvasLocation" x="267" y="-441"/>
         </view>
     </objects>
 </document>


### PR DESCRIPTION
Closes #697 - renders Reportback Items with dynamic height in the Campaign Detail view controller.

Instead of using iOS self sizing cells, we manually calculate the height based on xib values in a new `-(CGFloat)heightForWidth:width` method.

I've been fighting with getting a sizing cell to return the appropriate height (#687, #688, #694), but it keeps returning sizes that are too large (and the results vary upon each load, making it even trickier). 

Reviewed with @pixelrevision -- using good ol' math (similar to what we're already doing in the `LDTCampaignDetailViewController sizeForCellAtIndexPath:` iimplementation) seems just way more understandable and maintable at this point, vs fumbling around in the dark trying to get autolayout to magically calculate the numbers via `layoutSubviews`, `layoutIfNeeded`, etc.