### PR TITLE
UserViewController: User Profile a la React Native

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		B2E652E21B43822600EF9D69 /* LDTButton.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E652E11B43822600EF9D69 /* LDTButton.m */; };
 		B2E75D7F1B87B1610015BE4A /* LDTReportbackItemDetailView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2E75D7E1B87B1610015BE4A /* LDTReportbackItemDetailView.xib */; };
 		B2E75D831B87B1920015BE4A /* LDTReportbackItemDetailSingleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E75D821B87B1920015BE4A /* LDTReportbackItemDetailSingleViewController.m */; };
+		B2F2BA831C6440BF001EB1D5 /* LDTUserViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F2BA821C6440BF001EB1D5 /* LDTUserViewController.m */; };
 		C20BA2831AF3DBE400E9886F /* DSOCampaign.m in Sources */ = {isa = PBXBuildFile; fileRef = C20BA2781AF3DBE400E9886F /* DSOCampaign.m */; };
 		C20BA2881AF3DBE400E9886F /* DSOUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C20BA2821AF3DBE400E9886F /* DSOUser.m */; };
 		C20BA28D1AF3DCAB00E9886F /* NSDate+DSO.m in Sources */ = {isa = PBXBuildFile; fileRef = C20BA28A1AF3DCAB00E9886F /* NSDate+DSO.m */; };
@@ -199,6 +200,8 @@
 		B2E75D7E1B87B1610015BE4A /* LDTReportbackItemDetailView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTReportbackItemDetailView.xib; path = Reportback/LDTReportbackItemDetailView.xib; sourceTree = "<group>"; };
 		B2E75D811B87B1920015BE4A /* LDTReportbackItemDetailSingleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTReportbackItemDetailSingleViewController.h; path = Reportback/LDTReportbackItemDetailSingleViewController.h; sourceTree = "<group>"; };
 		B2E75D821B87B1920015BE4A /* LDTReportbackItemDetailSingleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTReportbackItemDetailSingleViewController.m; path = Reportback/LDTReportbackItemDetailSingleViewController.m; sourceTree = "<group>"; };
+		B2F2BA811C6440BF001EB1D5 /* LDTUserViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTUserViewController.h; path = User/LDTUserViewController.h; sourceTree = "<group>"; };
+		B2F2BA821C6440BF001EB1D5 /* LDTUserViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTUserViewController.m; path = User/LDTUserViewController.m; sourceTree = "<group>"; };
 		B92B81EBB03D9FF4D34E3FD9 /* Pods-Lets Do This.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lets Do This.release.xcconfig"; path = "Pods/Target Support Files/Pods-Lets Do This/Pods-Lets Do This.release.xcconfig"; sourceTree = "<group>"; };
 		C20BA2771AF3DBE400E9886F /* DSOCampaign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DSOCampaign.h; sourceTree = "<group>"; };
 		C20BA2781AF3DBE400E9886F /* DSOCampaign.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DSOCampaign.m; sourceTree = "<group>"; };
@@ -453,6 +456,15 @@
 			name = Reportback;
 			sourceTree = "<group>";
 		};
+		B2F2BA841C6440C4001EB1D5 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				B2F2BA811C6440BF001EB1D5 /* LDTUserViewController.h */,
+				B2F2BA821C6440BF001EB1D5 /* LDTUserViewController.m */,
+			);
+			name = User;
+			sourceTree = "<group>";
+		};
 		C2B151E01ACE04C30028C336 = {
 			isa = PBXGroup;
 			children = (
@@ -561,6 +573,7 @@
 				C2F35F0A1AD8272C00D12FE5 /* Login */,
 				B211C41C1C3AF4AA00A94E64 /* Cause */,
 				B22274021B587A02005C896D /* Campaign */,
+				B2F2BA841C6440C4001EB1D5 /* User */,
 				B2BB8F1A1C457CF3000EA5CA /* News */,
 				B27AF0E11B4F487C00164926 /* Profile */,
 				B2E75D801B87B16C0015BE4A /* Reportback */,
@@ -874,6 +887,7 @@
 				B22AB7661B4EE78500BE7052 /* LDTUserLoginViewController.m in Sources */,
 				B223AD761B7A724000D4AA40 /* DSOReportbackItem.m in Sources */,
 				C20BA28D1AF3DCAB00E9886F /* NSDate+DSO.m in Sources */,
+				B2F2BA831C6440BF001EB1D5 /* LDTUserViewController.m in Sources */,
 				B24FE0311BAA49AA001CAD5D /* LDTSubmitReportbackViewController.m in Sources */,
 				B22273FE1B58076F005C896D /* DSOAPI.m in Sources */,
 				C20BA2881AF3DBE400E9886F /* DSOUser.m in Sources */,

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -8,7 +8,7 @@
 
 #import "LDTTabBarController.h"
 #import "LDTNewsFeedViewController.h"
-#import "LDTProfileViewController.h"
+#import "LDTUserViewController.h"
 #import "LDTOnboardingPageViewController.h"
 #import "LDTUserConnectViewController.h"
 #import "LDTCauseListViewController.h"
@@ -36,7 +36,7 @@
         newsFeedViewController.title = @"News";
         UINavigationController *newsFeedNavigationController = [[UINavigationController alloc] initWithRootViewController:newsFeedViewController];
 
-        LDTProfileViewController *profileVC = [[LDTProfileViewController alloc] initWithUser:[DSOUserManager sharedInstance].user];
+        LDTUserViewController *profileVC = [[LDTUserViewController alloc] initWithUser:[DSOUserManager sharedInstance].user];
         profileVC.title = @"Me";
         UINavigationController *profileNavVC = [[UINavigationController alloc] initWithRootViewController:profileVC];
         profileNavVC.tabBarItem.image = [UIImage imageNamed:@"Me Icon"];

--- a/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignDetailViewController.m
@@ -11,7 +11,7 @@
 #import "LDTCampaignDetailCampaignCell.h"
 #import "LDTCampaignDetailReportbackItemCell.h"
 #import "LDTHeaderCollectionReusableView.h"
-#import "LDTProfileViewController.h"
+#import "LDTUserViewController.h"
 #import "LDTSubmitReportbackViewController.h"
 #import "LDTActivityViewController.h"
 #import "GAI+LDT.h"
@@ -394,7 +394,7 @@ typedef NS_ENUM(NSInteger, LDTCampaignDetailCampaignSectionRow) {
 }
 
 - (void)didClickOnReportbackItemUserForReportbackItemDetailView:(LDTReportbackItemDetailView *)reportbackItemDetailView {
-    LDTProfileViewController *destVC = [[LDTProfileViewController alloc] initWithUser:reportbackItemDetailView.reportbackItem.user];
+    LDTUserViewController *destVC = [[LDTUserViewController alloc] initWithUser:reportbackItemDetailView.reportbackItem.user];
     [self.navigationController pushViewController:destVC animated:YES];
 }
 

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.h
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.h
@@ -10,6 +10,8 @@
 
 @interface LDTSubmitReportbackViewController : LDTBaseViewController
 
+- (instancetype)initWithCampaign:(DSOCampaign *)campaign reportbackItemImage:(UIImage *)reportbackItemImage;
+
 - (instancetype)initWithReportbackItem:(DSOReportbackItem *)reportbackItem;
 
 @end

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -36,6 +36,17 @@
 
 #pragma mark - NSObject
 
+- (instancetype)initWithCampaign:(DSOCampaign *)campaign reportbackItemImage:(UIImage *)reportbackItemImage {
+    self = [super initWithNibName:@"LDTSubmitReportbackView" bundle:nil];
+
+    if (self) {
+        _reportbackItem = [[DSOReportbackItem alloc] initWithCampaign:campaign];
+        _reportbackItem.image = reportbackItemImage;
+    }
+
+    return self;
+}
+
 - (instancetype)initWithReportbackItem:(DSOReportbackItem *)reportbackItem {
     self = [super initWithNibName:@"LDTSubmitReportbackView" bundle:nil];
 
@@ -200,7 +211,6 @@
         [rootVC dismissViewControllerAnimated:YES completion:^{
             [LDTMessage displaySuccessMessageWithTitle:@"Stunning!" subtitle:[NSString stringWithFormat:@"You submitted your %@ photo for approval.", self.reportbackItem.campaign.title]];
         }];
-
     } errorHandler:^(NSError *error) {
         [SVProgressHUD dismiss];
         [LDTMessage displayErrorMessageInViewController:self error:error];

--- a/Lets Do This/Controllers/User/LDTUserViewController.h
+++ b/Lets Do This/Controllers/User/LDTUserViewController.h
@@ -1,0 +1,15 @@
+//
+//  LDTUserViewController.h
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 2/4/16.
+//  Copyright © 2016 Do Something. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface LDTUserViewController : UIViewController
+
+- (instancetype)initWithUser:(DSOUser *)user;
+
+@end

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -1,0 +1,234 @@
+//
+//  LDTUserViewController.m
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 2/4/16.
+//  Copyright © 2016 Do Something. All rights reserved.
+//
+
+#import "LDTUserViewController.h"
+#import "LDTTheme.h"
+#import "LDTTabBarController.h"
+#import "LDTCampaignDetailViewController.h"
+#import "LDTSubmitReportbackViewController.h"
+#import "LDTSettingsViewController.h"
+#import "GAI+LDT.h"
+#import "LDTAppDelegate.h"
+#import <RCTBridgeModule.h>
+#import <RCTRootView.h>
+
+@interface LDTUserViewController () <RCTBridgeModule, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
+
+@property (assign, nonatomic) BOOL isCurrentUserProfile;
+@property (strong, nonatomic) DSOCampaign *selectedCampaign;
+@property (strong, nonatomic) DSOUser *user;
+@property (strong, nonatomic) RCTRootView *reactRootView;
+@property (strong, nonatomic) UIImagePickerController *imagePickerController;
+
+@end
+
+@implementation LDTUserViewController
+
+#pragma mark - NSObject
+
+-(instancetype)initWithUser:(DSOUser *)user {
+    self = [super init];
+
+    if (self) {
+        _user = user;
+    }
+
+    return self;
+}
+
+#pragma mark - UIViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.navigationItem.title = nil;
+
+    if ([self.user isLoggedInUser] || !self.user) {
+        self.user = [DSOUserManager sharedInstance].user;
+        self.isCurrentUserProfile = YES;
+    }
+
+    if (self.isCurrentUserProfile) {
+        UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"Settings Icon"] style:UIBarButtonItemStylePlain target:self action:@selector(settingsTapped:)];
+        self.navigationItem.rightBarButtonItem = settingsButton;
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(receivedNotification:) name:@"updateCurrentUser" object:nil];
+    }
+
+    NSURL *jsCodeLocation = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate).jsCodeLocation;
+    self.reactRootView =[[RCTRootView alloc] initWithBundleURL:jsCodeLocation moduleName: @"UserView" initialProperties:[self appProperties] launchOptions:nil];
+    self.view = self.reactRootView;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+
+    [self.navigationController styleNavigationBar:LDTNavigationBarStyleClear];
+    [self.navigationController setNavigationBarHidden:NO animated:YES];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    [self styleView];
+
+    self.navigationController.hidesBarsOnSwipe = YES;
+    [self.navigationController.barHideOnSwipeGestureRecognizer addTarget:self action:@selector(handleSwipeGestureRecognizer:)];
+
+    // Make sure self profile is to to date
+    if (self.isCurrentUserProfile) {
+        self.user = [DSOUserManager sharedInstance].user;
+        self.reactRootView.appProperties = [self appProperties];
+    }
+
+    NSString *trackingString;
+    if (self.isCurrentUserProfile) {
+        trackingString = @"self";
+    }
+    else {
+        trackingString = self.user.userID;
+    }
+    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"user-profile/%@", trackingString]];
+}
+
+#pragma mark - LDTUserProfileViewController
+
+- (void)styleView {
+    [self styleBackBarButton];
+}
+
+- (NSDictionary *)appProperties {
+    NSString *profileURL = [[DSOAPI sharedInstance] profileURLforUser:self.user];
+    return @{
+           @"user" : self.user.dictionary,
+           @"url" : profileURL,
+           @"isSelfProfile" : [NSNumber numberWithBool:self.isCurrentUserProfile],
+           };
+}
+
+- (void)receivedNotification:(NSNotification *)notification {
+    if ([[notification name] isEqualToString:@"updateCurrentUser"]) {
+      self.reactRootView.appProperties = [self appProperties];
+    }
+}
+
+- (void)handleSwipeGestureRecognizer:(UISwipeGestureRecognizer *)recognizer {
+    [self setNeedsStatusBarAppearanceUpdate];
+}
+
+- (void)presentCampaignDetailViewControllerForCampaignId:(NSInteger)campaignID {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
+        LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
+        UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
+        LDTCampaignDetailViewController *campaignDetailViewController = [[LDTCampaignDetailViewController alloc] initWithCampaign:campaign];
+        [navigationController pushViewController:campaignDetailViewController animated:YES];
+    });
+}
+
+- (void)presentReportbackAlertControllerForCampaignId:(NSInteger)campaignID {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        // Initalizing here, because when we add it into viewDidLoad its set to nil at this point and we crash with uncaught exception 'NSInvalidArgumentException', reason: 'Application tried to present a nil modal view controller on target <LDTTabBarController>.'
+        // @todo This is pretty nasty to init every time. Some options are just getting this to work in viewDidLoad... or trying to send the selected file from React Native here
+        self.imagePickerController = [[UIImagePickerController alloc] init];
+        self.imagePickerController.delegate = self;
+        self.imagePickerController.allowsEditing = YES;
+        LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
+        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
+        self.selectedCampaign = campaign;
+        // @todo New reportbackPhotoAlertController subclass to DRY with Campaign Detail VC
+        UIAlertController *reportbackPhotoAlertController = [UIAlertController alertControllerWithTitle:@"Pics or it didn't happen!" message:nil                                                              preferredStyle:UIAlertControllerStyleActionSheet];
+        UIAlertAction *cameraAlertAction;
+        if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+            cameraAlertAction = [UIAlertAction actionWithTitle:@"Take Photo" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
+                [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"camera" value:nil];
+                self.imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
+                [tabBarController presentViewController:self.imagePickerController animated:YES completion:NULL];
+            }];
+        }
+        else {
+            cameraAlertAction = [UIAlertAction actionWithTitle:@"(Camera Unavailable)" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
+                // Nada
+            }];
+        }
+        UIAlertAction *photoLibraryAlertAction = [UIAlertAction actionWithTitle:@"Choose From Library" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
+            [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"gallery" value:nil];
+            self.imagePickerController.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+            [tabBarController presentViewController:self.imagePickerController animated:YES completion:NULL];
+        }];
+        UIAlertAction *cancelAlertAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
+            [reportbackPhotoAlertController dismissViewControllerAnimated:YES completion:nil];
+        }];
+        [reportbackPhotoAlertController addAction:cameraAlertAction];
+        [reportbackPhotoAlertController addAction:photoLibraryAlertAction];
+        [reportbackPhotoAlertController addAction:cancelAlertAction];
+        [tabBarController presentViewController:reportbackPhotoAlertController animated:YES completion:nil];
+    });
+}
+
+- (IBAction)settingsTapped:(id)sender {
+    LDTSettingsViewController *destVC = [[LDTSettingsViewController alloc] initWithNibName:@"LDTSettingsView" bundle:nil];
+    UINavigationController *destNavVC = [[UINavigationController alloc] initWithRootViewController:destVC];
+    [destNavVC styleNavigationBar:LDTNavigationBarStyleClear];
+    LDTTabBarController *tabBar = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    [tabBar presentViewController:destNavVC animated:YES completion:nil];
+}
+
+                                                             
+#pragma mark - RCTBridgeModule
+
+RCT_EXPORT_MODULE();
+
+- (NSDictionary *)constantsToExport {
+    NSDictionary *headers = [DSOUserManager sharedInstance].headers;
+    NSLog(@"headers %@", headers);
+    NSDictionary *campaigns =  [DSOUserManager sharedInstance].campaignDictionaries;
+    NSDictionary *props = @{
+                            @"apiKey" : headers[@"apiKey"],
+                            @"session" : headers[@"session"],
+                            @"campaigns" : campaigns
+                            };
+    return props;
+}
+
+
+RCT_EXPORT_METHOD(presentCampaign:(NSInteger)campaignID) {
+    [self presentCampaignDetailViewControllerForCampaignId:campaignID];
+}
+
+RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {
+    [self presentReportbackAlertControllerForCampaignId:campaignID];
+}
+
+# pragma mark - UINavigationControllerDelegate
+
+- (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
+    [viewController.navigationController styleNavigationBar:LDTNavigationBarStyleNormal];
+    viewController.title = [NSString stringWithFormat:@"I did %@", self.selectedCampaign.title].uppercaseString;
+    [viewController styleRightBarButton];
+    [viewController styleBackBarButton];
+}
+
+
+#pragma mark - UIImagePickerControllerDelegate
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
+    [picker dismissViewControllerAnimated:YES completion:^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
+            UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
+            UIImage *selectedImage = info[UIImagePickerControllerEditedImage];
+            LDTSubmitReportbackViewController *destVC = [[LDTSubmitReportbackViewController alloc] initWithCampaign:self.selectedCampaign reportbackItemImage:selectedImage];
+            UINavigationController *destNavVC = [[UINavigationController alloc] initWithRootViewController:destVC];
+            [navigationController presentViewController:destNavVC animated:YES completion:nil];
+        });
+    }];
+
+
+}
+
+@end

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -80,7 +80,7 @@
     [self.navigationController.barHideOnSwipeGestureRecognizer addTarget:self action:@selector(handleSwipeGestureRecognizer:)];
 
     // Make sure self profile is to to date
-    if (self.isCurrentUserProfile) {
+    if (self.isCurrentUserProfile && [DSOUserManager sharedInstance].user) {
         self.user = [DSOUserManager sharedInstance].user;
         self.reactRootView.appProperties = [self appProperties];
     }
@@ -102,13 +102,25 @@
 }
 
 - (NSDictionary *)appProperties {
+    NSDictionary *appProperties;
     NSString *profileURL = [[DSOAPI sharedInstance] profileURLforUser:self.user];
-    return @{
+    NSDictionary *userDict = [[NSDictionary alloc] init];
+    NSString *sessionToken = @"";
+    if (self.user) {
+        userDict = self.user.dictionary;
+        sessionToken = [DSOUserManager sharedInstance].sessionToken;
+    }
+
+    appProperties = @{
            @"user" : self.user.dictionary,
            @"url" : profileURL,
            @"isSelfProfile" : [NSNumber numberWithBool:self.isCurrentUserProfile],
+           @"apiKey": [DSOAPI sharedInstance].apiKey,
+           @"sessionToken": sessionToken,
            };
+    return appProperties;
 }
+
 
 - (void)receivedNotification:(NSNotification *)notification {
     if ([[notification name] isEqualToString:@"updateCurrentUser"]) {
@@ -184,14 +196,8 @@
 RCT_EXPORT_MODULE();
 
 - (NSDictionary *)constantsToExport {
-    NSDictionary *headers = [DSOUserManager sharedInstance].headers;
-    NSLog(@"headers %@", headers);
     NSDictionary *campaigns =  [DSOUserManager sharedInstance].campaignDictionaries;
-    NSDictionary *props = @{
-                            @"apiKey" : headers[@"apiKey"],
-                            @"session" : headers[@"session"],
-                            @"campaigns" : campaigns
-                            };
+    NSDictionary *props = @{@"campaigns" : campaigns};
     return props;
 }
 

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -88,6 +88,7 @@
              @"id" : [NSNumber numberWithInteger:self.campaignID],
              @"title" : self.title,
              @"image_url" : coverImage,
+             @"tagline" : self.tagline,
              };
 }
 

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -14,6 +14,8 @@
 @interface DSOUser : NSObject
 
 @property (nonatomic, strong, readonly) NSArray *campaignSignups;
+@property (nonatomic, strong, readonly) NSDictionary *dictionary;
+@property (nonatomic, strong, readonly) NSString *avatarURL;
 @property (nonatomic, strong, readonly) NSString *countryCode;
 @property (nonatomic, strong, readonly) NSString *countryName;
 @property (nonatomic, strong, readonly) NSString *displayName;

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -14,6 +14,7 @@
 @interface DSOUser()
 
 @property (nonatomic, strong, readwrite) NSMutableArray *mutableCampaignSignups;
+@property (nonatomic, strong, readwrite) NSString *avatarURL;
 @property (nonatomic, strong, readwrite) NSString *countryCode;
 @property (nonatomic, strong, readwrite) NSString *displayName;
 @property (nonatomic, strong, readwrite) NSString *email;
@@ -45,7 +46,7 @@
         _email = dict[@"email"];
         _sessionToken = dict[@"session_token"];
         _mutableCampaignSignups = [[NSMutableArray alloc] init];
-		
+        _avatarURL = [dict valueForKeyAsString:@"photo" nullValue:@""];
         if (dict[@"photo"]) {
             [[SDWebImageManager sharedManager] downloadImageWithURL:dict[@"photo"] options:0 progress:0 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL){
                  _photo = image;
@@ -56,7 +57,16 @@
     return self;
 }
 
+#pragma mark - Accessors
 
+- (NSDictionary *)dictionary {
+    return @{
+             @"id" : self.userID,
+             @"displayName" : self.displayName,
+             @"countryName" : self.countryName,
+             @"avatarURL": self.avatarURL
+             };
+}
 
 - (UIImage *)photo {
     if (!_photo) {

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -15,6 +15,7 @@
 
 @interface DSOAPI : AFHTTPSessionManager
 
+@property (nonatomic, strong, readonly) NSString *apiKey;
 @property (nonatomic, strong, readonly) NSString *phoenixBaseURL;
 @property (nonatomic, strong, readonly) NSString *phoenixApiURL;
 @property (nonatomic, strong, readonly) NSString *newsApiURL;
@@ -47,5 +48,6 @@
 
 - (void)loadCampaignSignupsForUser:(DSOUser *)user completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+- (NSString *)profileURLforUser:(DSOUser *)user;
 
 @end

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -40,6 +40,7 @@
 
 @interface DSOAPI()
 
+@property (nonatomic, strong, readwrite) NSString *apiKey;
 @property (nonatomic, strong, readwrite) NSString *phoenixBaseURL;
 @property (nonatomic, strong, readwrite) NSString *phoenixApiURL;
 @property (nonatomic, strong, readwrite) NSString *northstarBaseURL;
@@ -72,6 +73,7 @@
     self = [super initWithBaseURL:[NSURL URLWithString:northstarURLString]];
 
     if (self) {
+        _apiKey = apiKey;
         if (activityLoggerEnabled) {
             [[AFNetworkActivityLogger sharedLogger] startLogging];
             [[AFNetworkActivityLogger sharedLogger] setLevel:AFLoggerLevelDebug];
@@ -324,5 +326,11 @@
 - (void)logError:(NSError *)error methodName:(NSString *)methodName URLString:(NSString *)URLString {
     NSLog(@"\n*** DSOAPI ****\n\nError %li: %@\n%@\n%@ \n\n", (long)error.code, error.localizedDescription, methodName, URLString);
 }
+
+- (NSString *)profileURLforUser:(DSOUser *)user {
+    NSString *northstarURLString = [NSString stringWithFormat:@"https://%@/v1/", LDTSERVER];
+    return [NSString stringWithFormat:@"%@users/_id/%@/campaigns", northstarURLString, user.userID];
+}
+
 
 @end

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -13,8 +13,8 @@
 // Stores the current/authenticated user.
 @property (strong, nonatomic, readonly) DSOUser *user;
 
-// Stores headers for authenticated API requests.
-@property (strong, nonatomic, readonly) NSDictionary *headers;
+// Stores session token for authenticated API requests.
+@property (strong, nonatomic, readonly) NSString *sessionToken;
 
 // Stores all active DSOCampaigns to display.
 @property (strong, nonatomic, readonly) NSArray *activeCampaigns;

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -13,8 +13,12 @@
 // Stores the current/authenticated user.
 @property (strong, nonatomic, readonly) DSOUser *user;
 
+// Stores headers for authenticated API requests.
+@property (strong, nonatomic, readonly) NSDictionary *headers;
+
 // Stores all active DSOCampaigns to display.
 @property (strong, nonatomic, readonly) NSArray *activeCampaigns;
+@property (strong, nonatomic, readonly) NSDictionary *campaignDictionaries;
 
 // Singleton object for accessing authenticated User, activeCampaigns
 + (DSOUserManager *)sharedInstance;

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -61,25 +61,14 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     return [campaigns copy];
 }
 
-- (NSDictionary *)headers {
-    NSString *session = [SSKeychain passwordForService:self.currentService account:@"Session"];
-    NSString *apiKey = [DSOAPI sharedInstance].apiKey;
-    return @{
-             @"session" : session,
-             @"apiKey" : apiKey
-             };
-}
-
-#pragma mark - DSOUser
-
 - (NSString *)currentService {
     return [DSOAPI sharedInstance].baseURL.absoluteString;
 }
 
+#pragma mark - DSOUserManager
+
 - (BOOL)userHasCachedSession {
-    NSString *sessionToken = [SSKeychain passwordForService:self.currentService account:@"Session"];
-	
-    return sessionToken.length > 0;
+    return self.sessionToken.length > 0;
 }
 
 - (void)createSessionWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
@@ -100,22 +89,26 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
       }];
 }
 
-- (void)startSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+- (NSString *)sessionToken {
+    return [SSKeychain passwordForService:self.currentService account:@"Session"];
+}
 
-    NSString *sessionToken = [SSKeychain passwordForService:self.currentService account:@"Session"];
-    if (sessionToken.length == 0) {
+- (void)startSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    if (self.sessionToken.length == 0) {
         // @todo: Should return error here.
         return;
     }
 
     // @todo: Once Northstar API supports it, actively check for whether or saved session is valid before trying to start.
     // @see https://github.com/DoSomething/northstar/issues/186
-    [[DSOAPI sharedInstance] setHTTPHeaderFieldSession:sessionToken];
+    [[DSOAPI sharedInstance] setHTTPHeaderFieldSession:self.sessionToken];
 
     NSString *userID = [SSKeychain passwordForService:self.currentService account:@"UserID"];
     [[DSOAPI sharedInstance] loadUserWithUserId:userID completionHandler:^(DSOUser *user) {
         self.user = user;
         [self loadActiveCampaignSignupsForUser:self.user completionHandler:^{
+            // Adding this here for edge case when we need to refresh a User's Profile from signing out and then signing in as a different user.
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"updateCurrentUser" object:self];
             if (completionHandler) {
                 completionHandler();
             }

--- a/ReactComponents/NewsFeedView.js
+++ b/ReactComponents/NewsFeedView.js
@@ -79,9 +79,7 @@ var NewsFeedView = React.createClass({
       </View>
     );
   },
-  renderRow: function(
-    post: Object,
-  ) {
+  renderRow: function(post) {
     return (
       <NewsFeedPost
         key={post.id}

--- a/ReactComponents/ReportbackItemView.js
+++ b/ReactComponents/ReportbackItemView.js
@@ -1,0 +1,100 @@
+'use strict';
+
+import React, {
+  StyleSheet,
+  Text,
+  Image,
+  TouchableHighlight,
+  View
+} from 'react-native';
+import Dimensions from 'Dimensions';
+
+var Style = require('./Style.js');
+
+var ReportbackItemView = React.createClass({
+  render: function() {
+    // We only supporting displaying a single reportbackItem for now.
+    var reportbackItem = this.props.reportback.reportback_items.data[0];
+    var campaign = this.props.reportback.campaign;
+    var quantityLabel = campaign.reportback_info.noun + ' ' + campaign.reportback_info.verb;
+    var user = this.props.reportback.user;
+    // @todo: Need countryName from iOS
+    if (user.first_name.length == 0) {
+      user.first_name = 'Doer';
+    }
+    if (user.photo.length == 0) {
+      this.props.user.avatarURL = 'https://placekitten.com/g/600/600';
+    }
+
+    return(
+      <View style={styles.container}>
+       <Text style={[Style.textCaption, styles.countryNameText]}>{user.country}</Text>
+        <Image
+          style={styles.reportbackItemImage}
+          source={{uri:reportbackItem.media.uri}}
+        />
+        <View style={styles.contentContainer}>
+          <View style={{flexDirection: 'row'}}>
+            <Text style={[Style.textBodyBold, Style.textColorCtaBlue, {flex: 1}]}>
+              {campaign.title}
+            </Text>
+            <Text style={[Style.textCaptionBold, {textAlign: 'right'}]}>
+              {this.props.reportback.quantity} {quantityLabel}
+            </Text>
+          </View>
+          <Text style={Style.textBody}>{reportbackItem.caption}</Text>
+        </View>
+        <View style={styles.userContainer}>
+          <Image
+            style={styles.avatarImage}
+            source={{uri:user.photo}}
+          />
+          <Text style={[Style.textBodyBold, Style.textColorCtaBlue, styles.usernameText]}>
+            {user.first_name.toUpperCase()}
+          </Text>
+        </View>
+      </View>
+    );
+  }
+});
+
+var styles = React.StyleSheet.create({
+  container: {
+    backgroundColor: 'white',
+    paddingTop: 16,
+  },
+  headerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  userContainer: {
+    backgroundColor: 'transparent',
+    position: 'absolute',
+    flexDirection: 'row',
+    top: 14,
+    left: 8,
+  },
+  usernameText: {
+    paddingLeft: 5,
+  },
+  countryNameText: {
+    textAlign: 'right',
+    paddingRight: 8,
+  },
+  avatarImage: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    borderColor: 'white',
+    borderWidth: 2,
+  },
+  reportbackItemImage: {
+    height: Dimensions.get('window').width,
+  },
+  contentContainer: {
+    padding: 8,
+  },
+});
+
+module.exports = ReportbackItemView;

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -47,8 +47,8 @@ var UserView = React.createClass({
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Session': UserViewController.session,
-        'X-DS-REST-API-Key': UserViewController.apiKey,
+        'Session': this.props.sessionToken,
+        'X-DS-REST-API-Key': this.props.apiKey,
       },
     };
     fetch(this.props.url, options)
@@ -60,6 +60,9 @@ var UserView = React.createClass({
           rowIDs = [],
           i;
 
+        if (!responseData.data) {
+          return;
+        }
         sectionIDs.push(0);
         dataBlob[0] = "Actions I'm doing";
         rowIDs[0] = [];

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -14,6 +14,7 @@ import React, {
 
 var Style = require('./Style.js');
 var UserViewController = require('react-native').NativeModules.LDTUserViewController;
+var ReportbackItemView = require('./ReportbackItemView.js');
 
 var UserView = React.createClass({
   getInitialState: function() {
@@ -185,16 +186,10 @@ var UserView = React.createClass({
     );
   },
   renderDoneRow: function(signup) {
-    var campaignIDString = signup.drupal_id.toString();
-    var campaign = UserViewController.campaigns[campaignIDString];
     return (
-      <TouchableHighlight onPress={() => this._onPressRow(signup)}>
-        <View style={styles.row}>
-          <Text style={[Style.textHeading, Style.textColorCtaBlue]}>
-            Test {campaign.title}
-          </Text>
-        </View>
-      </TouchableHighlight>
+      <ReportbackItemView
+        key={signup.reportback_id}
+        reportback={signup.reportback_data} />
     );
   },
   _onPressRow(signup) {

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -1,0 +1,250 @@
+'use strict';
+
+import React, {
+  Component,
+  ListView,
+  StyleSheet,
+  Text,
+  Image,
+  RefreshControl,
+  TouchableHighlight,
+  ActivityIndicatorIOS,
+  View
+} from 'react-native';
+
+var Style = require('./Style.js');
+var UserViewController = require('react-native').NativeModules.LDTUserViewController;
+
+var UserView = React.createClass({
+  getInitialState: function() {
+    var getSectionData = (dataBlob, sectionID) => {
+      return dataBlob[sectionID];
+    }
+    var getRowData = (dataBlob, sectionID, rowID) => {
+      return dataBlob[sectionID + ':' + rowID];
+    }
+    return {
+      dataSource : new ListView.DataSource({
+        getSectionData          : getSectionData,
+        getRowData              : getRowData,
+        rowHasChanged           : (row1, row2) => row1 !== row2,
+        sectionHeaderHasChanged : (s1, s2) => s1 !== s2
+      }),
+      isRefreshing: false,
+      loaded: false,
+    };
+  },
+  componentDidMount: function() {
+    this.fetchData();
+  },
+  componentWillUpdate: function() {
+    this.fetchData();
+  },
+  fetchData: function() {
+    var options = { 
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Session': UserViewController.session,
+        'X-DS-REST-API-Key': UserViewController.apiKey,
+      },
+    };
+    fetch(this.props.url, options)
+      .then((response) => response.json())
+      .then((responseData) => {
+        var signups = responseData.data,
+          dataBlob = {},
+          sectionIDs = [],
+          rowIDs = [],
+          i;
+
+        sectionIDs.push(0);
+        dataBlob[0] = "Actions I'm doing";
+        rowIDs[0] = [];
+        sectionIDs.push(1);
+        dataBlob[1] = "Actions I've done";
+        rowIDs[1] = [];
+        for (i = 0; i < signups.length; i++) {
+          var signup = signups[i];
+          var sectionNumber = 0;
+          if (signup.reportback_data) {
+            sectionNumber = 1;
+          }
+          rowIDs[sectionNumber].push(signup.signup_id);
+          dataBlob[sectionNumber + ':' + signup.signup_id] = signup;
+        }
+
+        this.setState({
+          dataSource : this.state.dataSource.cloneWithRowsAndSections(dataBlob, sectionIDs, rowIDs),
+          loaded: true,
+        });
+      })
+      .done();
+  },
+  _onRefresh: function () {
+    this.setState({isRefreshing: true});
+    setTimeout(() => {
+      this.fetchData();
+      this.setState({
+        isRefreshing: false,
+      });
+    }, 1000);
+  },
+  renderLoadingView: function() {
+    // @todo DRY LoadingView ReactComponent
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicatorIOS animating={this.state.animating} style={[{height: 80}]} size="small" />
+        <Text style={Style.textBody}>
+          Loading profile...
+        </Text>
+      </View>
+    );
+  },
+  render: function() {
+    if (!this.state.loaded) {
+      return this.renderLoadingView();
+    }
+    return (
+      <ListView
+        style={Style.backgroundColorCtaBlue}
+        dataSource={this.state.dataSource}
+        renderRow={this.renderRow}
+        renderHeader={this.renderHeader}
+        renderSectionHeader = {this.renderSectionHeader}
+        refreshControl={
+          <RefreshControl
+            refreshing={this.state.isRefreshing}
+            onRefresh={this._onRefresh}
+            tintColor="white"
+            colors={['#ff0000', '#00ff00', '#0000ff']}
+            progressBackgroundColor="#ffff00"
+          />
+        }
+      />
+    );
+  },
+  renderHeader: function() {
+    var avatarURL = this.props.user.avatarURL;
+    if (avatarURL.length == 0) {
+      this.props.user.avatarURL = 'https://placekitten.com/g/600/600';
+    }
+    return (
+      <View style={[Style.backgroundColorCtaBlue, styles.headerContainer]}>
+        <Image
+          style={styles.avatar}
+          source={{uri: this.props.user.avatarURL}}
+        />
+        <Text style={[Style.textTitle, styles.headerText]}>
+          {this.props.user.displayName.toUpperCase()}
+        </Text>
+        <Text style={[Style.textHeading, styles.headerText]}>
+          {this.props.user.countryName.toUpperCase()}
+        </Text>
+      </View>
+    );
+  },
+  renderSectionHeader(sectionData, sectionID) {
+    return (
+      <View style={styles.sectionContainer}>
+        <Text style={[Style.textHeading, {textAlign: 'center'}]}>
+          {sectionData.toUpperCase()}
+        </Text>
+      </View>
+    );
+  },
+  renderRow: function(signup) {
+    if (!signup.drupal_id) {
+      return null;
+    }
+    if (signup.reportback_data) {
+      return this.renderDoneRow(signup);
+    }
+    else {
+      return this.renderDoingRow(signup);
+    }
+  },
+  renderDoingRow: function(signup) {
+    var campaignIDString = signup.drupal_id.toString();
+    var campaign = UserViewController.campaigns[campaignIDString];
+    if (this.props.isSelfProfile) {
+      // Render Prove It button
+    }
+    return (
+      <TouchableHighlight onPress={() => this._onPressDoingRow(signup)}>
+        <View style={styles.row}>
+          <Text style={[Style.textHeading, Style.textColorCtaBlue]}>
+            {campaign.title}
+          </Text>
+          <Text style={Style.textBody}>
+            {campaign.tagline}
+          </Text>
+        </View>
+      </TouchableHighlight>
+    );
+  },
+  renderDoneRow: function(signup) {
+    var campaignIDString = signup.drupal_id.toString();
+    var campaign = UserViewController.campaigns[campaignIDString];
+    return (
+      <TouchableHighlight onPress={() => this._onPressRow(signup)}>
+        <View style={styles.row}>
+          <Text style={[Style.textHeading, Style.textColorCtaBlue]}>
+            Test {campaign.title}
+          </Text>
+        </View>
+      </TouchableHighlight>
+    );
+  },
+  _onPressRow(signup) {
+    UserViewController.presentCampaign(Number(signup.drupal_id));
+  },
+  _onPressDoingRow(signup) {
+    var campaignID = Number(signup.drupal_id);
+    if (this.props.isSelfProfile) {
+      UserViewController.presentProveIt(campaignID);
+    }
+    else {
+      UserViewController.presentCampaign(campaignID);
+    }
+  },
+});
+
+var styles = React.StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#EEE',
+  },
+  headerContainer: {
+    alignItems: 'center',
+    flex: 1,
+    padding: 20,
+  },
+  sectionContainer: {
+    backgroundColor: '#F8F8F6',
+    padding: 14,
+  },
+  avatar: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    borderColor: 'white',
+    borderWidth: 2,
+    alignItems: 'center',
+  },
+  headerText: {
+    color: 'white',
+    flex: 1,
+    textAlign: 'center',
+  },
+  row: {
+    backgroundColor: 'white',
+    padding: 8,
+  },
+});
+
+module.exports = UserView;

--- a/index.ios.js
+++ b/index.ios.js
@@ -11,3 +11,6 @@ AppRegistry.registerComponent('CauseListView', () => CauseListView);
 
 var CauseDetailView = require('./ReactComponents/CauseDetailView.js');
 AppRegistry.registerComponent('CauseDetailView', () => CauseDetailView);
+
+var UserView = require('./ReactComponents/UserView.js');
+AppRegistry.registerComponent('UserView', () => UserView);


### PR DESCRIPTION
Begins work on the Profile Completed section (#807):
* Adds new `UserView` and `ReporbackItemView` React Components.
* Presents imagePicker / Submit Reportback screen on self profile when tapping a Doing campaign. Upon submitting a reportback, the User's profile is reloaded.

Decided to give rebuilding the Profile in React Native a try, as it seems easier to share code for networking errors if all main content-based screens are rendered with RN (#773, #620, #664). So far so good, it's definitely a lot easier (and a lot less code) for layout / self sizing content. Things aren't 100% dev complete but this is a good non-breaking place to merge into `develop` for a new release.

### TODO:
* [ ] Render the Prove It button on the Self Profile
* [ ] Present Campaign Detail from the User Profile
* [ ] Display user countryName instead of countryCode in `ReportbackItemView.js`
* [ ] Kill all now deprecated `UITableView`/  `LDTProfileViewController` code
* [ ] Refactor Campaign Detail as React Native component to re-use the `ReportbackItemView.js`
* [ ] Remove the observer from the User Profile upon `viewDidLoad` .. but this is tricky. Technically we never want to remove it from the self profile, but where we run into issues is the rare edge case where someone can access their profile from a campaign gallery. 
* [ ] DRY the Reportback Alert Controller, if possible (requires separate `self.imagePickerController`)... or potentially add this all into the `LDTBaseViewController` and have the Campaign Detail and User Profile subclass
* [ ] Remove sticky section headers? They randomly seem to stick and not stick (gif in this PR shows it both working and not working). having the transparent navigationBar seems to complicate.
* [ ] Reusable networking components (Loading View, Network Error View, [Network Image](https://facebook.github.io/react-native/docs/image.html#examples))

### Screens
![doing](https://cloud.githubusercontent.com/assets/1236811/12893411/f7f01b06-ce5e-11e5-9ab9-2e1154af1b25.gif)