### PR TITLE
Cause Google Analytics

### DIFF
--- a/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
@@ -10,6 +10,7 @@
 #import "LDTTheme.h"
 #import "LDTCampaignDetailViewController.h"
 #import "LDTCauseDetailCampaignCell.h"
+#import "GAI+LDT.h"
 
 @interface LDTCauseDetailViewController () <UITableViewDataSource, UITableViewDelegate>
 
@@ -56,6 +57,8 @@
     [super viewDidAppear:animated];
 
     self.navigationController.hidesBarsOnSwipe = NO;
+    NSString *screenName = [NSString stringWithFormat:@"taxonomy-term/%li", (long)self.cause.causeID];
+    [[GAI sharedInstance] trackScreenView:screenName];
 }
 
 #pragma mark - LDTCauseDetailViewController

--- a/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
@@ -9,6 +9,7 @@
 #import "LDTCauseListViewController.h"
 #import "LDTTheme.h"
 #import "LDTCauseDetailViewController.h"
+#import "GAI+LDT.h"
 
 @interface LDTCauseListViewController () <UITableViewDataSource, UITableViewDelegate>
 
@@ -44,7 +45,9 @@
     [super viewDidAppear:animated];
 
     self.navigationController.hidesBarsOnSwipe = NO;
-    // @todo: Not this?
+    [[GAI sharedInstance] trackScreenView:@"cause-list"];
+
+    // @todo: Not this? @see GH #746
     // -(void)receivedNotification: is no longer being called, so something needs to be fixed (or remove all notifications in general)
     if (self.causes.count == 0 && [DSOUserManager sharedInstance].activeCampaigns.count > 0) {
         [self loadCauses];


### PR DESCRIPTION
Closes #727, tracks:
* `cause-list`
* `taxonomy-term/:id`