### PR TITLE
Adds cause and formats date in header of news posts

### DIFF
--- a/ReactComponent/helpers.js
+++ b/ReactComponent/helpers.js
@@ -1,0 +1,35 @@
+module.exports = {
+  /**
+   * Formats date string to be use for news feed posts.
+   *
+   * @param date Unformatted date string
+   * @return string
+   */
+  formatDate: function(date) {
+    // @todo Will need a different way to handle this when multi-language
+    // support comes around.
+    var months = ['January', 'February', 'March', 'April', 'May', 'June',
+      'July', 'August', 'September', 'October', 'November', 'December'];
+    
+    // Fun fact: the API sends the date in the format "yyyy-MM-dd hh:mm:ss"
+    // This is fine with V8, but JavaScriptCore which iOS/Safari uses does
+    // not like it. Reformatting the string by adding a 'T' in place of the
+    // space makes it work for both.
+    var space = date.indexOf(' ');
+    if (space >= 0) {
+      date = date.substring(0, space) + 'T' + date.substring(space + 1);
+    }
+    var d = new Date(date);
+    var day = d.getDate();
+
+    var daySuffix = 'th';
+    if (day === 1 || day === 21 || day === 31) {
+      daySuffix = 'st';
+    }
+    else if (day === 3 || day === 23) {
+      daySuffix = 'rd';
+    }
+
+    return months[d.getMonth()] + ' ' + d.getDate() + daySuffix + ', ' + d.getFullYear();
+  }
+}

--- a/ReactComponent/index.ios.js
+++ b/ReactComponent/index.ios.js
@@ -12,6 +12,8 @@ import React, {
   View
 } from 'react-native';
 
+var Helpers = require('./helpers.js');
+
 var TAKE_ACTION_TEXT = 'Take action';
 
 var NewsFeedView = React.createClass({
@@ -115,10 +117,20 @@ var NewsFeedView = React.createClass({
       linkToArticle = null;
     }
 
+    var formattedDate = Helpers.formatDate(post.date);
+    var viewCategory = null;
+    if (post.categories.length > 0) {
+      viewCategory =
+        <View style={styles.categoryContainer}>
+          <Text style={styles.category}>{post.categories[0].title}</Text>
+        </View>;
+    }
+
     return(
       <View style={styles.postContainer}>
         <View style={styles.postHeader}>
-          <Text style={styles.date}>{post.date}</Text>
+          <Text style={styles.date}>{formattedDate}</Text>
+          {viewCategory}
         </View>
         {imgBackground}
         <View style={styles.postBody}>
@@ -176,6 +188,8 @@ var styles = React.StyleSheet.create({
     backgroundColor: '#EEE',
   },
   postHeader: {
+    flex: 1,
+    flexDirection: 'row',
     backgroundColor: '#00e4c8',
     borderTopLeftRadius: 4,
     borderTopRightRadius: 4,
@@ -200,6 +214,14 @@ var styles = React.StyleSheet.create({
     fontFamily: 'BrandonGrotesque-Bold',
     fontSize: 16,
     textAlign: 'center',
+  },
+  category: {
+    color: '#ffffff',
+    fontFamily: 'Brandon Grotesque',
+  },
+  categoryContainer: {
+    flex: 1,
+    alignItems: 'flex-end',
   },
   date: {
     color: '#ffffff',


### PR DESCRIPTION
#### What's this PR do?
Formats the date in the header of each post and displays the cause category.

![screen shot 2016-01-22 at 11 03 39 am](https://cloud.githubusercontent.com/assets/696595/12515765/d86622cc-c0f7-11e5-8ecc-d7052c59e0ba.png)

#### What should the reviewer look out for?
- **helpers.js:** Added a helper module that can also be used for future general helper-like functions. For now it's just the date formatting. Take note of the "fun fact" note on JavaScriptCore's implementation of `Date`. Without changing the format from the API from `yyyy-MM-dd hh:mm:ss` to `yyyy-MM-ddThh:mm:ss`, we'd just get an invalid date and lots of undefined and NaN in the post headers instead.
- `categoryContainer`: Still learning more about flex, but it seemed like I needed to do this in order to get cause category to right-align.
- `post.categories[0]`: The `categories` field gets returned as an array even though I imagine in practice we'll just be setting one category. Here I'm just defaulting to using the first one that it's in the array.

#### What are the relevant tickets?
Closes #739 