### PR TITLE
Fix for API change

### DIFF
--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -11,7 +11,12 @@
 #import "LDTOnboardingPageViewController.h"
 #import "LDTUserConnectViewController.h"
 #import "LDTCauseListViewController.h"
+#import "LDTEpicFailViewController.h"
 #import "LDTTheme.h"
+
+@interface LDTTabBarController () <LDTEpicFailSubmitButtonDelegate>
+
+@end
 
 @implementation LDTTabBarController
 
@@ -69,6 +74,7 @@
                 [[NSNotificationCenter defaultCenter] postNotificationName:@"activeCampaignsLoaded" object:self];
             } errorHandler:^(NSError *error) {
                 [[NSNotificationCenter defaultCenter] postNotificationName:@"epicFail" object:self];
+                [self presentEpicFailForError:error];
             }];
         }
     }
@@ -82,8 +88,18 @@
     [[DSOUserManager sharedInstance] startSessionWithCompletionHandler:^ {
         NSLog(@"syncCurrentUserWithCompletionHandler");
     } errorHandler:^(NSError *error) {
-        NSLog(@"error %@", error.localizedDescription);
+        [self presentEpicFailForError:error];
     }];
+}
+
+- (void)presentEpicFailForError:(NSError *)error {
+    LDTEpicFailViewController *epicFailVC = [[LDTEpicFailViewController alloc] initWithTitle:error.readableTitle subtitle:error.readableMessage];
+    epicFailVC.delegate = self;
+    UINavigationController *navVC = [[UINavigationController alloc] initWithRootViewController:epicFailVC];
+    [navVC styleNavigationBar:LDTNavigationBarStyleNormal];
+    [self presentViewController:navVC animated:YES completion:nil];
+    // @TODO: cleanup - this is dismissing the SVProgressHUD called dfrom DSOUserManager
+    [SVProgressHUD dismiss];
 }
 
 @end

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -210,8 +210,7 @@
 - (void)loadUserWithUserId:(NSString *)userID completionHandler:(void (^)(DSOUser *))completionHandler errorHandler:(void (^)(NSError *))errorHandler {
     NSString *url = [NSString stringWithFormat:@"users/_id/%@", userID];
     [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
-          NSArray *userInfo = responseObject[@"data"];
-          DSOUser *user = [[DSOUser alloc] initWithDict:userInfo.firstObject];
+          DSOUser *user = [[DSOUser alloc] initWithDict:responseObject[@"data"]];
           if (completionHandler) {
               completionHandler(user);
           }


### PR DESCRIPTION
Closes #728 - we get a single User object back instead of an array from the Northstar `users/_id/:id` endpoint.

Begins basic work on #731, but needs to implement the "Try Again" button (workaround for now will be to close app)