### PR TITLE
Clickable avatars

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -369,7 +369,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
     [self presentViewController:sharePhotoActivityViewController animated:YES completion:nil];
 }
 
-- (void)didClickUserNameButtonForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView {
+- (void)didClickOnReportbackItemUserForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView {
     LDTProfileViewController *destVC = [[LDTProfileViewController alloc] initWithUser:reportbackItemDetailView.reportbackItem.user];
     [self.navigationController pushViewController:destVC animated:YES];
 }

--- a/Lets Do This/Controllers/Profile/LDTProfileViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTProfileViewController.m
@@ -276,7 +276,7 @@ typedef NS_ENUM(NSInteger, LDTProfileSectionType) {
     [self presentViewController:sharePhotoActivityViewController animated:YES completion:nil];
 }
 
-- (void)didClickUserNameButtonForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView {
+- (void)didClickOnReportbackItemUserForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView {
     return;
 }
 

--- a/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTReportbackItemDetailSingleViewController.m
@@ -80,7 +80,7 @@
     [self.navigationController pushViewController:destVC animated:YES];
 }
 
-- (void)didClickUserNameButtonForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView {
+- (void)didClickOnReportbackItemUserForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView {
     LDTProfileViewController *destVC = [[LDTProfileViewController alloc] initWithUser:self.reportbackItem.user];
 	
     [self.navigationController pushViewController:destVC animated:YES];

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.h
@@ -36,7 +36,7 @@
 @required
 - (void)didClickCampaignTitleButtonForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView;
 
-- (void)didClickUserNameButtonForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView;
+- (void)didClickOnReportbackItemUserForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView;
 
 @optional
 - (void)didClickShareButtonForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView;

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
@@ -120,8 +120,8 @@
 }
 
 - (IBAction)userNameButtonTouchUpInside:(id)sender {
-    if (self.delegate && [self.delegate respondsToSelector:@selector(didClickUserNameButtonForReportbackItemDetailView:)]) {
-        [self.delegate didClickUserNameButtonForReportbackItemDetailView:self];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(didClickOnReportbackItemUserForReportbackItemDetailView:)]) {
+        [self.delegate didClickOnReportbackItemUserForReportbackItemDetailView:self];
     }
 }
 

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
@@ -36,6 +36,8 @@
 
     [self styleView];
 
+    UITapGestureRecognizer *userAvatarTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleUserAvatarTap:)];
+    [self.userAvatarImageView addGestureRecognizer:userAvatarTap];
 }
 
 - (void)styleView {
@@ -101,6 +103,10 @@
 
 - (void)setUserCountryNameLabelText:(NSString *)userCountryNameLabelText {
     self.userCountryNameLabel.text = userCountryNameLabelText.uppercaseString;
+}
+
+- (void)handleUserAvatarTap:(UITapGestureRecognizer *)recognizer {
+    [self userNameButtonTouchUpInside:recognizer];
 }
 
 - (void)setUserDisplayNameButtonTitle:(NSString *)userDisplayNameButtonTitle {

--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.xib
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.xib
@@ -69,7 +69,7 @@
                         </mask>
                     </variation>
                 </label>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="roJ-Pk-kPs" userLabel="User Avatar Image">
+                <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="roJ-Pk-kPs" userLabel="User Avatar Image">
                     <rect key="frame" x="8" y="8" width="50" height="50"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="IdX-HH-vVR"/>


### PR DESCRIPTION
Fixes #683 - renames the `LDTReportbackItemDetailViewDelegate` method from `didClickUserNameButtonForReportbackItemDetailView:`  to `didClickOnReportbackItemUserForReportbackItemDetailView:` - which will get called upon tapping either the User Name or User Avatar. 

It seemed like unnecessary overhead to specify two different methods (one for handling the avatar `UIImageView` and a separate for handling the User display name `UIButton`).