### PR TITLE
Cleanup

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -824,7 +824,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Fabric/Fabric.framework/run\" `defaults read \"$PWD\"/Lets\\ Do\\ This/keys.plist fabricApiKey` `defaults read \"$PWD\"/Lets\\ Do\\ This/keys.plist fabricBuildSecret`";
+			shellScript = "\"${PODS_ROOT}/Fabric/run\" `defaults read \"$PWD\"/Lets\\ Do\\ This/keys.plist fabricApiKey` `defaults read \"$PWD\"/Lets\\ Do\\ This/keys.plist fabricBuildSecret`";
 		};
 		57A97D3FE5F4843F35259D92 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
@@ -64,6 +64,7 @@
     [[DSOAPI sharedInstance] loadCausesWithCompletionHandler:^(NSArray *causes) {
         self.causes = causes;
         NSArray *activeCampaigns = [DSOUserManager sharedInstance].activeCampaigns;
+        NSMutableArray *causelessCampaignIDs = [[NSMutableArray alloc] init];
         for (DSOCampaign *campaign in activeCampaigns) {
             if (campaign.cause) {
                 NSNumber *causeID = [NSNumber numberWithInteger:campaign.cause.causeID];
@@ -72,9 +73,12 @@
                     [cause addActiveCampaign:campaign];
                 }
                 else {
-                    NSLog(@"Filtering Campaign %li: cause == %@.", (long)campaign.campaignID, causeID);
+                    [causelessCampaignIDs addObject:[NSString stringWithFormat:@"%li",(long)campaign.campaignID]];
                 }
             }
+        }
+        if (causelessCampaignIDs.count > 0) {
+            NSLog(@"[LDTCauseListViewController] Campaigns without Primary Cause: %@.", [causelessCampaignIDs componentsJoinedByString:@", "]);
         }
         [SVProgressHUD dismiss];
         [self.tableView reloadData];

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -17,7 +17,6 @@
 
 @property (nonatomic, strong, readonly) NSString *phoenixBaseURL;
 @property (nonatomic, strong, readonly) NSString *phoenixApiURL;
-@property (nonatomic, strong, readonly) NSString *northstarBaseURL;
 
 + (DSOAPI *)sharedInstance;
 

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -64,8 +64,8 @@
 #pragma mark - NSObject
 
 - (instancetype)initWithApiKey:(NSString *)apiKey applicationId:(NSString *)applicationId activityLoggerEnabled:(BOOL)activityLoggerEnabled{
-    NSURL *baseURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://%@/v1/", LDTSERVER]];
-    self = [super initWithBaseURL:baseURL];
+    NSString *northstarURLString = [NSString stringWithFormat:@"https://%@/v1/", LDTSERVER];
+    self = [super initWithBaseURL:[NSURL URLWithString:northstarURLString]];
 
     if (self) {
         if (activityLoggerEnabled) {
@@ -80,7 +80,6 @@
         [self.requestSerializer setValue:apiKey forHTTPHeaderField:@"X-DS-REST-API-Key"];
         _phoenixBaseURL =  [NSString stringWithFormat:@"https://%@/", DSOSERVER];
         _phoenixApiURL = [NSString stringWithFormat:@"%@api/v1/", self.phoenixBaseURL];
-        _northstarBaseURL = [NSString stringWithFormat:@"https://%@/", LDTSERVER];
     }
     return self;
 }

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -78,7 +78,7 @@
         [self.requestSerializer setValue:@"application/json" forHTTPHeaderField:@"Accept"];
         [self.requestSerializer setValue:applicationId forHTTPHeaderField:@"X-DS-Application-Id"];
         [self.requestSerializer setValue:apiKey forHTTPHeaderField:@"X-DS-REST-API-Key"];
-         _phoenixBaseURL =  [NSString stringWithFormat:@"https://%@/", DSOSERVER];
+        _phoenixBaseURL =  [NSString stringWithFormat:@"https://%@/", DSOSERVER];
         _phoenixApiURL = [NSString stringWithFormat:@"%@api/v1/", self.phoenixBaseURL];
         _northstarBaseURL = [NSString stringWithFormat:@"https://%@/", LDTSERVER];
     }

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -14,7 +14,6 @@
 
 
 // API Constants
-#define DSOPROTOCOL @"https"
 #define LDTSOURCENAME @"letsdothis_ios"
 
 #ifdef DEBUG
@@ -65,7 +64,7 @@
 #pragma mark - NSObject
 
 - (instancetype)initWithApiKey:(NSString *)apiKey applicationId:(NSString *)applicationId activityLoggerEnabled:(BOOL)activityLoggerEnabled{
-    NSURL *baseURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@/v1/", DSOPROTOCOL, LDTSERVER]];
+    NSURL *baseURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://%@/v1/", LDTSERVER]];
     self = [super initWithBaseURL:baseURL];
 
     if (self) {
@@ -79,9 +78,9 @@
         [self.requestSerializer setValue:@"application/json" forHTTPHeaderField:@"Accept"];
         [self.requestSerializer setValue:applicationId forHTTPHeaderField:@"X-DS-Application-Id"];
         [self.requestSerializer setValue:apiKey forHTTPHeaderField:@"X-DS-REST-API-Key"];
-        _phoenixBaseURL =  [NSString stringWithFormat:@"%@://%@/", DSOPROTOCOL, DSOSERVER];
+         _phoenixBaseURL =  [NSString stringWithFormat:@"https://%@/", DSOSERVER];
         _phoenixApiURL = [NSString stringWithFormat:@"%@api/v1/", self.phoenixBaseURL];
-        _northstarBaseURL = [NSString stringWithFormat:@"%@://%@/", DSOPROTOCOL, LDTSERVER];
+        _northstarBaseURL = [NSString stringWithFormat:@"https://%@/", LDTSERVER];
     }
     return self;
 }

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -54,8 +54,12 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 
 #pragma mark - DSOUser
 
+- (NSString *)currentService {
+    return [DSOAPI sharedInstance].baseURL.absoluteString;
+}
+
 - (BOOL)userHasCachedSession {
-    NSString *sessionToken = [SSKeychain passwordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"Session"];
+    NSString *sessionToken = [SSKeychain passwordForService:self.currentService account:@"Session"];
 	
     return sessionToken.length > 0;
 }
@@ -66,8 +70,8 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 
         [[DSOAPI sharedInstance] setHTTPHeaderFieldSession:user.sessionToken];
         // Save session in Keychain for when app is quit.
-        [SSKeychain setPassword:user.sessionToken forService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"Session"];
-        [SSKeychain setPassword:self.user.userID forService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"UserID"];
+        [SSKeychain setPassword:user.sessionToken forService:self.currentService account:@"Session"];
+        [SSKeychain setPassword:self.user.userID forService:self.currentService account:@"UserID"];
         if (completionHandler) {
             completionHandler(user);
         }
@@ -80,7 +84,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 
 - (void)startSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
 
-    NSString *sessionToken = [SSKeychain passwordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"Session"];
+    NSString *sessionToken = [SSKeychain passwordForService:self.currentService account:@"Session"];
     if (sessionToken.length == 0) {
         // @todo: Should return error here.
         return;
@@ -90,8 +94,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     // @see https://github.com/DoSomething/northstar/issues/186
     [[DSOAPI sharedInstance] setHTTPHeaderFieldSession:sessionToken];
 
-    NSString *userID = [SSKeychain passwordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"UserID"];
-
+    NSString *userID = [SSKeychain passwordForService:self.currentService account:@"UserID"];
     [[DSOAPI sharedInstance] loadUserWithUserId:userID completionHandler:^(DSOUser *user) {
         self.user = user;
         [self loadActiveCampaignSignupsForUser:self.user completionHandler:^{
@@ -134,8 +137,8 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 }
 
 - (void)endSession {
-    [SSKeychain deletePasswordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"Session"];
-    [SSKeychain deletePasswordForService:[[DSOAPI sharedInstance] northstarBaseURL] account:@"UserID"];
+    [SSKeychain deletePasswordForService:self.currentService account:@"Session"];
+    [SSKeychain deletePasswordForService:self.currentService account:@"UserID"];
     [self deleteAvatar];
     self.user = nil;
 }

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -111,13 +111,17 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 - (void)loadActiveCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     [[DSOAPI sharedInstance] loadCampaignSignupsForUser:user completionHandler:^(NSArray *campaignSignups) {
         [user removeAllCampaignSignups];
+        NSMutableArray *inactiveCampaignIDs = [[NSMutableArray alloc] init];
         for (DSOCampaignSignup *signup in campaignSignups) {
             if ([self activeCampaignWithId:signup.campaign.campaignID]) {
                 [user addCampaignSignup:signup];
             }
             else {
-                NSLog(@"Filtering signup for inactive campaign %li.", (long)signup.campaign.campaignID);
+                [inactiveCampaignIDs addObject:[NSString stringWithFormat:@"%li", (long)signup.campaign.campaignID]];
             }
+        }
+        if (inactiveCampaignIDs.count > 0) {
+            NSLog(@"[DSOUserManager] Filtering signups for inactive Campaigns:[ %@ ]", [inactiveCampaignIDs componentsJoinedByString:@","]);
         }
         if (completionHandler) {
             completionHandler();
@@ -203,13 +207,17 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
             NSLog(@"No campaigns found.");
         }
         self.mutableActiveCampaigns = [[NSMutableArray alloc] init];
+        NSMutableArray *inactiveCampaignIDs = [[NSMutableArray alloc] init];
         for (DSOCampaign *campaign in campaigns) {
             if ([campaign.status isEqual:@"active"]) {
                 [self.mutableActiveCampaigns addObject:campaign];
             }
             else {
-                NSLog(@"Filtering Campaign %li: status == %@.", (long)campaign.campaignID, campaign.status);
+                [inactiveCampaignIDs addObject:[NSString stringWithFormat:@"%li", (long)campaign.campaignID]];
             }
+        }
+        if (inactiveCampaignIDs.count > 0) {
+            NSLog(@"[DSOUserManager] Filtering inactive Campaigns:[ %@ ]", [inactiveCampaignIDs componentsJoinedByString:@", "]);
         }
 
         [self startSessionWithCompletionHandler:^ {

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -121,7 +121,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
             }
         }
         if (inactiveCampaignIDs.count > 0) {
-            NSLog(@"[DSOUserManager] Filtering signups for inactive Campaigns:[ %@ ]", [inactiveCampaignIDs componentsJoinedByString:@","]);
+            NSLog(@"[DSOUserManager] Filtering User %@ Signups for inactive Campaigns %@.", user.userID, [inactiveCampaignIDs componentsJoinedByString:@","]);
         }
         if (completionHandler) {
             completionHandler();
@@ -217,7 +217,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
             }
         }
         if (inactiveCampaignIDs.count > 0) {
-            NSLog(@"[DSOUserManager] Filtering inactive Campaigns:[ %@ ]", [inactiveCampaignIDs componentsJoinedByString:@", "]);
+            NSLog(@"[DSOUserManager] Filtering inactive Campaigns %@.", [inactiveCampaignIDs componentsJoinedByString:@", "]);
         }
 
         [self startSessionWithCompletionHandler:^ {


### PR DESCRIPTION
* Fixes #782 - concatenate inactive / causeless campaign ID's into a single `NSLog` to cut down on noise
* Fixes #760 - updates Fabric script location
* Removes `DSOAPI.northstarBaseURL` -- it duplicates `AFHTTPSessionManager.baseURL`. Refactors as new method `DSOUserManager -(NSString *)currentService` - which returns the `baseURL.absoluteString`
* Removes `DSOPROTOCOL` from `DSOAPI` to improve code readability 