### PR TITLE
More DSOAPI changes

### DIFF
--- a/Lets Do This/Models/DSOCampaignSignup.m
+++ b/Lets Do This/Models/DSOCampaignSignup.m
@@ -26,7 +26,7 @@
     self = [super init];
 
     if (self) {
-        if (dict[@"reportback_data"]) {
+        if ([dict valueForKeyPath:@"reportback_items.campaign"]) {
             _campaign = [[DSOCampaign alloc] initWithDict:(NSDictionary *)[dict valueForKeyPath:@"reportback_data.campaign"]];
             NSArray *reportbackItems = [dict[@"reportback_data"] valueForKeyPath:@"reportback_items.data"];
             // For now, we only support uploading and displaying a single ReportbackItem per Reportback. Future functionality could include uploading multiple ReportbackItems, as per the web.


### PR DESCRIPTION
Refs https://github.com/DoSomething/northstar/issues/210 -- we get the `reportback_data` property back from a Campaign Activity object regardless of whether a Reportback exists, it's set to null. Alters logic to check for a nested Campaign object. 

Hopefully closes #728 - missed this in #732 by not testing with a User who had any existing `campaignSignups`.