### PR TITLE
NewsFeed Cause colors

### DIFF
--- a/Lets Do This/Models/DSOCause.h
+++ b/Lets Do This/Models/DSOCause.h
@@ -15,5 +15,7 @@
 
 - (instancetype)initWithDict:(NSDictionary *)dict;
 - (void)addActiveCampaign:(DSOCampaign *)campaign;
+// We'll want to split this out into a Category method eventually, as this color is LDT specific.
+- (UIColor *)color;
 
 @end

--- a/Lets Do This/Models/DSOCause.m
+++ b/Lets Do This/Models/DSOCause.m
@@ -49,4 +49,31 @@
     [self.mutableActiveCampaigns addObject:campaign];
 }
 
+- (UIColor *)color {
+    NSDictionary *hex = @{
+                          @"Animals" : @"#1BC2DD",
+                          @"Bullying" : @"#E75526",
+                          @"Disasters" : @"#1D78FB",
+                          @"Discrimination" : @"#E1000D",
+                          @"Education" : @"#1AE3C6",
+                          @"Environment" : @"#12D168",
+                          @"Homelessness" : @"#FBB71D",
+                          @"Mental Health" : @"#BA2CC7",
+                          @"Physical Health" : @"#BA2CC7",
+                          @"Sex" : @"#FB1DA9",
+                          @"Violence" : @"#F1921A",
+                          @"Poverty" : @"#69D24B",
+                          @"Relationships" : @"#A01DFB"
+                          };
+    unsigned rgbValue = 0;
+    NSString *hexString = hex[self.title];
+    if (!hexString) {
+        return nil;
+    }
+    NSScanner *scanner = [NSScanner scannerWithString:hexString];
+    [scanner setScanLocation:1]; // bypass '#' character
+    [scanner scanHexInt:&rgbValue];
+    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+}
+
 @end

--- a/ReactComponent/index.ios.js
+++ b/ReactComponent/index.ios.js
@@ -122,7 +122,46 @@ var NewsFeedView = React.createClass({
     var causeTitle = null;
     if (post.categories.length > 0) {
       causeTitle = post.categories[0].title;
-      causeStyle = {backgroundColor: '#FF0033'};
+      var causeBackgroundColor: '#FF0033';
+      switch (causeTitle) {
+        case 'Animals':
+          causeBackgroundColor = '#1BC2DD';
+          break;
+        case 'Bullying':
+          causeBackgroundColor = '#E75526';
+          break;
+        case 'Disasters':
+          causeBackgroundColor = '#1D78FB';
+          break;
+        case 'Discrimination':
+          causeBackgroundColor = '#E1000D';
+          break;
+        case 'Education':
+          causeBackgroundColor = '#1AE3C6';
+          break;
+        case 'Environment':
+          causeBackgroundColor = '#12D168';
+          break;
+        case 'Homelessness':
+          causeBackgroundColor = '#FBB71D';
+          break;
+        case 'Mental Health':
+          causeBackgroundColor = '#BA2CC7';
+          break;
+        case 'Physical Health':
+          causeBackgroundColor = '#BA2CC7';
+          break;
+        case 'Relationships':
+          causeBackgroundColor = '#A01DFB';
+          break;
+        case 'Sex':
+          causeBackgroundColor = '#FB1DA9';
+          break;
+        case 'Violence':
+          causeBackgroundColor = '#F1921A';
+          break;
+      }
+      causeStyle = {backgroundColor: causeBackgroundColor};
     }
 
     return(

--- a/ReactComponent/index.ios.js
+++ b/ReactComponent/index.ios.js
@@ -118,19 +118,20 @@ var NewsFeedView = React.createClass({
     }
 
     var formattedDate = Helpers.formatDate(post.date);
-    var viewCategory = null;
+    var causeStyle = null;
+    var causeTitle = null;
     if (post.categories.length > 0) {
-      viewCategory =
-        <View style={styles.categoryContainer}>
-          <Text style={styles.category}>{post.categories[0].title}</Text>
-        </View>;
+      causeTitle = post.categories[0].title;
+      causeStyle = {backgroundColor: '#FF0033'};
     }
 
     return(
       <View style={styles.postContainer}>
-        <View style={styles.postHeader}>
+        <View style={[styles.postHeader, causeStyle]}>
           <Text style={styles.date}>{formattedDate}</Text>
-          {viewCategory}
+          <View style={styles.categoryContainer}>
+            <Text style={styles.category}>{causeTitle}</Text>
+          </View>
         </View>
         {imgBackground}
         <View style={styles.postBody}>


### PR DESCRIPTION
Closes #756 - Adds a `DSOCause -(UIColor *)color` method to return the `UIColor` for a Cause.

Closes #766  - Adds inline styles to the News Feed via big ol `switch` statement. A very nice to have here would be sending the hex strings defined in `DSOCause` to the `NewsFeedView` component's styles via `initialProperties` - but not needed for merge.

## Screenshots

![simulator screen shot jan 25 2016 9 57 28 am](https://cloud.githubusercontent.com/assets/1236811/12559600/e3c9cf4c-c34a-11e5-9bad-455dece6bd3d.png)