### PR TITLE
Fixes improperly sized Reportback captions

### DIFF
--- a/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
+++ b/Lets Do This/Views/Reportback/LDTReportbackItemDetailView.m
@@ -138,8 +138,11 @@
     CGFloat height = width + 39;
     // Campaign title button has a height constraint of 22 + top/bottom constraints of 8.
     height += 22 + 8 + 8;
-    // Calculate captionSize height + bottom constraint of 8
-    CGRect captionSize = [self.reportbackItemCaptionLabel.text  boundingRectWithSize:CGSizeMake(width, 100) options:NSStringDrawingUsesLineFragmentOrigin attributes:@{NSFontAttributeName:self.reportbackItemCaptionLabel.font} context:nil];
+    // Subtract reportbackItemCaptionLabel left and right padding of 8 for width of caption, with obscene height to encompass the longest values.
+    CGSize captionBoundingRectSize = CGSizeMake(width - 16, 500);
+    // Calculate reportbackItemCaptionLabel height.
+    CGRect captionSize = [self.reportbackItemCaptionLabel.text  boundingRectWithSize:captionBoundingRectSize options:NSStringDrawingUsesLineFragmentOrigin attributes:@{NSFontAttributeName:self.reportbackItemCaptionLabel.font} context:nil];
+    //  Add our caption's height + bottom constraint of 8
     height += captionSize.size.height + 8;
     if (self.displayShareButton) {
         // Share Button height is 50 + bottom constraint of 16


### PR DESCRIPTION
Fixes https://github.com/DoSomething/LetsDoThis-iOS/issues/697#issuecomment-169218671.

* Subtracts the Caption label's left and right padding from `width` when calculating its height
* Bumps up max height to account for 3 line captions

![simulator screen shot jan 6 2016 12 51 55 pm](https://cloud.githubusercontent.com/assets/1236811/12154592/46553d20-b475-11e5-821e-22b10717efdb.png)


