### PR TITLE
DSOUserManager.activeCampaigns

### DIFF
--- a/Lets Do This/Controllers/Base/LDTTabBarController.h
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.h
@@ -8,6 +8,6 @@
 
 @interface LDTTabBarController : UITabBarController
 
--(void)loadCurrentUserAndCampaigns;
+-(void)reloadCurrentUser;
 
 @end

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -79,7 +79,7 @@
 - (void)reloadCurrentUser {
     UINavigationController *initialVC = (UINavigationController *)self.viewControllers[0];
     [initialVC popToRootViewControllerAnimated:YES];
-    [[DSOUserManager sharedInstance] syncCurrentUserWithCompletionHandler:^ {
+    [[DSOUserManager sharedInstance] startSessionWithCompletionHandler:^ {
         NSLog(@"syncCurrentUserWithCompletionHandler");
     } errorHandler:^(NSError *error) {
         NSLog(@"error %@", error.localizedDescription);

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -67,6 +67,7 @@
 
 #pragma mark - LDTTabBarController
 
+// @todo: Reload current user (don't need to reload activeCampaigns).
 - (void)loadCurrentUserAndCampaigns {
     UINavigationController *initialVC = (UINavigationController *)self.viewControllers[0];
     [initialVC popToRootViewControllerAnimated:YES];

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -63,16 +63,27 @@
         [destNavVC styleNavigationBar:LDTNavigationBarStyleClear];
         [self presentViewController:destNavVC animated:YES completion:nil];
     }
+    else {
+        if ([DSOUserManager sharedInstance].activeCampaigns.count == 0) {
+            [[DSOUserManager sharedInstance] loadCurrentUserAndActiveCampaignsWithCompletionHander:^(NSArray *activeCampaigns) {
+                [[NSNotificationCenter defaultCenter] postNotificationName:@"activeCampaignsLoaded" object:self];
+            } errorHandler:^(NSError *error) {
+                [[NSNotificationCenter defaultCenter] postNotificationName:@"epicFail" object:self];
+            }];
+        }
+    }
 }
 
 #pragma mark - LDTTabBarController
 
-// @todo: Reload current user (don't need to reload activeCampaigns).
-- (void)loadCurrentUserAndCampaigns {
+- (void)reloadCurrentUser {
     UINavigationController *initialVC = (UINavigationController *)self.viewControllers[0];
     [initialVC popToRootViewControllerAnimated:YES];
-    LDTCauseListViewController *causeListViewController = (LDTCauseListViewController *)initialVC.topViewController;
-    [causeListViewController loadCurrentUserAndCampaigns];
+    [[DSOUserManager sharedInstance] syncCurrentUserWithCompletionHandler:^ {
+        NSLog(@"syncCurrentUserWithCompletionHandler");
+    } errorHandler:^(NSError *error) {
+        NSLog(@"error %@", error.localizedDescription);
+    }];
 }
 
 @end

--- a/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignListViewController.m
@@ -180,7 +180,9 @@ const CGFloat kHeightExpanded = 382;
             }
         }
 
-        [[DSOUserManager sharedInstance] setActiveMobileAppCampaigns:self.allCampaigns];
+        // This code is all moving into DSOUserManager - (void)loadCurrentUserAndActiveCampaignsWithCompletionHander:errorHandler: and we're about to delete this class entirely soon
+        /*
+        [[DSOUserManager sharedInstance] setActiveCampaigns:self.allCampaigns];
         [[DSOUserManager sharedInstance] syncCurrentUserWithCompletionHandler:^ {
             NSLog(@"syncCurrentUserWithCompletionHandler");
             if ([self loadInterestGroups]) {
@@ -194,6 +196,7 @@ const CGFloat kHeightExpanded = 382;
 			self.loadErrorType = LDTLoadErrorCampaign;
             [self presentEpicFailForError:error];
         }];
+         */
     } errorHandler:^(NSError *error) {
 		self.loadErrorType = LDTLoadErrorCampaign;
         [self presentEpicFailForError:error];

--- a/Lets Do This/Controllers/Cause/LDTCauseListViewController.h
+++ b/Lets Do This/Controllers/Cause/LDTCauseListViewController.h
@@ -10,6 +10,4 @@
 
 @interface LDTCauseListViewController : UIViewController
 
-- (void)loadCurrentUserAndCampaigns;
-
 @end

--- a/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
@@ -50,6 +50,8 @@
 
 - (void)styleView {
     [self styleBackBarButton];
+    self.view.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"Full Background"]];
+    self.tableView.backgroundColor = UIColor.clearColor;
 }
 
 - (void)loadCauses {

--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -138,7 +138,7 @@
         if ([self.presentingViewController isKindOfClass:[LDTTabBarController class]]) {
             LDTTabBarController *rootVC = (LDTTabBarController *)self.presentingViewController;
             [rootVC dismissViewControllerAnimated:YES completion:^{
-                [rootVC loadCurrentUserAndCampaigns];
+                [rootVC reloadCurrentUser];
             }];
         }
     } errorHandler:^(NSError *error) {

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -173,7 +173,7 @@
                 if ([self.presentingViewController isKindOfClass:[LDTTabBarController class]]) {
                     LDTTabBarController *rootVC = (LDTTabBarController *)self.presentingViewController;
                     [rootVC dismissViewControllerAnimated:YES completion:^{
-                        [rootVC loadCurrentUserAndCampaigns];
+                        [rootVC reloadCurrentUser];
                     }];
                 }
             } errorHandler:^(NSError *error) {

--- a/Lets Do This/Controllers/Profile/LDTProfileViewController.m
+++ b/Lets Do This/Controllers/Profile/LDTProfileViewController.m
@@ -144,7 +144,7 @@ typedef NS_ENUM(NSInteger, LDTProfileSectionType) {
 - (void)loadUserProfile {
     [SVProgressHUD showWithStatus:@"Loading profile..."];
 
-    [[DSOUserManager sharedInstance] loadActiveMobileAppCampaignSignupsForUser:self.user completionHandler:^{
+    [[DSOUserManager sharedInstance] loadActiveCampaignSignupsForUser:self.user completionHandler:^{
         [SVProgressHUD dismiss];
         self.isProfileLoaded = YES;
         [self.tableView reloadData];
@@ -379,7 +379,7 @@ typedef NS_ENUM(NSInteger, LDTProfileSectionType) {
         return reportbackItemCell;
     }
     else {
-        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeMobileAppCampaignWithId:signup.campaign.campaignID];
+        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:signup.campaign.campaignID];
         LDTProfileCampaignTableViewCell *campaignCell = [tableView dequeueReusableCellWithIdentifier:@"campaignCell"];
         [self configureCampaignCell:campaignCell campaign:campaign];
         return campaignCell;

--- a/Lets Do This/Models/DSOReportbackItem.m
+++ b/Lets Do This/Models/DSOReportbackItem.m
@@ -55,10 +55,10 @@
 }
 
 - (DSOCampaign *)campaign {
-    // Return fully loaded DSOCampaign if activeMobileAppCampaign.
-    DSOCampaign *activeMobileAppCampaign = [[DSOUserManager sharedInstance] activeMobileAppCampaignWithId:_campaign.campaignID];
-    if (activeMobileAppCampaign) {
-        return activeMobileAppCampaign;
+    // Return fully loaded DSOCampaign if its an activeCampaign.
+    DSOCampaign *activeCampaign = [[DSOUserManager sharedInstance] activeCampaignWithId:_campaign.campaignID];
+    if (activeCampaign) {
+        return activeCampaign;
     }
     return _campaign;
 }

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -10,16 +10,14 @@
 
 @interface DSOUserManager : NSObject
 
-// Stores the authenticated user (if user has logged in).
+// Stores the current/authenticated user.
 @property (strong, nonatomic, readonly) DSOUser *user;
 
-// Stores all DSOCampaigns which are available for participation via this app.
-@property (strong, nonatomic, readonly) NSArray *activeMobileAppCampaigns;
+// Stores all active DSOCampaigns to display.
+@property (strong, nonatomic, readonly) NSArray *activeCampaigns;
 
-// Singleton object for accessing authenticated User, activeMobileAppCampaigns.
+// Singleton object for accessing authenticated User, activeCampaigns
 + (DSOUserManager *)sharedInstance;
-
-- (void)setActiveMobileAppCampaigns:(NSArray *)activeMobileAppCampaigns;
 
 // Posts login request to the API with given email and password, and saves session tokens to remain authenticated upon future app usage.
 - (void)createSessionWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
@@ -27,11 +25,8 @@
 // Returns whether an authenticated user session has been saved.
 - (BOOL)userHasCachedSession;
 
-// Fetches the current user from API and updates the user property. Called when user is first logged in, when app opens with a saved session, or when user posts Campaign activity (signup/reportback).
-- (void)syncCurrentUserWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
-// Gets the campaignSignups for given user for all activeMobileAppCampaigns.
-- (void)loadActiveMobileAppCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+// Loads the campaignSignups for given user for all activeCampaigns.
+- (void)loadActiveCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 // Logs out the user and deletes the saved session tokens. Called when User logs out from Settings screen.
 - (void)endSessionWithCompletionHandler:(void(^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
@@ -42,8 +37,10 @@
 // Posts a Reportback Item for the current user, and updates activity.
 - (void)postUserReportbackItem:(DSOReportbackItem *)reportbackItem completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-// Returns DSOCampaign for a given Campaign id if it exists in the activeMobileAppCampaigns property.
-- (DSOCampaign *)activeMobileAppCampaignWithId:(NSInteger)campaignID;
+// Returns DSOCampaign for a given Campaign id if it exists in the activeCampaigns property.
+- (DSOCampaign *)activeCampaignWithId:(NSInteger)campaignID;
+
+- (void)loadCurrentUserAndActiveCampaignsWithCompletionHander:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 // Stores the user's avatar image within the filesystem. 
 - (void)storeAvatar:(UIImage *)photo;

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -22,7 +22,8 @@
 // Posts login request to the API with given email and password, and saves session tokens to remain authenticated upon future app usage.
 - (void)createSessionWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)syncCurrentUserWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+// Use saved session to set relevant DSOAPI headers and loads the current user's campaignSignups.
+- (void)startSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 // Returns whether an authenticated user session has been saved.
 - (BOOL)userHasCachedSession;

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -22,6 +22,8 @@
 // Posts login request to the API with given email and password, and saves session tokens to remain authenticated upon future app usage.
 - (void)createSessionWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+- (void)syncCurrentUserWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+
 // Returns whether an authenticated user session has been saved.
 - (BOOL)userHasCachedSession;
 

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -17,7 +17,8 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 @interface DSOUserManager()
 
 @property (strong, nonatomic, readwrite) DSOUser *user;
-@property (strong, nonatomic, readwrite) NSArray *activeMobileAppCampaigns;
+@property (strong, nonatomic, readwrite) NSArray *activeCampaigns;
+@property (strong, nonatomic) NSMutableArray *mutableActiveCampaigns;
 
 @end
 
@@ -36,7 +37,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     return _sharedInstance;
 }
 
-#pragma mark - DSOUserManager
+#pragma mark - Accessors
 
 - (void)setUser:(DSOUser *)user {
     _user = user;
@@ -47,6 +48,12 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
         [[Crashlytics sharedInstance] setUserIdentifier:nil];
     }
 }
+
+- (NSArray *)activeCampaigns {
+    return [self.mutableActiveCampaigns copy];
+}
+
+#pragma mark - DSOUser
 
 - (BOOL)userHasCachedSession {
     NSString *sessionToken = [SSKeychain passwordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"Session"];
@@ -86,7 +93,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 
     [[DSOAPI sharedInstance] loadUserWithUserId:userID completionHandler:^(DSOUser *user) {
         self.user = user;
-        [self loadActiveMobileAppCampaignSignupsForUser:self.user completionHandler:^{
+        [self loadActiveCampaignSignupsForUser:self.user completionHandler:^{
             if (completionHandler) {
                 completionHandler();
             }
@@ -100,11 +107,11 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     }];
 }
 
-- (void)loadActiveMobileAppCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+- (void)loadActiveCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     [[DSOAPI sharedInstance] loadCampaignSignupsForUser:user completionHandler:^(NSArray *campaignSignups) {
         [user removeAllCampaignSignups];
         for (DSOCampaignSignup *signup in campaignSignups) {
-            if ([self activeMobileAppCampaignWithId:signup.campaign.campaignID]) {
+            if ([self activeCampaignWithId:signup.campaign.campaignID]) {
                 [user addCampaignSignup:signup];
             }
             else {
@@ -178,13 +185,50 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     self.user = nil;
 }
 
-- (DSOCampaign *)activeMobileAppCampaignWithId:(NSInteger)campaignID {
-    for (DSOCampaign *campaign in self.activeMobileAppCampaigns) {
+- (DSOCampaign *)activeCampaignWithId:(NSInteger)campaignID {
+    for (DSOCampaign *campaign in self.activeCampaigns) {
         if (campaign.campaignID == campaignID) {
             return campaign;
         }
     }
     return nil;
+}
+
+- (void)loadCurrentUserAndActiveCampaignsWithCompletionHander:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    [SVProgressHUD showWithStatus:@"Loading actions..."];
+    [[DSOAPI sharedInstance] loadAllCampaignsWithCompletionHandler:^(NSArray *campaigns) {
+        NSLog(@"loadAllCampaignsWithCompletionHandler");
+        if (campaigns.count == 0) {
+            NSLog(@"No campaigns found.");
+        }
+        self.mutableActiveCampaigns = [[NSMutableArray alloc] init];
+        for (DSOCampaign *campaign in campaigns) {
+            if ([campaign.status isEqual:@"active"]) {
+                [self.mutableActiveCampaigns addObject:campaign];
+            }
+            else {
+                NSLog(@"Filtering Campaign %li: status == %@.", (long)campaign.campaignID, campaign.status);
+            }
+        }
+
+        [self syncCurrentUserWithCompletionHandler:^ {
+            NSLog(@"syncCurrentUserWithCompletionHandler");
+            [SVProgressHUD dismiss];
+            if (completionHandler) {
+                completionHandler(self.activeCampaigns);
+            }
+        } errorHandler:^(NSError *error) {
+            [SVProgressHUD dismiss];
+            if (errorHandler) {
+                errorHandler(error);
+            }
+        }];
+    } errorHandler:^(NSError *error) {
+        [SVProgressHUD dismiss];
+        if (errorHandler) {
+            errorHandler(error);
+        }
+    }];
 }
 
 #pragma mark - Avatar CRUD

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -17,7 +17,6 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 @interface DSOUserManager()
 
 @property (strong, nonatomic, readwrite) DSOUser *user;
-@property (strong, nonatomic, readwrite) NSArray *activeCampaigns;
 @property (strong, nonatomic) NSMutableArray *mutableActiveCampaigns;
 
 @end
@@ -79,7 +78,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
       }];
 }
 
-- (void)syncCurrentUserWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+- (void)startSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
 
     NSString *sessionToken = [SSKeychain passwordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"Session"];
     if (sessionToken.length == 0) {
@@ -211,7 +210,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
             }
         }
 
-        [self syncCurrentUserWithCompletionHandler:^ {
+        [self startSessionWithCompletionHandler:^ {
             NSLog(@"syncCurrentUserWithCompletionHandler");
             [SVProgressHUD dismiss];
             if (completionHandler) {


### PR DESCRIPTION
Closes #714:
* refactors the `activeMobileAppCampaigns` property as `activeCampaigns`
* moves loading `activeCampaigns` to our root `LDTTabBarController` instead of the `LDTCauseListViewController`, to make it easier to switch out the initial app View Controllers (we'll want to change it to the News Feed next, the call was initially made in the `LDTCampaignListViewController`) 
* `LDTTabBarController` posts a `NSNotification` with name `activeCampaignsLoaded` when completed, or `epicFail`: a todo here is to handle it, like we did in the `LDTCampaignListViewController` with the Epic Fail VC
* `LDTCauseListViewController` adds an observer watching for the `NSNotification`