### PR TITLE
Cause List arrow image

### DIFF
--- a/ReactComponents/CauseListView.js
+++ b/ReactComponents/CauseListView.js
@@ -7,6 +7,7 @@ import React, {
   Component,
   StyleSheet,
   Text,
+  Image,
   RefreshControl,
   TouchableHighlight,
   View
@@ -88,11 +89,17 @@ var CauseListView = React.createClass({
       <TouchableHighlight onPress={() => this._onPressCauseRow(cause)}>
         <View style={styles.row}>
           <View style={[styles.causeColor, causeColorStyle]} />
-          <View style={styles.content}>
+          <View style={[styles.content, styles.bordered]}>
             <View>
               <Text style={styles.title}>{cause.title}</Text>
               <Text style={styles.text}>{cause.description}</Text>
             </View>
+          </View>
+          <View style={[styles.arrowContainer, styles.bordered]}>
+              <Image
+                style={styles.arrowImage}
+                source={require('image!Arrow')}
+              />  
           </View>
         </View>
       </TouchableHighlight>
@@ -117,26 +124,38 @@ var styles = React.StyleSheet.create({
     fontFamily: 'Brandon Grotesque',
     fontSize: 12,
   },
+  row: {
+    backgroundColor: '#FFFFFF',
+    flex: 1,
+    flexDirection: 'row',
+  },
   causeColor: {
     width: 8,
     backgroundColor: '#00FF00',
     height: 84,
+  },
+  bordered: {
+    borderColor: '#EDEDED',
+    borderTopWidth: 2,
+    borderBottomWidth: 2,    
   },
   content: {
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     paddingLeft: 8,
-    borderColor: '#EDEDED',
-    borderTopWidth: 2,
-    borderBottomWidth: 2,
     height: 84,
   },
-  row: {
-    backgroundColor: '#FFFFFF',
-    flex: 1,
-    flexDirection: 'row',
+  arrowContainer: {
+    width: 38,
+    height: 84,
     alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  arrowImage: {
+    width: 12,
+    height: 21,
   },
   title: {
     color: '4A4A4A',


### PR DESCRIPTION
Adds arrow image to the Cause Detail (#799), although description still doesn't word wrap.

This has fixed height. Need to hardcode it in order to get the `causeColor` View to display (refs https://github.com/facebook/react-native/issues/3381).

Even without the color cell, I ran into difficulty getting multi-line layout to work properly with the Arrow Image, with similar things going on here: https://github.com/facebook/react-native/issues/5361#issuecomment-172282488, where using `flexDirection: row` is discouraged

iPhone 5S:
![simulator screen shot feb 2 2016 9 47 45 am](https://cloud.githubusercontent.com/assets/1236811/12759461/0de9fb2a-c996-11e5-86d6-31be5a98b089.png)
