### PR TITLE
News tweaks

### DIFF
--- a/ReactComponents/NewsFeedPost.js
+++ b/ReactComponents/NewsFeedPost.js
@@ -21,28 +21,23 @@ var NewsFeedPost = React.createClass({
     NewsFeedViewController.presentFullArticle(this.props.post.id, urlString);
   },
   render: function() {
-    var imgBackground;
-    var imgOval;
     var post = this.props.post;
-    var postTitle = post.title.toUpperCase();
 
+    var photoImage;
     if (typeof post !== 'undefined'
         && typeof post.attachments[0] !== 'undefined'
         && typeof post.attachments[0].images !== 'undefined'
         && typeof post.attachments[0].images.full !== 'undefined') {
-        imgBackground = <Image
+        photoImage = <Image
           style={{flex: 1, height: 128, alignItems: 'stretch'}}
           source={{uri: post.attachments[0].images.full.url}}>
-            <View style={styles.titleContainer}>
-              <Text style={styles.title}>{postTitle}</Text>
-            </View>
           </Image>;
     }
     else {
-      imgBackground = <Text style={styles.title}>{postTitle}</Text>;
+      photoImage = null;
     }
 
-    imgOval = require('image!listitem-oval');
+    var imgOval = require('image!listitem-oval');
 
     var linkToArticle;
     if (typeof post.custom_fields.full_article_url !== 'undefined'
@@ -72,9 +67,9 @@ var NewsFeedPost = React.createClass({
             <Text style={styles.category}>{causeTitle}</Text>
           </View>
         </View>
-        {imgBackground}
+        {photoImage}
         <View style={styles.postBody}>
-          <Text style={styles.subtitle}>{post.custom_fields.subtitle}</Text>
+          <Text style={styles.title}>{post.title.toUpperCase()}</Text>
           <View style={styles.summaryItem}>
             <View style={styles.listItemOvalContainer}>
               <Image source={imgOval} />
@@ -157,11 +152,6 @@ var styles = StyleSheet.create({
     height: 21.5,
     justifyContent: 'center',
   },
-  subtitle: {
-    color: '#4A4A4A',
-    fontFamily: 'BrandonGrotesque-Bold',
-    fontSize: 18,
-  },
   summaryItem: {
     flex: 1,
     flexDirection: 'row',
@@ -177,19 +167,11 @@ var styles = StyleSheet.create({
     marginLeft: 4,
   },
   title: {
-    color: '#ffffff',
+    color: '#4A4A4A',
     flex: 1,
     flexDirection: 'column',
     fontFamily: 'BrandonGrotesque-Bold',
     fontSize: 20,
-    textAlign: 'center',
-  },
-  titleContainer: {
-    backgroundColor: 'rgba(0,0,0,0.3)',
-    alignItems: 'center',
-    flex: 1,
-    flexDirection: 'row',
-    padding: 20,
   },
 });
 

--- a/ReactComponents/NewsFeedPost.js
+++ b/ReactComponents/NewsFeedPost.js
@@ -22,13 +22,19 @@ var NewsFeedPost = React.createClass({
     NewsFeedViewController.presentFullArticle(this.props.post.id, urlString);
   },
   renderSummaryItem: function(summaryItemText) {
-    return (
-      <View style={styles.summaryItem}>
-        <View style={styles.listItemOvalContainer}>
-          <Image source={require('image!listitem-oval')} />
+    if (summaryItemText.length > 0) {
+      return (
+        <View style={styles.summaryItem}>
+          <View style={styles.listItemOvalContainer}>
+            <Image source={require('image!listitem-oval')} />
+          </View>
+          <Text style={styles.summaryText}>{summaryItemText}</Text>
         </View>
-        <Text style={styles.summaryText}>{summaryItemText}</Text>
-      </View>);
+      );
+    }
+    else {
+      return null;
+    }
   },
   render: function() {
     var post = this.props.post;
@@ -66,6 +72,7 @@ var NewsFeedPost = React.createClass({
       causeTitle = post.categories[0].title;
       causeStyle = {backgroundColor: Helpers.causeBackgroundColor(causeTitle)};
     }
+
     return(
       <View style={styles.postContainer}>
         <View style={[styles.postHeader, causeStyle]}>
@@ -77,9 +84,9 @@ var NewsFeedPost = React.createClass({
         {postImage}
         <View style={styles.postBody}>
           <Text style={styles.title}>{post.title.toUpperCase()}</Text>
-          {this.renderSummaryItem(post.custom_fields.summary_1)}
-          {this.renderSummaryItem(post.custom_fields.summary_2)}
-          {this.renderSummaryItem(post.custom_fields.summary_3)}
+          {this.renderSummaryItem(post.custom_fields.summary_1[0])}
+          {this.renderSummaryItem(post.custom_fields.summary_2[0])}
+          {this.renderSummaryItem(post.custom_fields.summary_3[0])}
           {linkToArticle}
         </View>
         <TouchableHighlight onPress={this.ctaButtonPressed} style={styles.btn}>

--- a/ReactComponents/NewsFeedPost.js
+++ b/ReactComponents/NewsFeedPost.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React, {
+  Component,
   StyleSheet,
   Text,
   Image,
@@ -20,24 +21,31 @@ var NewsFeedPost = React.createClass({
     var urlString = this.props.post.custom_fields.full_article_url[0];
     NewsFeedViewController.presentFullArticle(this.props.post.id, urlString);
   },
+  renderSummaryItem: function(summaryItemText) {
+    return (
+      <View style={styles.summaryItem}>
+        <View style={styles.listItemOvalContainer}>
+          <Image source={require('image!listitem-oval')} />
+        </View>
+        <Text style={styles.summaryText}>{summaryItemText}</Text>
+      </View>);
+  },
   render: function() {
     var post = this.props.post;
 
-    var photoImage;
+    var postImage;
     if (typeof post !== 'undefined'
         && typeof post.attachments[0] !== 'undefined'
         && typeof post.attachments[0].images !== 'undefined'
         && typeof post.attachments[0].images.full !== 'undefined') {
-        photoImage = <Image
+        postImage = <Image
           style={{flex: 1, height: 128, alignItems: 'stretch'}}
           source={{uri: post.attachments[0].images.full.url}}>
           </Image>;
     }
     else {
-      photoImage = null;
+      postImage = null;
     }
-
-    var imgOval = require('image!listitem-oval');
 
     var linkToArticle;
     if (typeof post.custom_fields.full_article_url !== 'undefined'
@@ -58,7 +66,6 @@ var NewsFeedPost = React.createClass({
       causeTitle = post.categories[0].title;
       causeStyle = {backgroundColor: Helpers.causeBackgroundColor(causeTitle)};
     }
-
     return(
       <View style={styles.postContainer}>
         <View style={[styles.postHeader, causeStyle]}>
@@ -67,27 +74,12 @@ var NewsFeedPost = React.createClass({
             <Text style={styles.category}>{causeTitle}</Text>
           </View>
         </View>
-        {photoImage}
+        {postImage}
         <View style={styles.postBody}>
           <Text style={styles.title}>{post.title.toUpperCase()}</Text>
-          <View style={styles.summaryItem}>
-            <View style={styles.listItemOvalContainer}>
-              <Image source={imgOval} />
-            </View>
-            <Text style={styles.summaryText}>{post.custom_fields.summary_1}</Text>
-          </View>
-          <View style={styles.summaryItem}>
-            <View style={styles.listItemOvalContainer}>
-              <Image source={imgOval} />
-            </View>
-            <Text style={styles.summaryText}>{post.custom_fields.summary_2}</Text>
-          </View>
-          <View style={styles.summaryItem}>
-            <View style={styles.listItemOvalContainer}>
-              <Image source={imgOval} />
-            </View>
-            <Text style={styles.summaryText}>{post.custom_fields.summary_3}</Text>
-          </View>
+          {this.renderSummaryItem(post.custom_fields.summary_1)}
+          {this.renderSummaryItem(post.custom_fields.summary_2)}
+          {this.renderSummaryItem(post.custom_fields.summary_3)}
           {linkToArticle}
         </View>
         <TouchableHighlight onPress={this.ctaButtonPressed} style={styles.btn}>

--- a/ReactComponents/NewsFeedPost.js
+++ b/ReactComponents/NewsFeedPost.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import React, {
-  Component,
   StyleSheet,
   Text,
   Image,


### PR DESCRIPTION
* Fixes #788 -- check for existence of summary item before displaying. DRY with new `renderSummaryItem` function
* Implements new design changes to resolve  #787 -- removes Subtitle, displays Title underneath the News Image

cc @jonuy ch-ch-changes

![news](https://cloud.githubusercontent.com/assets/1236811/12633674/5f6066e6-c528-11e5-9b7c-d255969dc88a.gif)