### PR TITLE
Use tabBarController.selectedIndex for pushing from React Native

### DIFF
--- a/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "LDTCauseDetailViewController.h"
+#import "LDTTabBarController.h"
 #import "LDTTheme.h"
 #import "LDTCampaignDetailViewController.h"
 #import "GAI+LDT.h"
@@ -85,11 +86,8 @@ RCT_EXPORT_MODULE();
 
 - (void)presentCampaignDetailViewControllerForCampaignId:(NSInteger)campaignID {
     DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-
-    // @todo DRY
-    // http://stackoverflow.com/a/29762965/1470725
-    UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
-    UINavigationController *navigationController = keyWindow.rootViewController.childViewControllers[1];
+    LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
     LDTCampaignDetailViewController *campaignDetailViewController = [[LDTCampaignDetailViewController alloc] initWithCampaign:campaign];
     dispatch_async(dispatch_get_main_queue(), ^{
         [navigationController pushViewController:campaignDetailViewController animated:YES];

--- a/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
@@ -8,6 +8,7 @@
 
 #import "LDTCauseListViewController.h"
 #import "LDTTheme.h"
+#import "LDTTabBarController.h"
 #import "LDTCauseDetailViewController.h"
 #import "GAI+LDT.h"
 #import "LDTAppDelegate.h"
@@ -66,11 +67,8 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(presentCause:(NSDictionary *)causeDict) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
-        // This is the worst.
-        // May need to look into creating a separate UIView and then adding our ReactView as a subview: http://stackoverflow.com/questions/29597610/cant-push-a-native-view-controller-from-a-react-native-click
-
-        UINavigationController *navigationController = keyWindow.rootViewController.childViewControllers[1];
+        LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
+        UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
         DSOCause *cause = [[DSOCause alloc] initWithNewsDict:causeDict];
         LDTCauseDetailViewController *causeDetailViewController = [[LDTCauseDetailViewController alloc] initWithCause:cause];
         [navigationController pushViewController:causeDetailViewController animated:YES];

--- a/Lets Do This/Controllers/News/LDTNewsFeedViewController.m
+++ b/Lets Do This/Controllers/News/LDTNewsFeedViewController.m
@@ -62,12 +62,8 @@ RCT_EXPORT_MODULE();
 
 - (void)presentCampaignDetailViewControllerForCampaignId:(NSInteger)campaignID {
     DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-
-    // Without this trickery, the ReactView won't push to the Campaign Detail VC, even though this method gets called (will output NSLog calls, etc).
-    // http://stackoverflow.com/a/29762965/1470725
-    UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
-    UINavigationController *navigationController = keyWindow.rootViewController.childViewControllers[0];
-
+    LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
     if (!campaign) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [LDTMessage displayErrorMessageInViewController:navigationController.topViewController title:@"Our bad. That's an invalid campaign ID :("];


### PR DESCRIPTION
Just using a normal `self.navigationController pushViewController:animated:` isn't working when we're trying to push a View Controller with its root view set as a React Native `RCTRootView`. 

Found [this solution on SO](http://stackoverflow.com/questions/29597610/cant-push-a-native-view-controller-from-a-react-native-click/29762965#29762965) but it hardcodes the selected tab index, which is no good for something like the User Profile or Campaign Detail which could be accessed from multiple tabs. This PR changes these blocks to instead inspect our root Tab Bar Controller's selectedIndex.

Still haven't had much time to look into whether or not [this](http://stackoverflow.com/questions/29597610/cant-push-a-native-view-controller-from-a-react-native-click/29762965#29762965) is the real fix though, or reading up on the threading stuff a bit more.