### PR TITLE
Northstar signups endpoint

### DIFF
--- a/Lets Do This/Models/DSOCampaignSignup.h
+++ b/Lets Do This/Models/DSOCampaignSignup.h
@@ -14,6 +14,7 @@
 @property (strong, nonatomic) DSOCampaign *campaign;
 @property (strong, nonatomic) DSOUser *user;
 @property (strong, nonatomic) DSOReportbackItem *reportbackItem;
+@property (assign, nonatomic, readonly) NSInteger signupID;
 
 - (instancetype)initWithCampaign:(DSOCampaign *)campaign user:(DSOUser *)user;
 - (instancetype)initWithDict:(NSDictionary *)dict;

--- a/Lets Do This/Models/DSOCampaignSignup.m
+++ b/Lets Do This/Models/DSOCampaignSignup.m
@@ -9,6 +9,12 @@
 #import "DSOCampaignSignup.h"
 #import "NSDictionary+DSOJsonHelper.h"
 
+@interface DSOCampaignSignup ()
+
+@property (assign, nonatomic, readwrite) NSInteger signupID;
+
+@end
+
 @implementation DSOCampaignSignup
 
 - (instancetype)initWithCampaign:(DSOCampaign *)campaign user:(DSOUser *)user {
@@ -16,6 +22,7 @@
 
     if (self) {
         _campaign = campaign;
+        // Dont think we even need this here, its always for the current user and we store signups array on a user.
         _user = user;
     }
 
@@ -26,21 +33,9 @@
     self = [super init];
 
     if (self) {
-        NSInteger reportbackID = [dict valueForKeyAsInt:@"reportback_id" nullValue:0];
-        if (reportbackID > 0 && [dict valueForJSONKey:@"reportback_data"]) {
-            _campaign = [[DSOCampaign alloc] initWithDict:(NSDictionary *)[dict valueForKeyPath:@"reportback_data.campaign"]];
-            NSArray *reportbackItems = [dict[@"reportback_data"] valueForKeyPath:@"reportback_items.data"];
-            // For now, we only support uploading and displaying a single ReportbackItem per Reportback. Future functionality could include uploading multiple ReportbackItems, as per the web.
-            NSDictionary *reportbackItemDict = reportbackItems.firstObject;
-            _reportbackItem = [[DSOReportbackItem alloc] initWithCampaign:self.campaign];
-            _reportbackItem.quantity = [[dict valueForKeyPath:@"reportback_data.quantity"] integerValue];
-            _reportbackItem.caption = reportbackItemDict[@"caption"];
-            _reportbackItem.imageURL =[NSURL URLWithString:[reportbackItemDict valueForKeyPath:@"media.uri"]];
-        }
-        else {
-            // If no reportback_id exists, API returns the campaign simply as a drupal_id (corresponding to its campaign ID, no object returned) -- https://github.com/DoSomething/northstar/issues/210
-            _campaign = [[DSOCampaign alloc] initWithCampaignID:[dict valueForKeyAsInt:@"drupal_id" nullValue:0] title:nil];
-        }
+        _signupID = [dict valueForKeyAsInt:@"id" nullValue:0];
+        _campaign = [[DSOCampaign alloc] initWithDict:dict[@"campaign"]];
+        // @todo: Waiting for Reportback object: https://github.com/DoSomething/phoenix/issues/6151
     }
 
     return self;

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -15,6 +15,7 @@
 
 @property (nonatomic, strong, readonly) NSArray *campaignSignups;
 @property (nonatomic, strong, readonly) NSDictionary *dictionary;
+@property (nonatomic, assign, readonly) NSInteger phoenixID;
 @property (nonatomic, strong, readonly) NSString *avatarURL;
 @property (nonatomic, strong, readonly) NSString *countryCode;
 @property (nonatomic, strong, readonly) NSString *countryName;

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -13,6 +13,7 @@
 
 @interface DSOUser()
 
+@property (nonatomic, assign, readwrite) NSInteger phoenixID;
 @property (nonatomic, strong, readwrite) NSMutableArray *mutableCampaignSignups;
 @property (nonatomic, strong, readwrite) NSString *avatarURL;
 @property (nonatomic, strong, readwrite) NSString *countryCode;
@@ -44,6 +45,7 @@
         }
         _firstName = [dict valueForKeyAsString:@"first_name" nullValue:@"Doer"];
         _email = dict[@"email"];
+        _phoenixID = [dict valueForKeyAsInt:@"drupal_id" nullValue:0];
         _sessionToken = dict[@"session_token"];
         _mutableCampaignSignups = [[NSMutableArray alloc] init];
         _avatarURL = [dict valueForKeyAsString:@"photo" nullValue:@""];

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -305,7 +305,7 @@
 }
 
 - (void)loadCampaignSignupsForUser:(DSOUser *)user completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    NSString *url = [NSString stringWithFormat:@"users/_id/%@/campaigns", user.userID];
+    NSString *url = [self profileURLforUser:user];
     [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         NSMutableArray *campaignSignups = [[NSMutableArray alloc] init];
         for (NSDictionary *campaignSignupDict in responseObject[@"data"]) {
@@ -329,7 +329,7 @@
 
 - (NSString *)profileURLforUser:(DSOUser *)user {
     NSString *northstarURLString = [NSString stringWithFormat:@"https://%@/v1/", LDTSERVER];
-    return [NSString stringWithFormat:@"%@users/_id/%@/campaigns", northstarURLString, user.userID];
+    return [NSString stringWithFormat:@"%@signups?user=%li", northstarURLString, (long)user.phoenixID];
 }
 
 

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -79,6 +79,9 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
         // Save session in Keychain for when app is quit.
         [SSKeychain setPassword:user.sessionToken forService:self.currentService account:@"Session"];
         [SSKeychain setPassword:self.user.userID forService:self.currentService account:@"UserID"];
+        // Need to store this when querying for current user's signups.
+        NSString *phoenixID = [NSString stringWithFormat:@"%li", self.user.phoenixID];
+        [SSKeychain setPassword:phoenixID forService:self.currentService account:@"PhoenixID"];
         if (completionHandler) {
             completionHandler(user);
         }

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -74,22 +74,17 @@ var UserView = React.createClass({
         rowIDs[1] = [];
         for (i = 0; i < signups.length; i++) {
           var signup = signups[i];
-          if (!signup.drupal_id) {
-            continue;
-          }
-          var campaignIDString = signup.drupal_id.toString();
           // Filter out inactive campaigns.
-          var campaign = UserViewController.campaigns[campaignIDString];
+          var campaign = UserViewController.campaigns[signup.campaign.id];
           if (!campaign) {
             continue;
           }
-          signup.campaign = campaign;
           var sectionNumber = 0;
-          if (signup.reportback_data) {
+          if (signup.reportback) {
             sectionNumber = 1;
           }
-          rowIDs[sectionNumber].push(signup.signup_id);
-          dataBlob[sectionNumber + ':' + signup.signup_id] = signup;
+          rowIDs[sectionNumber].push(signup.id);
+          dataBlob[sectionNumber + ':' + signup.id] = signup;
         }
 
         this.setState({
@@ -191,12 +186,13 @@ var UserView = React.createClass({
       </View>
     );
   },
-  renderRow: function(signup) {
-    if (signup.reportback_data) {
-      return this.renderDoneRow(signup);
+  renderRow: function(rowData) {
+    console.log(rowData);
+    if (rowData.reportback) {
+      return this.renderDoneRow(rowData);
     }
     else {
-      return this.renderDoingRow(signup);
+      return this.renderDoingRow(rowData);
     }
   },
   renderDoingRow: function(signup) {
@@ -223,16 +219,18 @@ var UserView = React.createClass({
         reportback={signup.reportback_data} />
     );
   },
-  _onPressRow(signup) {
-    UserViewController.presentCampaign(Number(signup.drupal_id));
+  _onPressRow(rowData) {
+    UserViewController.presentCampaign(Number(rowData.campaign.id));
   },
-  _onPressDoingRow(signup) {
-    var campaignID = Number(signup.drupal_id);
+  _onPressDoingRow(rowData) {
+    UserViewController.presentCampaign(Number(rowData.campaign.id));
+    return;
+    // @todo Fix me
     if (this.props.isSelfProfile) {
-      UserViewController.presentProveIt(campaignID);
+      UserViewController.presentProveIt(Number(rowData.campaign.id));
     }
     else {
-      UserViewController.presentCampaign(campaignID);
+      UserViewController.presentCampaign(Number(rowData.campaign.id));
     }
   },
 });


### PR DESCRIPTION
Refs #814 

Updates DSOAPI `- (void)loadCampaignSignupsForUser:completionHandler:errorHandler:` and `(NSString *)profileURLforUser:` to query the new Northstar Signups endpoint, as the `user/:id/campaigns` is now gone (RIP https://github.com/DoSomething/northstar/pull/273)

This blocks us from rendering Reportbacks until https://github.com/DoSomething/phoenix/issues/6151 is place.