### PR TITLE
Converts unicode values in post titles to their human-readable form

### DIFF
--- a/ReactComponents/Helpers.js
+++ b/ReactComponents/Helpers.js
@@ -67,4 +67,46 @@ module.exports = {
     }
     return '#FF0033';
   },
+
+  /**
+   * Convert unicode character codes to their human-readable characters.
+   *
+   * @param raw String to convert
+   * @result string
+   */
+  convertUnicode: function(raw) {
+    const regex = /&#[0-9]*;/g;
+    var result = raw;
+    var match;
+    var matches = [];
+    var i = -1;
+
+    while ((match = regex.exec(raw)) !== null) {
+      i++;
+      matches[i] = match;
+    }
+
+    if (matches.length > 0) {
+      // Reverse the array to work from the back of the raw string to the front
+      matches.reverse();
+
+      for (i = 0; i < matches.length; i++) {
+        // First item in the match array is the unicode value
+        let unicode = matches[i][0];
+
+        // Extract the code, removing the leading `&#` and trailing `;`
+        let code = unicode.substring(2, unicode.length - 1);
+
+        // Convert to human readable character
+        let character = String.fromCharCode(parseInt(code, 10));
+
+        // Insert `character` in place of the unicode string
+        let before = result.substring(0, matches[i].index);
+        let after = result.substring(matches[i].index + unicode.length);
+        result = before + character + after;
+      }
+    }
+
+    return result;
+  },
 }

--- a/ReactComponents/NewsFeedPost.js
+++ b/ReactComponents/NewsFeedPost.js
@@ -98,6 +98,7 @@ var NewsFeedPost = React.createClass({
   },
   render: function() {
     var post = this.props.post;
+    var postTitle = Helpers.convertUnicode(post.title);
     var causeTitle, causeStyle = null;
     if (post.categories.length > 0) {
       causeTitle = post.categories[0].title;
@@ -114,7 +115,7 @@ var NewsFeedPost = React.createClass({
         </View>
         {this.renderImage()}
         <View style={styles.content}>
-          <Text style={styles.title}>{post.title.toUpperCase()}</Text>
+          <Text style={styles.title}>{postTitle.toUpperCase()}</Text>
           {this.renderSummaryItem(post.custom_fields.summary_1[0])}
           {this.renderSummaryItem(post.custom_fields.summary_2[0])}
           {this.renderSummaryItem(post.custom_fields.summary_3[0])}


### PR DESCRIPTION
#### What's this PR do?

Behold:
![screen shot 2016-01-29 at 10 50 36 am](https://cloud.githubusercontent.com/assets/696595/12680574/99458430-c678-11e5-9eb0-1a5124dc941b.png)

There's a new `Helpers.convertUnicode` function that will convert unicode values in a string (`/&#[0-9]*;/g`) to the actual character. This is only applied to the post title. The problem doesn't seem to affect the summary items.

Closes #753 