### PR TITLE
Filter UserView data by active campaigns

### DIFF
--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -172,6 +172,9 @@ var UserView = React.createClass({
   renderDoingRow: function(signup) {
     var campaignIDString = signup.drupal_id.toString();
     var campaign = UserViewController.campaigns[campaignIDString];
+    if (!campaign) {
+      return null;
+    }
     if (this.props.isSelfProfile) {
       // Render Prove It button
     }


### PR DESCRIPTION
Missed this in #815 
App crashes if the campaign doesn't exist (because it's not active). We may run into the same problem displaying reportbacks for closed campaigns also.... 