### PR TITLE
LDTCampaignViewController + LDTReactBridge

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		B24FE0311BAA49AA001CAD5D /* LDTSubmitReportbackViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B24FE0301BAA49AA001CAD5D /* LDTSubmitReportbackViewController.m */; };
 		B24FE0331BAA49CE001CAD5D /* LDTSubmitReportbackView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B24FE0321BAA49CE001CAD5D /* LDTSubmitReportbackView.xib */; };
 		B250A2791C5803200076B66D /* environment.plist in Resources */ = {isa = PBXBuildFile; fileRef = B250A2781C5803200076B66D /* environment.plist */; };
+		B25146991C6A7C120067452E /* LDTCampaignViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B25146981C6A7C120067452E /* LDTCampaignViewController.m */; };
 		B258EB311B8E548B00B298C0 /* LDTReportbackItemDetailView.m in Sources */ = {isa = PBXBuildFile; fileRef = B258EB301B8E548B00B298C0 /* LDTReportbackItemDetailView.m */; };
 		B258EB331B8E696100B298C0 /* LDTReportbackItemDetailSingleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B258EB321B8E696100B298C0 /* LDTReportbackItemDetailSingleView.xib */; };
 		B273A7681B459BB700CBD4E1 /* Brandon_med.otf in Resources */ = {isa = PBXBuildFile; fileRef = B273A7661B459B6C00CBD4E1 /* Brandon_med.otf */; };
@@ -154,6 +155,8 @@
 		B24FE0301BAA49AA001CAD5D /* LDTSubmitReportbackViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTSubmitReportbackViewController.m; path = Reportback/LDTSubmitReportbackViewController.m; sourceTree = "<group>"; };
 		B24FE0321BAA49CE001CAD5D /* LDTSubmitReportbackView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTSubmitReportbackView.xib; path = Reportback/LDTSubmitReportbackView.xib; sourceTree = "<group>"; };
 		B250A2781C5803200076B66D /* environment.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = environment.plist; sourceTree = "<group>"; };
+		B25146971C6A7C110067452E /* LDTCampaignViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTCampaignViewController.h; path = Campaign/LDTCampaignViewController.h; sourceTree = "<group>"; };
+		B25146981C6A7C120067452E /* LDTCampaignViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTCampaignViewController.m; path = Campaign/LDTCampaignViewController.m; sourceTree = "<group>"; };
 		B258EB2F1B8E548B00B298C0 /* LDTReportbackItemDetailView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTReportbackItemDetailView.h; path = Reportback/LDTReportbackItemDetailView.h; sourceTree = "<group>"; };
 		B258EB301B8E548B00B298C0 /* LDTReportbackItemDetailView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTReportbackItemDetailView.m; path = Reportback/LDTReportbackItemDetailView.m; sourceTree = "<group>"; };
 		B258EB321B8E696100B298C0 /* LDTReportbackItemDetailSingleView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTReportbackItemDetailSingleView.xib; path = Reportback/LDTReportbackItemDetailSingleView.xib; sourceTree = "<group>"; };
@@ -290,6 +293,8 @@
 		B22274021B587A02005C896D /* Campaign */ = {
 			isa = PBXGroup;
 			children = (
+				B25146971C6A7C110067452E /* LDTCampaignViewController.h */,
+				B25146981C6A7C120067452E /* LDTCampaignViewController.m */,
 				B27F49EB1B6ADB93005CFC35 /* LDTCampaignDetailViewController.h */,
 				B27F49EC1B6ADB93005CFC35 /* LDTCampaignDetailViewController.m */,
 			);
@@ -893,6 +898,7 @@
 				C20BA2881AF3DBE400E9886F /* DSOUser.m in Sources */,
 				B23E68211B8FC728005BFB5E /* LDTCampaignDetailCampaignCell.m in Sources */,
 				B27F49ED1B6ADB93005CFC35 /* LDTCampaignDetailViewController.m in Sources */,
+				B25146991C6A7C120067452E /* LDTCampaignViewController.m in Sources */,
 				B21107381C04E94E00282619 /* LDTProfileCampaignTableViewCell.m in Sources */,
 				B2E75D831B87B1920015BE4A /* LDTReportbackItemDetailSingleViewController.m in Sources */,
 				B240DD321B73DA4D00CA6C6E /* LDTTabBarController.m in Sources */,

--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		B2BB8F191C457CEC000EA5CA /* LDTNewsFeedViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2BB8F181C457CEC000EA5CA /* LDTNewsFeedViewController.m */; };
 		B2C1ADA51C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C1ADA31C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.m */; };
 		B2C1ADA61C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2C1ADA41C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.xib */; };
+		B2C257E91C7213B1006DB1CE /* LDTReactBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C257E81C7213B1006DB1CE /* LDTReactBridge.m */; };
 		B2C3054B1BE142AE0046CD10 /* NSError+LDT.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C3054A1BE142AE0046CD10 /* NSError+LDT.m */; };
 		B2E652DF1B4380AD00EF9D69 /* LDTTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E652DE1B4380AD00EF9D69 /* LDTTheme.m */; };
 		B2E652E21B43822600EF9D69 /* LDTButton.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E652E11B43822600EF9D69 /* LDTButton.m */; };
@@ -194,6 +195,8 @@
 		B2C1ADA21C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTProfileNoSignupsTableViewCell.h; path = Profile/LDTProfileNoSignupsTableViewCell.h; sourceTree = "<group>"; };
 		B2C1ADA31C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTProfileNoSignupsTableViewCell.m; path = Profile/LDTProfileNoSignupsTableViewCell.m; sourceTree = "<group>"; };
 		B2C1ADA41C053B61007137B8 /* LDTProfileNoSignupsTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LDTProfileNoSignupsTableViewCell.xib; path = Profile/LDTProfileNoSignupsTableViewCell.xib; sourceTree = "<group>"; };
+		B2C257E71C7213B1006DB1CE /* LDTReactBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LDTReactBridge.h; sourceTree = "<group>"; };
+		B2C257E81C7213B1006DB1CE /* LDTReactBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LDTReactBridge.m; sourceTree = "<group>"; };
 		B2C305491BE142AE0046CD10 /* NSError+LDT.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+LDT.h"; sourceTree = "<group>"; };
 		B2C3054A1BE142AE0046CD10 /* NSError+LDT.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+LDT.m"; sourceTree = "<group>"; };
 		B2E652DD1B4380AD00EF9D69 /* LDTTheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTTheme.h; path = Base/LDTTheme.h; sourceTree = "<group>"; };
@@ -587,6 +590,8 @@
 				B27FD03D1BBD99FF00A44952 /* LDTEpicFailViewController.m */,
 				B24D53031C0F71040090C8EC /* LDTActivityViewController.h */,
 				B24D53041C0F71040090C8EC /* LDTActivityViewController.m */,
+				B2C257E71C7213B1006DB1CE /* LDTReactBridge.h */,
+				B2C257E81C7213B1006DB1CE /* LDTReactBridge.m */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -921,6 +926,7 @@
 				B2753E391BD17C49004DDD6A /* GAI+LDT.m in Sources */,
 				B28124CF1BAA0DF000DF58DA /* UINavigationController+LDT.m in Sources */,
 				B2963E0A1BD83D1000D2B6EE /* LDTOnboardingPageViewController.m in Sources */,
+				B2C257E91C7213B1006DB1CE /* LDTReactBridge.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Lets Do This/Classes/LDTAppDelegate.h
+++ b/Lets Do This/Classes/LDTAppDelegate.h
@@ -12,5 +12,8 @@
 @property (strong, nonatomic) UIWindow *window;
 @property (strong, nonatomic) UIView *statusBarBackgroundView;
 
+// Pushes given viewController in the NavigationController of our root TabBarController.
+- (void)pushViewController:(UIViewController *)viewController;
+
 @end
 

--- a/Lets Do This/Classes/LDTAppDelegate.h
+++ b/Lets Do This/Classes/LDTAppDelegate.h
@@ -5,15 +5,14 @@
 //  Created by Ryan Grimm on 4/2/15.
 //  Copyright (c) 2015 Do Something. All rights reserved.
 //
+#import "LDTTabBarController.h"
 
 @interface LDTAppDelegate : UIResponder <UIApplicationDelegate>
 
+@property (strong, nonatomic, readonly) LDTTabBarController *tabBarController;
 @property (strong, nonatomic, readonly) NSURL *jsCodeLocation;
 @property (strong, nonatomic) UIWindow *window;
 @property (strong, nonatomic) UIView *statusBarBackgroundView;
-
-// Pushes given viewController in the NavigationController of our root TabBarController.
-- (void)pushViewController:(UIViewController *)viewController;
 
 @end
 

--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -120,4 +120,12 @@
     [PFPush handlePush:userInfo];
 }
 
+#pragma mark - LDTAppDelegate
+
+- (void)pushViewController:(UIViewController *)viewController {
+    LDTTabBarController *tabBarController = (LDTTabBarController *)self.window.rootViewController;
+    UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
+    [navigationController pushViewController:viewController animated:YES];
+}
+
 @end

--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -10,7 +10,6 @@
 #import "AFNetworkActivityIndicatorManager.h"
 #import <Parse/Parse.h>
 #import "LDTTheme.h"
-#import "LDTTabBarController.h"
 #import "TSMessageView.h"
 #import "GAI+LDT.h"
 #import <Fabric/Fabric.h>
@@ -120,12 +119,10 @@
     [PFPush handlePush:userInfo];
 }
 
-#pragma mark - LDTAppDelegate
+# pragma mark - Accessors
 
-- (void)pushViewController:(UIViewController *)viewController {
-    LDTTabBarController *tabBarController = (LDTTabBarController *)self.window.rootViewController;
-    UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
-    [navigationController pushViewController:viewController animated:YES];
+- (LDTTabBarController *)tabBarController {
+    return (LDTTabBarController *)self.window.rootViewController;
 }
 
 @end

--- a/Lets Do This/Controllers/Base/LDTTabBarController.h
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.h
@@ -10,4 +10,6 @@
 
 -(void)reloadCurrentUser;
 
+- (void)presentReportbackAlertControllerForCampaignID:(NSInteger)campaignID;
+
 @end

--- a/Lets Do This/Controllers/Base/LDTTabBarController.h
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.h
@@ -12,4 +12,7 @@
 
 - (void)presentReportbackAlertControllerForCampaignID:(NSInteger)campaignID;
 
+// Convenience method for pushing given VC on the selected tab's UINavigationController.
+- (void)pushViewController:(UIViewController *)viewController;
+
 @end

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -112,6 +112,7 @@
 }
 
 - (void)reloadCurrentUser {
+    // @todo Pop all child view controllers, not just first.
     UINavigationController *initialVC = (UINavigationController *)self.viewControllers[0];
     [initialVC popToRootViewControllerAnimated:YES];
     [[DSOUserManager sharedInstance] startSessionWithCompletionHandler:^ {
@@ -140,36 +141,33 @@
 }
 
 - (void)presentReportbackAlertControllerForCampaignID:(NSInteger)campaignID {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-        self.proveItCampaign = campaign;
-        UIAlertController *reportbackPhotoAlertController = [UIAlertController alertControllerWithTitle:@"Pics or it didn't happen!" message:nil                                                              preferredStyle:UIAlertControllerStyleActionSheet];
-        UIAlertAction *cameraAlertAction;
-        if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
-            cameraAlertAction = [UIAlertAction actionWithTitle:@"Take Photo" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
-                [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"camera" value:nil];
-                self.imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
-                [self presentViewController:self.imagePickerController animated:YES completion:NULL];
-            }];
-        }
-        else {
-            cameraAlertAction = [UIAlertAction actionWithTitle:@"(Camera Unavailable)" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
-                // Nada
-            }];
-        }
-        UIAlertAction *photoLibraryAlertAction = [UIAlertAction actionWithTitle:@"Choose From Library" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
-            [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"gallery" value:nil];
-            self.imagePickerController.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+    DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
+    self.proveItCampaign = campaign;
+    UIAlertController *reportbackPhotoAlertController = [UIAlertController alertControllerWithTitle:@"Pics or it didn't happen!" message:nil                                                              preferredStyle:UIAlertControllerStyleActionSheet];
+    UIAlertAction *cameraAlertAction;
+    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+        cameraAlertAction = [UIAlertAction actionWithTitle:@"Take Photo" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
+            [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"camera" value:nil];
+            self.imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
             [self presentViewController:self.imagePickerController animated:YES completion:NULL];
         }];
-        UIAlertAction *cancelAlertAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
-            [reportbackPhotoAlertController dismissViewControllerAnimated:YES completion:nil];
-        }];
-        [reportbackPhotoAlertController addAction:cameraAlertAction];
-        [reportbackPhotoAlertController addAction:photoLibraryAlertAction];
-        [reportbackPhotoAlertController addAction:cancelAlertAction];
-        [self presentViewController:reportbackPhotoAlertController animated:YES completion:nil];
-    });
+    }
+    else {
+        cameraAlertAction = [UIAlertAction actionWithTitle:@"(Camera Unavailable)" style:UIAlertActionStyleDefault handler:nil];
+    }
+    UIAlertAction *photoLibraryAlertAction = [UIAlertAction actionWithTitle:@"Choose From Library" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
+        [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"gallery" value:nil];
+        self.imagePickerController.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+        [self presentViewController:self.imagePickerController animated:YES completion:NULL];
+    }];
+    UIAlertAction *cancelAlertAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
+        [reportbackPhotoAlertController dismissViewControllerAnimated:YES completion:nil];
+    }];
+    [reportbackPhotoAlertController addAction:cameraAlertAction];
+    [reportbackPhotoAlertController addAction:photoLibraryAlertAction];
+    [reportbackPhotoAlertController addAction:cancelAlertAction];
+    [self presentViewController:reportbackPhotoAlertController animated:YES completion:nil];
+
 }
 
 # pragma mark - UINavigationControllerDelegate
@@ -185,12 +183,10 @@
 
 - (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
     [picker dismissViewControllerAnimated:YES completion:^{
-        dispatch_async(dispatch_get_main_queue(), ^{
-            UIImage *selectedImage = info[UIImagePickerControllerEditedImage];
-            LDTSubmitReportbackViewController *destVC = [[LDTSubmitReportbackViewController alloc] initWithCampaign:self.proveItCampaign reportbackItemImage:selectedImage];
-            UINavigationController *destNavVC = [[UINavigationController alloc] initWithRootViewController:destVC];
-            [self presentViewController:destNavVC animated:YES completion:nil];
-        });
+        UIImage *selectedImage = info[UIImagePickerControllerEditedImage];
+        LDTSubmitReportbackViewController *destVC = [[LDTSubmitReportbackViewController alloc] initWithCampaign:self.proveItCampaign reportbackItemImage:selectedImage];
+        UINavigationController *destNavVC = [[UINavigationController alloc] initWithRootViewController:destVC];
+        [self presentViewController:destNavVC animated:YES completion:nil];
     }];
 }
 

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -13,9 +13,14 @@
 #import "LDTUserConnectViewController.h"
 #import "LDTCauseListViewController.h"
 #import "LDTEpicFailViewController.h"
+#import "LDTSubmitReportbackViewController.h"
 #import "LDTTheme.h"
+#import "GAI+LDT.h"
 
-@interface LDTTabBarController () <LDTEpicFailSubmitButtonDelegate>
+@interface LDTTabBarController () <LDTEpicFailSubmitButtonDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
+
+@property (strong, nonatomic) DSOCampaign *proveItCampaign;
+@property (strong, nonatomic) UIImagePickerController *imagePickerController;
 
 @end
 
@@ -55,7 +60,9 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    self.view.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"Full Background"]];
+    self.imagePickerController = [[UIImagePickerController alloc] init];
+    self.imagePickerController.delegate = self;
+    self.imagePickerController.allowsEditing = YES;
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -125,6 +132,61 @@
     [destNavVC styleNavigationBar:LDTNavigationBarStyleClear];
     destNavVC.navigationBar.barStyle = UIStatusBarStyleLightContent;
     [self presentViewController:destNavVC animated:YES completion:nil];
+}
+
+- (void)presentReportbackAlertControllerForCampaignID:(NSInteger)campaignID {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
+        self.proveItCampaign = campaign;
+        UIAlertController *reportbackPhotoAlertController = [UIAlertController alertControllerWithTitle:@"Pics or it didn't happen!" message:nil                                                              preferredStyle:UIAlertControllerStyleActionSheet];
+        UIAlertAction *cameraAlertAction;
+        if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+            cameraAlertAction = [UIAlertAction actionWithTitle:@"Take Photo" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
+                [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"camera" value:nil];
+                self.imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
+                [self presentViewController:self.imagePickerController animated:YES completion:NULL];
+            }];
+        }
+        else {
+            cameraAlertAction = [UIAlertAction actionWithTitle:@"(Camera Unavailable)" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
+                // Nada
+            }];
+        }
+        UIAlertAction *photoLibraryAlertAction = [UIAlertAction actionWithTitle:@"Choose From Library" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
+            [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"gallery" value:nil];
+            self.imagePickerController.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+            [self presentViewController:self.imagePickerController animated:YES completion:NULL];
+        }];
+        UIAlertAction *cancelAlertAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
+            [reportbackPhotoAlertController dismissViewControllerAnimated:YES completion:nil];
+        }];
+        [reportbackPhotoAlertController addAction:cameraAlertAction];
+        [reportbackPhotoAlertController addAction:photoLibraryAlertAction];
+        [reportbackPhotoAlertController addAction:cancelAlertAction];
+        [self presentViewController:reportbackPhotoAlertController animated:YES completion:nil];
+    });
+}
+
+# pragma mark - UINavigationControllerDelegate
+
+- (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
+    [viewController.navigationController styleNavigationBar:LDTNavigationBarStyleNormal];
+    viewController.title = [NSString stringWithFormat:@"I did %@", self.proveItCampaign.title].uppercaseString;
+    [viewController styleRightBarButton];
+    [viewController styleBackBarButton];
+}
+
+#pragma mark - UIImagePickerControllerDelegate
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
+    [picker dismissViewControllerAnimated:YES completion:^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UIImage *selectedImage = info[UIImagePickerControllerEditedImage];
+            LDTSubmitReportbackViewController *destVC = [[LDTSubmitReportbackViewController alloc] initWithCampaign:self.proveItCampaign reportbackItemImage:selectedImage];
+            UINavigationController *destNavVC = [[UINavigationController alloc] initWithRootViewController:destVC];
+            [self presentViewController:destNavVC animated:YES completion:nil];
+        });
+    }];
 }
 
 @end

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -106,6 +106,11 @@
 
 #pragma mark - LDTTabBarController
 
+- (void)pushViewController:(UIViewController *)viewController {
+    UINavigationController *navigationController = self.childViewControllers[self.selectedIndex];
+    [navigationController pushViewController:viewController animated:YES];
+}
+
 - (void)reloadCurrentUser {
     UINavigationController *initialVC = (UINavigationController *)self.viewControllers[0];
     [initialVC popToRootViewControllerAnimated:YES];

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.h
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.h
@@ -1,0 +1,15 @@
+//
+//  LDTCampaignViewController.h
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 2/9/16.
+//  Copyright © 2016 Do Something. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface LDTCampaignViewController : UIViewController
+
+- (instancetype)initWithCampaign:(DSOCampaign *)campaign;
+
+@end

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -83,11 +83,14 @@
     else {
         currentUserSignupDict = [[NSDictionary alloc] init];
     }
-
+    NSString *signupURLString = [NSString stringWithFormat:@"%@signups?user=%@", [DSOAPI sharedInstance].baseURL, [DSOUserManager sharedInstance].user.userID];
     appProperties = @{
                       @"campaign" : self.campaign.dictionary,
-                      @"url" : url,
-                      @"currentUserSignup" : currentUserSignupDict,
+                      @"galleryUrl" : url,
+                      @"signupUrl" : signupURLString,
+                      @"initialSignup" : currentUserSignupDict,
+                      @"apiKey": [DSOAPI sharedInstance].apiKey,
+                      @"sessionToken": [DSOUserManager sharedInstance].sessionToken,
                       };
     return appProperties;
 }
@@ -102,6 +105,13 @@ RCT_EXPORT_METHOD(presentUser:(NSDictionary *)userDict) {
     LDTUserViewController *viewController = [[LDTUserViewController alloc] initWithUser:user];
     dispatch_async(dispatch_get_main_queue(), ^{
         [appDelegate pushViewController:viewController];
+    });
+}
+
+RCT_EXPORT_METHOD(signupConfirmMessageForCampaignTitle:(NSString *)campaignTitle) {
+    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
+     dispatch_async(dispatch_get_main_queue(), ^{
+        [LDTMessage displaySuccessMessageInViewController:appDelegate.window.rootViewController title:@"Niiiiice." subtitle:[NSString stringWithFormat:@"You signed up for %@.", campaignTitle]];
     });
 }
 

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -9,6 +9,7 @@
 #import "LDTCampaignViewController.h"
 #import "LDTUserViewController.h"
 #import "LDTAppDelegate.h"
+#import "LDTTabBarController.h"
 #import "GAI+LDT.h"
 #import "LDTTheme.h"
 #import <RCTBridgeModule.h>
@@ -112,6 +113,14 @@ RCT_EXPORT_METHOD(signupConfirmMessageForCampaignTitle:(NSString *)campaignTitle
     LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
      dispatch_async(dispatch_get_main_queue(), ^{
         [LDTMessage displaySuccessMessageInViewController:appDelegate.window.rootViewController title:@"Niiiiice." subtitle:[NSString stringWithFormat:@"You signed up for %@.", campaignTitle]];
+    });
+}
+
+RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {
+    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        LDTTabBarController *tabBarController = (LDTTabBarController *)appDelegate.window.rootViewController;
+        [tabBarController presentReportbackAlertControllerForCampaignID:campaignID];
     });
 }
 

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -1,0 +1,114 @@
+//
+//  LDTCampaignViewController.m
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 2/9/16.
+//  Copyright © 2016 Do Something. All rights reserved.
+//
+
+#import "LDTCampaignViewController.h"
+#import "LDTUserViewController.h"
+#import "LDTAppDelegate.h"
+#import "GAI+LDT.h"
+#import "LDTTheme.h"
+#import <RCTBridgeModule.h>
+#import <RCTRootView.h>
+
+@interface LDTCampaignViewController () <RCTBridgeModule, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
+
+@property (strong, nonatomic) DSOCampaign *campaign;
+@property (strong, nonatomic) RCTRootView *reactRootView;
+@property (strong, nonatomic) UIImagePickerController *imagePickerController;
+
+@end
+
+@implementation LDTCampaignViewController
+
+#pragma mark - NSObject
+
+- (instancetype)initWithCampaign:(DSOCampaign *)campaign {
+    self = [super init];
+
+    if (self) {
+        _campaign = campaign;
+    }
+
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = self.campaign.title.uppercaseString;
+    [self styleView];
+
+    self.imagePickerController = [[UIImagePickerController alloc] init];
+    self.imagePickerController.delegate = self;
+    self.imagePickerController.allowsEditing = YES;
+    NSURL *jsCodeLocation = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate).jsCodeLocation;
+    self.reactRootView =[[RCTRootView alloc] initWithBundleURL:jsCodeLocation moduleName: @"CampaignView" initialProperties:[self appProperties] launchOptions:nil];
+    self.view = self.reactRootView;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+
+    [self.navigationController styleNavigationBar:LDTNavigationBarStyleNormal];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    DSOUser *currentUser = [DSOUserManager sharedInstance].user;
+    NSString *screenStatus;
+    if ([currentUser hasCompletedCampaign:self.campaign]) {
+        screenStatus = @"completed";
+    }
+    else if ([currentUser isDoingCampaign:self.campaign]) {
+        screenStatus = @"proveit";
+    }
+    else {
+        screenStatus = @"pitch";
+    }
+    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"campaign/%ld/%@", (long)self.campaign.campaignID, screenStatus]];
+}
+
+#pragma mark - LDTCampaignViewController
+
+- (void)styleView {
+    [self styleBackBarButton];
+}
+
+- (NSDictionary *)appProperties {
+    NSDictionary *appProperties;
+    NSString *url = [NSString stringWithFormat:@"%@reportback-items?load_user=true&status=approved,promoted&campaigns=%li", [DSOAPI sharedInstance].phoenixApiURL, (long)self.campaign.campaignID];
+    NSDictionary *currentUserSignupDict;
+    if (self.campaign.currentUserSignup) {
+        currentUserSignupDict = self.campaign.currentUserSignup.dictionary;
+    }
+    else {
+        currentUserSignupDict = [[NSDictionary alloc] init];
+    }
+
+    appProperties = @{
+                      @"campaign" : self.campaign.dictionary,
+                      @"url" : url,
+                      @"currentUserSignup" : currentUserSignupDict,
+                      };
+    return appProperties;
+}
+
+#pragma mark - RCTBridgeModule
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(presentUser:(NSDictionary *)userDict) {
+    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
+    DSOUser *user = [[DSOUser alloc] initWithDict:userDict];
+    LDTUserViewController *viewController = [[LDTUserViewController alloc] initWithUser:user];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [appDelegate pushViewController:viewController];
+    });
+}
+
+@end

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -50,12 +50,6 @@
     self.view = self.reactRootView;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [self.navigationController styleNavigationBar:LDTNavigationBarStyleNormal];
-}
-
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -105,7 +105,7 @@ RCT_EXPORT_METHOD(presentUser:(NSDictionary *)userDict) {
     DSOUser *user = [[DSOUser alloc] initWithDict:userDict];
     LDTUserViewController *viewController = [[LDTUserViewController alloc] initWithUser:user];
     dispatch_async(dispatch_get_main_queue(), ^{
-        [appDelegate pushViewController:viewController];
+        [appDelegate.tabBarController pushViewController:viewController];
     });
 }
 

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -12,10 +12,9 @@
 #import "LDTTabBarController.h"
 #import "GAI+LDT.h"
 #import "LDTTheme.h"
-#import <RCTBridgeModule.h>
 #import <RCTRootView.h>
 
-@interface LDTCampaignViewController () <RCTBridgeModule, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
+@interface LDTCampaignViewController () < UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
 @property (strong, nonatomic) DSOCampaign *campaign;
 @property (strong, nonatomic) RCTRootView *reactRootView;
@@ -94,34 +93,6 @@
                       @"sessionToken": [DSOUserManager sharedInstance].sessionToken,
                       };
     return appProperties;
-}
-
-#pragma mark - RCTBridgeModule
-
-RCT_EXPORT_MODULE();
-
-RCT_EXPORT_METHOD(presentUser:(NSDictionary *)userDict) {
-    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
-    DSOUser *user = [[DSOUser alloc] initWithDict:userDict];
-    LDTUserViewController *viewController = [[LDTUserViewController alloc] initWithUser:user];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [appDelegate.tabBarController pushViewController:viewController];
-    });
-}
-
-RCT_EXPORT_METHOD(signupConfirmMessageForCampaignTitle:(NSString *)campaignTitle) {
-    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
-     dispatch_async(dispatch_get_main_queue(), ^{
-        [LDTMessage displaySuccessMessageInViewController:appDelegate.window.rootViewController title:@"Niiiiice." subtitle:[NSString stringWithFormat:@"You signed up for %@.", campaignTitle]];
-    });
-}
-
-RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {
-    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
-    dispatch_async(dispatch_get_main_queue(), ^{
-        LDTTabBarController *tabBarController = (LDTTabBarController *)appDelegate.window.rootViewController;
-        [tabBarController presentReportbackAlertControllerForCampaignID:campaignID];
-    });
 }
 
 @end

--- a/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
@@ -9,7 +9,7 @@
 #import "LDTCauseDetailViewController.h"
 #import "LDTTabBarController.h"
 #import "LDTTheme.h"
-#import "LDTCampaignDetailViewController.h"
+#import "LDTCampaignViewController.h"
 #import "GAI+LDT.h"
 #import "LDTAppDelegate.h"
 #import <RCTBridgeModule.h>
@@ -56,7 +56,7 @@ RCT_EXPORT_MODULE();
     NSArray *activeCampaigns = [DSOUserManager sharedInstance].activeCampaigns;
 
     for (DSOCampaign *campaign in activeCampaigns) {
-        if (campaign.cause.causeID == self.cause.causeID) {
+        if (campaign.cause.causeID == self.cause.causeID && [campaign.status isEqualToString:@"active"]) {
             [self.campaigns addObject:campaign.dictionary];
         }
     }
@@ -84,20 +84,15 @@ RCT_EXPORT_MODULE();
     [self styleBackBarButton];
 }
 
-- (void)presentCampaignDetailViewControllerForCampaignId:(NSInteger)campaignID {
-    DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-    LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-    UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
-    LDTCampaignDetailViewController *campaignDetailViewController = [[LDTCampaignDetailViewController alloc] initWithCampaign:campaign];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [navigationController pushViewController:campaignDetailViewController animated:YES];
-    });
-}
-
 #pragma mark - RCTBridgeModule
 
 RCT_EXPORT_METHOD(presentCampaign:(NSInteger)campaignID) {
-    [self presentCampaignDetailViewControllerForCampaignId:campaignID];
+    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
+    DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
+    LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [appDelegate pushViewController:viewController];
+    });
 }
 
 @end

--- a/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
@@ -7,15 +7,12 @@
 //
 
 #import "LDTCauseDetailViewController.h"
-#import "LDTTabBarController.h"
 #import "LDTTheme.h"
-#import "LDTCampaignViewController.h"
 #import "GAI+LDT.h"
 #import "LDTAppDelegate.h"
-#import <RCTBridgeModule.h>
 #import <RCTRootView.h>
 
-@interface LDTCauseDetailViewController () <RCTBridgeModule>
+@interface LDTCauseDetailViewController ()
 
 @property (strong, nonatomic) DSOCause *cause;
 @property (strong, nonatomic) NSMutableArray *campaigns;
@@ -23,8 +20,6 @@
 @end
 
 @implementation LDTCauseDetailViewController
-
-RCT_EXPORT_MODULE();
 
 #pragma mark - NSObject
 
@@ -82,17 +77,6 @@ RCT_EXPORT_MODULE();
 
 - (void)styleView {
     [self styleBackBarButton];
-}
-
-#pragma mark - RCTBridgeModule
-
-RCT_EXPORT_METHOD(presentCampaign:(NSInteger)campaignID) {
-    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
-    DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-    LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [appDelegate.tabBarController pushViewController:viewController];
-    });
 }
 
 @end

--- a/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(presentCampaign:(NSInteger)campaignID) {
     DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
     LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
     dispatch_async(dispatch_get_main_queue(), ^{
-        [appDelegate pushViewController:viewController];
+        [appDelegate.tabBarController pushViewController:viewController];
     });
 }
 

--- a/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
@@ -66,12 +66,11 @@ RCT_EXPORT_MODULE();
 #pragma mark - RCTBridgeModule
 
 RCT_EXPORT_METHOD(presentCause:(NSDictionary *)causeDict) {
+    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
+    DSOCause *cause = [[DSOCause alloc] initWithNewsDict:causeDict];
+    LDTCauseDetailViewController *causeDetailViewController = [[LDTCauseDetailViewController alloc] initWithCause:cause];
     dispatch_async(dispatch_get_main_queue(), ^{
-        LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-        UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
-        DSOCause *cause = [[DSOCause alloc] initWithNewsDict:causeDict];
-        LDTCauseDetailViewController *causeDetailViewController = [[LDTCauseDetailViewController alloc] initWithCause:cause];
-        [navigationController pushViewController:causeDetailViewController animated:YES];
+        [appDelegate pushViewController:causeDetailViewController];
     });
 }
 

--- a/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
@@ -70,7 +70,7 @@ RCT_EXPORT_METHOD(presentCause:(NSDictionary *)causeDict) {
     DSOCause *cause = [[DSOCause alloc] initWithNewsDict:causeDict];
     LDTCauseDetailViewController *causeDetailViewController = [[LDTCauseDetailViewController alloc] initWithCause:cause];
     dispatch_async(dispatch_get_main_queue(), ^{
-        [appDelegate pushViewController:causeDetailViewController];
+        [appDelegate.tabBarController pushViewController:causeDetailViewController];
     });
 }
 

--- a/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseListViewController.m
@@ -8,22 +8,17 @@
 
 #import "LDTCauseListViewController.h"
 #import "LDTTheme.h"
-#import "LDTTabBarController.h"
-#import "LDTCauseDetailViewController.h"
 #import "GAI+LDT.h"
 #import "LDTAppDelegate.h"
-#import <RCTBridgeModule.h>
 #import <RCTRootView.h>
 
-@interface LDTCauseListViewController () <RCTBridgeModule>
+@interface LDTCauseListViewController ()
 
 @property (strong, nonatomic) NSArray *causes;
 
 @end
 
 @implementation LDTCauseListViewController
-
-RCT_EXPORT_MODULE();
 
 #pragma mark - UIViewController
 
@@ -61,17 +56,6 @@ RCT_EXPORT_MODULE();
 
 - (void)styleView {
     [self styleBackBarButton];
-}
-
-#pragma mark - RCTBridgeModule
-
-RCT_EXPORT_METHOD(presentCause:(NSDictionary *)causeDict) {
-    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
-    DSOCause *cause = [[DSOCause alloc] initWithNewsDict:causeDict];
-    LDTCauseDetailViewController *causeDetailViewController = [[LDTCauseDetailViewController alloc] initWithCause:cause];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [appDelegate.tabBarController pushViewController:causeDetailViewController];
-    });
 }
 
 @end

--- a/Lets Do This/Controllers/LDTReactBridge.h
+++ b/Lets Do This/Controllers/LDTReactBridge.h
@@ -1,0 +1,13 @@
+//
+//  LDTReactBridge.h
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 2/15/16.
+//  Copyright © 2016 Do Something. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface LDTReactBridge : NSObject
+
+@end

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -1,0 +1,93 @@
+//
+//  LDTReactBridge.m
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 2/15/16.
+//  Copyright © 2016 Do Something. All rights reserved.
+//
+
+#import "LDTReactBridge.h"
+#import <RCTBridgeModule.h>
+#import "LDTAppDelegate.h"
+#import "LDTTabBarController.h"
+#import "LDTUserViewController.h"
+#import "LDTCampaignViewController.h"
+#import "LDTCauseDetailViewController.h"
+#import "LDTNewsArticleViewController.h"
+#import "LDTMessage.h"
+
+
+@interface LDTReactBridge() <RCTBridgeModule>
+
+@end
+
+@implementation LDTReactBridge
+
+#pragma mark - LDTReactBridge
+
+-(LDTTabBarController *)tabBarController {
+    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
+    return appDelegate.tabBarController;
+}
+
+#pragma mark - RCTBridgeModule
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(pushUser:(NSDictionary *)userDict) {
+    DSOUser *user = [[DSOUser alloc] initWithDict:userDict];
+    LDTUserViewController *viewController = [[LDTUserViewController alloc] initWithUser:user];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.tabBarController pushViewController:viewController];
+    });
+}
+
+RCT_EXPORT_METHOD(pushCampaign:(NSInteger)campaignID) {
+    DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
+    if (!campaign) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSString *message = [NSString stringWithFormat:@"Error occured: invalid Campaign ID %li", (long)campaignID];
+            [LDTMessage displayErrorMessageInViewController:self.tabBarController title:message];
+        });
+        return;
+    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
+        [self.tabBarController pushViewController:viewController];
+    });
+}
+
+RCT_EXPORT_METHOD(signupConfirmMessageForCampaignTitle:(NSString *)campaignTitle) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [LDTMessage displaySuccessMessageInViewController:self.tabBarController title:@"Niiiiice." subtitle:[NSString stringWithFormat:@"You signed up for %@.", campaignTitle]];
+    });
+}
+
+RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.tabBarController presentReportbackAlertControllerForCampaignID:campaignID];
+    });
+}
+
+RCT_EXPORT_METHOD(pushCause:(NSDictionary *)causeDict) {
+    DSOCause *cause = [[DSOCause alloc] initWithNewsDict:causeDict];
+    LDTCauseDetailViewController *causeDetailViewController = [[LDTCauseDetailViewController alloc] initWithCause:cause];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.tabBarController pushViewController:causeDetailViewController];
+    });
+}
+
+RCT_EXPORT_METHOD(presentNewsArticle:(NSInteger)newsPostID urlString:(NSString *)urlString) {
+    LDTNewsArticleViewController *articleViewController = [[LDTNewsArticleViewController alloc] initWithNewsPostID:newsPostID urlString:urlString];
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:articleViewController];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.tabBarController presentViewController:navigationController animated:YES completion:nil];
+    });
+}
+
+// I wonder if this will work?
+//- (dispatch_queue_t)methodQueue {
+//    return dispatch_get_main_queue();
+//}
+
+@end

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -34,6 +34,11 @@
 
 RCT_EXPORT_MODULE();
 
+// @see http://facebook.github.io/react-native/docs/native-modules-ios.html#threading
+- (dispatch_queue_t)methodQueue {
+    return dispatch_get_main_queue();
+}
+
 RCT_EXPORT_METHOD(pushUser:(NSDictionary *)userDict) {
     DSOUser *user = [[DSOUser alloc] initWithDict:userDict];
     LDTUserViewController *viewController = [[LDTUserViewController alloc] initWithUser:user];
@@ -45,49 +50,32 @@ RCT_EXPORT_METHOD(pushUser:(NSDictionary *)userDict) {
 RCT_EXPORT_METHOD(pushCampaign:(NSInteger)campaignID) {
     DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
     if (!campaign) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            NSString *message = [NSString stringWithFormat:@"Error occured: invalid Campaign ID %li", (long)campaignID];
-            [LDTMessage displayErrorMessageInViewController:self.tabBarController title:message];
-        });
+        NSString *message = [NSString stringWithFormat:@"Error occured: invalid Campaign ID %li", (long)campaignID];
+        [LDTMessage displayErrorMessageInViewController:self.tabBarController title:message];
         return;
     }
-    dispatch_async(dispatch_get_main_queue(), ^{
-        LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
-        [self.tabBarController pushViewController:viewController];
-    });
+    LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
+    [self.tabBarController pushViewController:viewController];
 }
 
-RCT_EXPORT_METHOD(signupConfirmMessageForCampaignTitle:(NSString *)campaignTitle) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [LDTMessage displaySuccessMessageInViewController:self.tabBarController title:@"Niiiiice." subtitle:[NSString stringWithFormat:@"You signed up for %@.", campaignTitle]];
-    });
+RCT_EXPORT_METHOD(displaySignupSuccessMessageWithCampaignTitle:(NSString *)campaignTitle) {
+    [LDTMessage displaySuccessMessageInViewController:self.tabBarController title:@"Niiiiice." subtitle:[NSString stringWithFormat:@"You signed up for %@.", campaignTitle]];
 }
 
 RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.tabBarController presentReportbackAlertControllerForCampaignID:campaignID];
-    });
+    [self.tabBarController presentReportbackAlertControllerForCampaignID:campaignID];
 }
 
 RCT_EXPORT_METHOD(pushCause:(NSDictionary *)causeDict) {
     DSOCause *cause = [[DSOCause alloc] initWithNewsDict:causeDict];
     LDTCauseDetailViewController *causeDetailViewController = [[LDTCauseDetailViewController alloc] initWithCause:cause];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.tabBarController pushViewController:causeDetailViewController];
-    });
+    [self.tabBarController pushViewController:causeDetailViewController];
 }
 
 RCT_EXPORT_METHOD(presentNewsArticle:(NSInteger)newsPostID urlString:(NSString *)urlString) {
     LDTNewsArticleViewController *articleViewController = [[LDTNewsArticleViewController alloc] initWithNewsPostID:newsPostID urlString:urlString];
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:articleViewController];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.tabBarController presentViewController:navigationController animated:YES completion:nil];
-    });
+    [self.tabBarController presentViewController:navigationController animated:YES completion:nil];
 }
-
-// I wonder if this will work?
-//- (dispatch_queue_t)methodQueue {
-//    return dispatch_get_main_queue();
-//}
 
 @end

--- a/Lets Do This/Controllers/News/LDTNewsFeedViewController.m
+++ b/Lets Do This/Controllers/News/LDTNewsFeedViewController.m
@@ -74,7 +74,7 @@ RCT_EXPORT_MODULE();
     }
     LDTCampaignViewController *campaignDetailViewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
     dispatch_async(dispatch_get_main_queue(), ^{
-        [appDelegate pushViewController:campaignDetailViewController];
+        [appDelegate.tabBarController pushViewController:campaignDetailViewController];
     });
 }
 

--- a/Lets Do This/Controllers/News/LDTNewsFeedViewController.m
+++ b/Lets Do This/Controllers/News/LDTNewsFeedViewController.m
@@ -9,20 +9,10 @@
 #import "LDTNewsFeedViewController.h"
 #import "LDTTheme.h"
 #import "LDTAppDelegate.h"
-#import <RCTBridgeModule.h>
 #import <RCTRootView.h>
-#import "LDTCampaignViewController.h"
-#import "LDTNewsArticleViewController.h"
-#import "LDTTabBarController.h"
 #import "GAI+LDT.h"
 
-@interface LDTNewsFeedViewController () <RCTBridgeModule>
-
-@end
-
 @implementation LDTNewsFeedViewController
-
-RCT_EXPORT_MODULE();
 
 #pragma mark - UIViewController
 
@@ -37,7 +27,7 @@ RCT_EXPORT_MODULE();
     RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation moduleName: @"NewsFeedView" initialProperties:props launchOptions:nil];
     self.view = rootView;
 
-    [self styleView];
+    [self styleBackBarButton];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -52,55 +42,6 @@ RCT_EXPORT_MODULE();
 
     self.navigationController.hidesBarsOnSwipe = NO;
     [[GAI sharedInstance] trackScreenView:@"news"];
-}
-
-#pragma mark - LDTNewsFeedViewController
-
-- (void)styleView {
-    [self styleBackBarButton];
-}
-
-- (void)presentCampaignDetailViewControllerForCampaignId:(NSInteger)campaignID {
-    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
-    // @todo: Dont filter by active campaigns anymore to avoid this.
-    DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-    UINavigationController *navController = (UINavigationController *)appDelegate.window.rootViewController.childViewControllers[0];
-    if (!campaign) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            NSString *message = [NSString stringWithFormat:@"Our bad. %li is an invalid campaign id :(", (long)campaignID];
-            [LDTMessage displayErrorMessageInViewController:appDelegate.window.rootViewController title:message];
-        });
-        return;
-    }
-    LDTCampaignViewController *campaignDetailViewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [appDelegate.tabBarController pushViewController:campaignDetailViewController];
-    });
-}
-
-- (void)presentNewsArticleViewControllerForNewsPostID:(NSInteger)newsPostID urlString:(NSString *)urlString {
-    LDTNewsArticleViewController *articleViewController = [[LDTNewsArticleViewController alloc] initWithNewsPostID:newsPostID urlString:urlString];
-    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:articleViewController];
-    LDTTabBarController *tabBar = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [tabBar presentViewController:navigationController animated:YES completion:nil];
-    });
-}
-
-#pragma mark - RCTBridgeModule
-
-RCT_EXPORT_METHOD(presentCampaign:(NSInteger)campaignID) {
-    [self presentCampaignDetailViewControllerForCampaignId:campaignID];
-}
-
-RCT_EXPORT_METHOD(presentFullArticle:(NSInteger)newsPostID urlString:(NSString *)urlString) {
-    [self presentNewsArticleViewControllerForNewsPostID:newsPostID urlString:urlString];
-}
-
-// Adding this hoping to get rid of all the trickery but it doesn't seem to do anything.
-// @see https://facebook.github.io/react-native/docs/native-modules-ios.html#threading
-- (dispatch_queue_t)methodQueue {
-    return dispatch_get_main_queue();
 }
 
 @end

--- a/Lets Do This/Controllers/News/LDTNewsFeedViewController.m
+++ b/Lets Do This/Controllers/News/LDTNewsFeedViewController.m
@@ -11,7 +11,7 @@
 #import "LDTAppDelegate.h"
 #import <RCTBridgeModule.h>
 #import <RCTRootView.h>
-#import "LDTCampaignDetailViewController.h"
+#import "LDTCampaignViewController.h"
 #import "LDTNewsArticleViewController.h"
 #import "LDTTabBarController.h"
 #import "GAI+LDT.h"
@@ -61,18 +61,20 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)presentCampaignDetailViewControllerForCampaignId:(NSInteger)campaignID {
+    LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
+    // @todo: Dont filter by active campaigns anymore to avoid this.
     DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-    LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-    UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
+    UINavigationController *navController = (UINavigationController *)appDelegate.window.rootViewController.childViewControllers[0];
     if (!campaign) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [LDTMessage displayErrorMessageInViewController:navigationController.topViewController title:@"Our bad. That's an invalid campaign ID :("];
+            NSString *message = [NSString stringWithFormat:@"Our bad. %li is an invalid campaign id :(", (long)campaignID];
+            [LDTMessage displayErrorMessageInViewController:appDelegate.window.rootViewController title:message];
         });
         return;
     }
-    LDTCampaignDetailViewController *campaignDetailViewController = [[LDTCampaignDetailViewController alloc] initWithCampaign:campaign];
+    LDTCampaignViewController *campaignDetailViewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
     dispatch_async(dispatch_get_main_queue(), ^{
-        [navigationController pushViewController:campaignDetailViewController animated:YES];
+        [appDelegate pushViewController:campaignDetailViewController];
     });
 }
 

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -47,7 +47,6 @@
     [super viewDidLoad];
 
     self.navigationItem.title = nil;
-
     if ([self.user isLoggedInUser] || !self.user) {
         self.user = [DSOUserManager sharedInstance].user;
         self.isCurrentUserProfile = YES;
@@ -58,26 +57,17 @@
         self.navigationItem.rightBarButtonItem = settingsButton;
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(receivedNotification:) name:@"updateCurrentUser" object:nil];
     }
+    self.navigationItem.title = self.user.displayName.uppercaseString;
 
     NSURL *jsCodeLocation = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate).jsCodeLocation;
     self.reactRootView =[[RCTRootView alloc] initWithBundleURL:jsCodeLocation moduleName: @"UserView" initialProperties:[self appProperties] launchOptions:nil];
     self.view = self.reactRootView;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [self.navigationController styleNavigationBar:LDTNavigationBarStyleClear];
-    [self.navigationController setNavigationBarHidden:NO animated:YES];
-}
-
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
     [self styleView];
-
-    self.navigationController.hidesBarsOnSwipe = YES;
-    [self.navigationController.barHideOnSwipeGestureRecognizer addTarget:self action:@selector(handleSwipeGestureRecognizer:)];
 
     // Make sure self profile is to to date
     if (self.isCurrentUserProfile && [DSOUserManager sharedInstance].user) {
@@ -99,6 +89,7 @@
 
 - (void)styleView {
     [self styleBackBarButton];
+    [self.navigationController styleNavigationBar:LDTNavigationBarStyleNormal];
 }
 
 - (NSDictionary *)appProperties {
@@ -126,10 +117,6 @@
     if ([[notification name] isEqualToString:@"updateCurrentUser"]) {
       self.reactRootView.appProperties = [self appProperties];
     }
-}
-
-- (void)handleSwipeGestureRecognizer:(UISwipeGestureRecognizer *)recognizer {
-    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)presentCampaignDetailViewControllerForCampaignId:(NSInteger)campaignID {
@@ -184,7 +171,7 @@
 - (IBAction)settingsTapped:(id)sender {
     LDTSettingsViewController *destVC = [[LDTSettingsViewController alloc] initWithNibName:@"LDTSettingsView" bundle:nil];
     UINavigationController *destNavVC = [[UINavigationController alloc] initWithRootViewController:destVC];
-    [destNavVC styleNavigationBar:LDTNavigationBarStyleClear];
+    [destNavVC styleNavigationBar:LDTNavigationBarStyleNormal];
     LDTTabBarController *tabBar = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
     [tabBar presentViewController:destNavVC animated:YES completion:nil];
 }
@@ -199,7 +186,6 @@ RCT_EXPORT_MODULE();
     NSDictionary *props = @{@"campaigns" : campaigns};
     return props;
 }
-
 
 RCT_EXPORT_METHOD(presentCampaign:(NSInteger)campaignID) {
     [self presentCampaignDetailViewControllerForCampaignId:campaignID];
@@ -218,7 +204,6 @@ RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {
     [viewController styleBackBarButton];
 }
 
-
 #pragma mark - UIImagePickerControllerDelegate
 
 - (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
@@ -232,8 +217,6 @@ RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {
             [navigationController presentViewController:destNavVC animated:YES completion:nil];
         });
     }];
-
-
 }
 
 @end

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -143,7 +143,7 @@ RCT_EXPORT_METHOD(presentCampaign:(NSInteger)campaignID) {
         LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
         DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
         LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
-        [appDelegate pushViewController:viewController];
+        [appDelegate.tabBarController pushViewController:viewController];
     });
 }
 

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -119,55 +119,6 @@
     }
 }
 
-- (void)presentCampaignDetailViewControllerForCampaignId:(NSInteger)campaignID {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
-        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-        LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
-        [appDelegate pushViewController:viewController];
-    });
-}
-
-- (void)presentReportbackAlertControllerForCampaignId:(NSInteger)campaignID {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        // Initalizing here, because when we add it into viewDidLoad its set to nil at this point and we crash with uncaught exception 'NSInvalidArgumentException', reason: 'Application tried to present a nil modal view controller on target <LDTTabBarController>.'
-        // @todo This is pretty nasty to init every time. Some options are just getting this to work in viewDidLoad... or trying to send the selected file from React Native here
-        self.imagePickerController = [[UIImagePickerController alloc] init];
-        self.imagePickerController.delegate = self;
-        self.imagePickerController.allowsEditing = YES;
-        LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-        self.selectedCampaign = campaign;
-        // @todo New reportbackPhotoAlertController subclass to DRY with Campaign Detail VC
-        UIAlertController *reportbackPhotoAlertController = [UIAlertController alertControllerWithTitle:@"Pics or it didn't happen!" message:nil                                                              preferredStyle:UIAlertControllerStyleActionSheet];
-        UIAlertAction *cameraAlertAction;
-        if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
-            cameraAlertAction = [UIAlertAction actionWithTitle:@"Take Photo" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
-                [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"camera" value:nil];
-                self.imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
-                [tabBarController presentViewController:self.imagePickerController animated:YES completion:NULL];
-            }];
-        }
-        else {
-            cameraAlertAction = [UIAlertAction actionWithTitle:@"(Camera Unavailable)" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
-                // Nada
-            }];
-        }
-        UIAlertAction *photoLibraryAlertAction = [UIAlertAction actionWithTitle:@"Choose From Library" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action){
-            [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"choose reportback photo" label:@"gallery" value:nil];
-            self.imagePickerController.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
-            [tabBarController presentViewController:self.imagePickerController animated:YES completion:NULL];
-        }];
-        UIAlertAction *cancelAlertAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
-            [reportbackPhotoAlertController dismissViewControllerAnimated:YES completion:nil];
-        }];
-        [reportbackPhotoAlertController addAction:cameraAlertAction];
-        [reportbackPhotoAlertController addAction:photoLibraryAlertAction];
-        [reportbackPhotoAlertController addAction:cancelAlertAction];
-        [tabBarController presentViewController:reportbackPhotoAlertController animated:YES completion:nil];
-    });
-}
-
 - (IBAction)settingsTapped:(id)sender {
     LDTSettingsViewController *destVC = [[LDTSettingsViewController alloc] initWithNibName:@"LDTSettingsView" bundle:nil];
     UINavigationController *destNavVC = [[UINavigationController alloc] initWithRootViewController:destVC];
@@ -188,35 +139,12 @@ RCT_EXPORT_MODULE();
 }
 
 RCT_EXPORT_METHOD(presentCampaign:(NSInteger)campaignID) {
-    [self presentCampaignDetailViewControllerForCampaignId:campaignID];
-}
-
-RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {
-    [self presentReportbackAlertControllerForCampaignId:campaignID];
-}
-
-# pragma mark - UINavigationControllerDelegate
-
-- (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
-    [viewController.navigationController styleNavigationBar:LDTNavigationBarStyleNormal];
-    viewController.title = [NSString stringWithFormat:@"I did %@", self.selectedCampaign.title].uppercaseString;
-    [viewController styleRightBarButton];
-    [viewController styleBackBarButton];
-}
-
-#pragma mark - UIImagePickerControllerDelegate
-
-- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
-    [picker dismissViewControllerAnimated:YES completion:^{
-        dispatch_async(dispatch_get_main_queue(), ^{
-            LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-            UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
-            UIImage *selectedImage = info[UIImagePickerControllerEditedImage];
-            LDTSubmitReportbackViewController *destVC = [[LDTSubmitReportbackViewController alloc] initWithCampaign:self.selectedCampaign reportbackItemImage:selectedImage];
-            UINavigationController *destNavVC = [[UINavigationController alloc] initWithRootViewController:destVC];
-            [navigationController presentViewController:destNavVC animated:YES completion:nil];
-        });
-    }];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
+        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
+        LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
+        [appDelegate pushViewController:viewController];
+    });
 }
 
 @end

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -9,7 +9,7 @@
 #import "LDTUserViewController.h"
 #import "LDTTheme.h"
 #import "LDTTabBarController.h"
-#import "LDTCampaignDetailViewController.h"
+#import "LDTCampaignViewController.h"
 #import "LDTSubmitReportbackViewController.h"
 #import "LDTSettingsViewController.h"
 #import "GAI+LDT.h"
@@ -134,11 +134,10 @@
 
 - (void)presentCampaignDetailViewControllerForCampaignId:(NSInteger)campaignID {
     dispatch_async(dispatch_get_main_queue(), ^{
+        LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
         DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-        LDTTabBarController *tabBarController = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-        UINavigationController *navigationController = tabBarController.childViewControllers[tabBarController.selectedIndex];
-        LDTCampaignDetailViewController *campaignDetailViewController = [[LDTCampaignDetailViewController alloc] initWithCampaign:campaign];
-        [navigationController pushViewController:campaignDetailViewController animated:YES];
+        LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
+        [appDelegate pushViewController:viewController];
     });
 }
 

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -138,13 +138,4 @@ RCT_EXPORT_MODULE();
     return props;
 }
 
-RCT_EXPORT_METHOD(presentCampaign:(NSInteger)campaignID) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        LDTAppDelegate *appDelegate = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
-        DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-        LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
-        [appDelegate.tabBarController pushViewController:viewController];
-    });
-}
-
 @end

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -13,7 +13,7 @@
 @interface DSOCampaign : NSObject
 
 @property (strong, nonatomic, readonly) DSOCause *cause;
-@property (strong, nonatomic, readonly) DSOCampaignSignup *currentUserSignup;
+@property (strong, nonatomic) DSOCampaignSignup *currentUserSignup;
 @property (strong, nonatomic, readonly) NSArray *tags;
 @property (strong, nonatomic, readonly) NSDictionary *dictionary;
 @property (assign, nonatomic, readonly) NSInteger campaignID;

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -7,12 +7,13 @@
 //
 
 @class DSOCampaign;
+@class DSOCampaignSignup;
 @class DSOCause;
 
 @interface DSOCampaign : NSObject
 
-@property (assign, nonatomic, readonly) BOOL isCoverImageDarkBackground;
 @property (strong, nonatomic, readonly) DSOCause *cause;
+@property (strong, nonatomic, readonly) DSOCampaignSignup *currentUserSignup;
 @property (strong, nonatomic, readonly) NSArray *tags;
 @property (strong, nonatomic, readonly) NSDictionary *dictionary;
 @property (assign, nonatomic, readonly) NSInteger campaignID;

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -83,7 +83,7 @@
     else {
         coverImage = @"";
     }
-    // Hack for some kind of crash
+    // @todo This is hack for default solutionCopy nullValue not being set
     if (!self.solutionCopy) {
         self.solutionCopy = @"";
     }
@@ -101,7 +101,6 @@
              @"solutionCopy" : self.solutionCopy,
              @"solutionSupportCopy" : self.solutionSupportCopy,
              };
-    NSLog(@"dict %@", dict);
     return dict;
 }
 

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -52,18 +52,17 @@
         NSDictionary *causeDict = [values valueForKeyPath:@"causes.primary"];
         _cause = [[DSOCause alloc] initWithPhoenixDict:causeDict];
         _tagline = [values valueForKeyAsString:@"tagline" nullValue:@""];
-        _coverImage = [[values valueForKeyPath:@"cover_image.default.sizes.landscape"] valueForKeyAsString:@"uri" nullValue:@""];
-        _isCoverImageDarkBackground = [[values valueForKeyPath:@"cover_image.default"] valueForKeyAsBool:@"dark_background" nullValue:NO];
+        _coverImage = [[values valueForKeyPath:@"cover_image.default.sizes.landscape"] valueForKeyAsString:@"uri" nullValue:@""];;
         _reportbackNoun = [values valueForKeyPath:@"reportback_info.noun"];
         _reportbackVerb = [values valueForKeyPath:@"reportback_info.verb"];
-        _solutionCopy = [[values valueForKeyPath:@"solutions.copy"] valueForKeyAsString:@"raw" nullValue:nil];
+        _solutionCopy = [[values valueForKeyPath:@"solutions.copy"] valueForKeyAsString:@"raw" nullValue:@""];
         if ([values[@"solutions"] objectForKey:@"support_copy"]) {
             // Might be string: see https://github.com/DoSomething/phoenix/issues/5069
             if ([[values[@"solutions"] objectForKey:@"support_copy"] isKindOfClass:[NSString class]]) {
                 _solutionSupportCopy = [values valueForKeyPath:@"solutions.support_copy"];
             }
             else {
-                _solutionSupportCopy = [[values valueForKeyPath:@"solutions.support_copy"] valueForKeyAsString:@"raw" nullValue:nil];
+                _solutionSupportCopy = [[values valueForKeyPath:@"solutions.support_copy"] valueForKeyAsString:@"raw" nullValue:@""];
             }
         }
         _tags = values[@"tags"];
@@ -84,12 +83,37 @@
     else {
         coverImage = @"";
     }
-    return @{
+    // Hack for some kind of crash
+    if (!self.solutionCopy) {
+        self.solutionCopy = @"";
+    }
+    if (!self.solutionSupportCopy) {
+        self.solutionSupportCopy = @"";
+    }
+    NSDictionary *reportbackInfo = @{@"noun" : self.reportbackNoun, @"verb" : self.reportbackVerb};
+    NSDictionary *dict = @{
              @"id" : [NSNumber numberWithInteger:self.campaignID],
+             @"status": self.status,
              @"title" : self.title,
              @"image_url" : coverImage,
              @"tagline" : self.tagline,
+             @"reportback_info" : reportbackInfo,
+             @"solutionCopy" : self.solutionCopy,
+             @"solutionSupportCopy" : self.solutionSupportCopy,
              };
+    NSLog(@"dict %@", dict);
+    return dict;
+}
+
+- (DSOCampaignSignup *)currentUserSignup {
+    DSOUser *currentUser = [DSOUserManager sharedInstance].user;
+    for (DSOCampaignSignup *signup in currentUser.campaignSignups) {
+
+        if (self.campaignID == signup.campaign.campaignID) {
+            return signup;
+        }
+    }
+    return nil;
 }
 
 @end

--- a/Lets Do This/Models/DSOCampaignSignup.h
+++ b/Lets Do This/Models/DSOCampaignSignup.h
@@ -15,6 +15,8 @@
 @property (strong, nonatomic) DSOUser *user;
 @property (strong, nonatomic) DSOReportbackItem *reportbackItem;
 @property (assign, nonatomic, readonly) NSInteger signupID;
+@property (strong, nonatomic) NSDictionary *dictionary;
+
 
 - (instancetype)initWithCampaign:(DSOCampaign *)campaign user:(DSOUser *)user;
 - (instancetype)initWithDict:(NSDictionary *)dict;

--- a/Lets Do This/Models/DSOCampaignSignup.h
+++ b/Lets Do This/Models/DSOCampaignSignup.h
@@ -20,5 +20,6 @@
 
 - (instancetype)initWithCampaign:(DSOCampaign *)campaign user:(DSOUser *)user;
 - (instancetype)initWithDict:(NSDictionary *)dict;
+- (instancetype)initWithID:(NSInteger)signupID campaign:(DSOCampaign *)campaign;
 
 @end

--- a/Lets Do This/Models/DSOCampaignSignup.m
+++ b/Lets Do This/Models/DSOCampaignSignup.m
@@ -42,6 +42,20 @@
     return self;
 }
 
+- (instancetype)initWithID:(NSInteger)signupID campaign:(DSOCampaign *)campaign {
+
+    self = [super init];
+
+    if (self) {
+        _signupID = signupID;
+        _campaign = campaign;
+    }
+
+    return self;
+}
+
+#pragma mark - Accessors
+
 - (NSDictionary *)dictionary {
     return @{
              @"id" : [NSNumber numberWithInteger:self.signupID],

--- a/Lets Do This/Models/DSOCampaignSignup.m
+++ b/Lets Do This/Models/DSOCampaignSignup.m
@@ -33,6 +33,7 @@
     self = [super init];
 
     if (self) {
+
         _signupID = [dict valueForKeyAsInt:@"id" nullValue:0];
         _campaign = [[DSOCampaign alloc] initWithDict:dict[@"campaign"]];
         // @todo: Waiting for Reportback object: https://github.com/DoSomething/phoenix/issues/6151
@@ -40,5 +41,12 @@
 
     return self;
 }
+
+- (NSDictionary *)dictionary {
+    return @{
+             @"id" : [NSNumber numberWithInteger:self.signupID],
+             };
+}
+
 
 @end

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -32,8 +32,6 @@
 
 - (void)postUserAvatarWithUserId:(NSString *)userID avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)createCampaignSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
 - (void)postReportbackItem:(DSOReportbackItem *)reportbackItem completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)loadUserWithUserId:(NSString *)userID completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -38,6 +38,8 @@
 
 - (void)loadUserWithUserId:(NSString *)userID completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+- (void)postSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+
 // Potentially temporary method, exploring loading all Campaigns into memory.
 - (void)loadAllCampaignsWithCompletionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -174,6 +174,26 @@
     }];
 }
 
+- (void)postSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    NSDictionary *params = @{@"campaign_id" : [NSNumber numberWithInteger:campaign.campaignID], @"source" : LDTSOURCENAME};
+    NSString *url = @"signups";
+    [self POST:url parameters:params success:^(NSURLSessionDataTask *task, id responseObject) {
+        NSLog(@"responseObject %@", responseObject);
+        // @todo This is my insane API endpoint we should change to return an actual Signup object
+        // This seems to fial, cant figure out how to get responseObject in value with ( parenthesis )
+//        NSInteger signupID = (NSInteger)responseObject;
+        DSOCampaignSignup *signup = [[DSOCampaignSignup alloc] init];
+        if (completionHandler) {
+            completionHandler(signup);
+        }
+    } failure:^(NSURLSessionDataTask *task, NSError *error) {
+        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
+        if (errorHandler) {
+            errorHandler(error);
+        }
+    }];
+}
+
 - (void)createCampaignSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *url = [NSString stringWithFormat:@"user/campaigns/%ld/signup", (long)campaign.campaignID];
     NSDictionary *params = @{@"source": LDTSOURCENAME};

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -194,27 +194,10 @@
     }];
 }
 
-- (void)createCampaignSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    NSString *url = [NSString stringWithFormat:@"user/campaigns/%ld/signup", (long)campaign.campaignID];
-    NSDictionary *params = @{@"source": LDTSOURCENAME};
-
-    [self POST:url parameters:params success:^(NSURLSessionDataTask *task, id responseObject) {
-        DSOCampaignSignup *signup = [[DSOCampaignSignup alloc] initWithDict:responseObject[@"data"]];
-        signup.campaign = campaign;
-        if (completionHandler) {
-            completionHandler(signup);
-        }
-      } failure:^(NSURLSessionDataTask *task, NSError *error) {
-          [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
-          if (errorHandler) {
-              errorHandler(error);
-          }
-      }];
-}
-
 - (void)postReportbackItem:(DSOReportbackItem *)reportbackItem completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    NSString *url = [NSString stringWithFormat:@"user/campaigns/%ld/reportback", (long)reportbackItem.campaign.campaignID];
+    NSString *url = @"reportbacks";
     NSDictionary *params = @{
+                             @"campaign_id": [NSNumber numberWithInteger:reportbackItem.campaign.campaignID],
                              @"quantity": [NSNumber numberWithInteger:reportbackItem.quantity],
                              @"caption": reportbackItem.caption,
                              // why_participated is a required property on server-side that we currently don't collect in the app.

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -17,7 +17,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 @interface DSOUserManager()
 
 @property (strong, nonatomic, readwrite) DSOUser *user;
-@property (strong, nonatomic) NSMutableArray *mutableActiveCampaigns;
+@property (strong, nonatomic) NSMutableArray *mutableCampaigns;
 
 @end
 
@@ -49,7 +49,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 }
 
 - (NSArray *)activeCampaigns {
-    return [self.mutableActiveCampaigns copy];
+    return [self.mutableCampaigns copy];
 }
 
 - (NSDictionary *)campaignDictionaries {
@@ -125,17 +125,8 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 - (void)loadActiveCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     [[DSOAPI sharedInstance] loadCampaignSignupsForUser:user completionHandler:^(NSArray *campaignSignups) {
         [user removeAllCampaignSignups];
-        NSMutableArray *inactiveCampaignIDs = [[NSMutableArray alloc] init];
         for (DSOCampaignSignup *signup in campaignSignups) {
-            if ([self activeCampaignWithId:signup.campaign.campaignID]) {
-                [user addCampaignSignup:signup];
-            }
-            else {
-                [inactiveCampaignIDs addObject:[NSString stringWithFormat:@"%li", (long)signup.campaign.campaignID]];
-            }
-        }
-        if (inactiveCampaignIDs.count > 0) {
-            NSLog(@"[DSOUserManager] Filtering User %@ Signups for inactive Campaigns %@.", user.userID, [inactiveCampaignIDs componentsJoinedByString:@","]);
+            [user addCampaignSignup:signup];
         }
         if (completionHandler) {
             completionHandler();
@@ -220,20 +211,12 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     [[DSOAPI sharedInstance] loadAllCampaignsWithCompletionHandler:^(NSArray *campaigns) {
         NSLog(@"loadAllCampaignsWithCompletionHandler");
         if (campaigns.count == 0) {
+            // @todo Throw error here
             NSLog(@"No campaigns found.");
         }
-        self.mutableActiveCampaigns = [[NSMutableArray alloc] init];
-        NSMutableArray *inactiveCampaignIDs = [[NSMutableArray alloc] init];
+        self.mutableCampaigns = [[NSMutableArray alloc] init];
         for (DSOCampaign *campaign in campaigns) {
-            if ([campaign.status isEqual:@"active"]) {
-                [self.mutableActiveCampaigns addObject:campaign];
-            }
-            else {
-                [inactiveCampaignIDs addObject:[NSString stringWithFormat:@"%li", (long)campaign.campaignID]];
-            }
-        }
-        if (inactiveCampaignIDs.count > 0) {
-            NSLog(@"[DSOUserManager] Filtering inactive Campaigns %@.", [inactiveCampaignIDs componentsJoinedByString:@", "]);
+            [self.mutableCampaigns addObject:campaign];
         }
 
         [self startSessionWithCompletionHandler:^ {

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -163,9 +163,9 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 }
 
 - (void)signupUserForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    [[DSOAPI sharedInstance] createCampaignSignupForCampaign:campaign completionHandler:^(DSOCampaignSignup *signup) {
+    [[DSOAPI sharedInstance] postSignupForCampaign:campaign completionHandler:^(DSOCampaignSignup *signup) {
         [self.user addCampaignSignup:signup];
-        [[GAI sharedInstance] trackEventWithCategory:@"campaign" action:@"submit signup" label:[NSString stringWithFormat:@"%li", (long)campaign.campaignID] value:nil];
+//        [[GAI sharedInstance] trackEventWithCategory:@"campaign" action:@"submit signup" label:[NSString stringWithFormat:@"%li", (long)campaign.campaignID] value:nil];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"updateCurrentUser" object:self];
         if (completionHandler) {
             completionHandler(signup);

--- a/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
+++ b/Lets Do This/Views/Campaign/LDTCampaignDetailCampaignCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -136,7 +136,7 @@ var CampaignView = React.createClass({
       .done();
     }
     else {
-      CampaignViewController.presentProveIt();
+      CampaignViewController.presentProveIt(Number(this.props.campaign.id));
     }
   },
   renderActionButton: function() {

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -134,7 +134,15 @@ var CampaignView = React.createClass({
     if (!this.props.currentUserSignup.id) {
       return null;
     }
-
+    var solutionText, solutionSupportText;
+    if (this.props.campaign.solutionCopy.length > 0) {
+      solutionText = this.renderCampaignContentText(this.props.campaign.solutionCopy);
+    }
+    if (this.props.campaign.solutionSupportCopy.length > 0) {
+      solutionSupportText = this.renderCampaignContentText(this.props.campaign.solutionSupportCopy);
+    }
+    var submitCopy = "When you're done, submit a pic of yourself in action. #picsoritdidnthappen";
+    var submitText = this.renderCampaignContentText(submitCopy);
     return (
       <View>
         <View style={Style.sectionHeader}>
@@ -143,17 +151,16 @@ var CampaignView = React.createClass({
           </Text>
         </View>
         <View style={styles.content}>
-          <Text style={[Style.textBody, styles.paragraph]}>
-            {this.props.campaign.solutionCopy}
-          </Text>
-          <Text style={[Style.textBody, styles.paragraph]}>
-            {this.props.campaign.solutionSupportCopy}
-          </Text>
-          <Text style={[Style.textBody, styles.paragraph]}>
-            When you’re done, submit a pic of yourself in action. #picsoritdidnthappen
-          </Text>
+          {solutionText}
+          {solutionSupportText}
+          {submitText}
         </View>
       </View>
+    );
+  },
+  renderCampaignContentText: function(copy) {
+    return (
+      <Text style={[Style.textBody, styles.contentText]}>{copy}</Text>
     );
   },
   renderCover: function() {
@@ -254,7 +261,7 @@ var styles = React.StyleSheet.create({
   content: {
     padding: 8,
   },
-  paragraph: {
+  contentText: {
     paddingBottom: 12,
   }
 });

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -1,0 +1,263 @@
+'use strict';
+
+import React, {
+  StyleSheet,
+  Text,
+  Image,
+  TouchableHighlight,
+  ListView,
+  View,
+  ActivityIndicatorIOS,
+  RefreshControl
+} from 'react-native';
+import Dimensions from 'Dimensions';
+
+var Style = require('./Style.js');
+var ReportbackItemView = require('./ReportbackItemView.js');
+var CampaignViewController = require('react-native').NativeModules.LDTCampaignViewController;
+
+var CampaignView = React.createClass({
+  getInitialState: function() {
+    return {
+      dataSource: new ListView.DataSource({
+        rowHasChanged: (row1, row2) => row1 !== row2,
+      }),
+      isRefreshing: false,
+      loaded: false,
+      error: false,
+    };
+  },
+  componentDidMount: function() {
+    this.fetchData();
+  },
+  fetchData: function() {
+    fetch(this.props.url)
+      .then((response) => response.json())
+      .then((responseData) => {
+        this.setState({
+          dataSource: this.state.dataSource.cloneWithRows(responseData.data),
+          loaded: true,
+        });
+      })
+      .catch((error) => this.catchError(error))
+      .done();
+  },
+  catchError: function(error) {
+    console.log(error);
+    this.setState({
+      error: error,
+    });
+  },
+  renderError: function() {
+    return (
+      <View>
+        {this.renderCover()}
+        <View style={styles.loadingContainer}>
+          <Text style={Style.textBody}>
+            Epic Fail
+          </Text>
+        </View>
+      </View>
+    );
+  },
+  renderLoadingView: function() {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicatorIOS animating={this.state.animating} style={[{height: 80}]} size="small" />
+        <Text style={Style.textBody}>
+          Loading photos...
+        </Text>
+      </View>
+    );
+  },
+  _onRefresh: function () {
+    this.setState({isRefreshing: true});
+    setTimeout(() => {
+      this.fetchData();
+      this.setState({
+        isRefreshing: false,
+      });
+    }, 1000);
+  },
+  render: function() {
+    if (this.state.error) {
+      return this.renderError();
+    }
+    if (!this.state.loaded) {
+      return this.renderLoadingView();
+    }
+    return (      
+      <ListView
+      dataSource={this.state.dataSource}
+      renderHeader={this.renderHeader}
+      renderRow={this.renderRow}
+      refreshControl= {
+        <RefreshControl
+          refreshing={this.state.isRefreshing}
+          onRefresh={this._onRefresh}
+          tintColor="#CCC"
+          colors={['#ff0000', '#00ff00', '#0000ff']}
+          progressBackgroundColor="#ffff00"
+        />}
+      />
+    );
+  },
+  _onPressActionButton: function() {
+    console.log('Tappy');
+  },
+  renderActionButton: function() {
+    // @todo: If reportback, return selfReportback;
+    var actionButtonText = 'Do this now';
+    if (this.props.currentUserSignup.id) {
+      var actionButtonText = 'Prove it';
+    }    
+    return (
+      <View style={styles.content}>
+        <TouchableHighlight style={[Style.actionButton, styles.content]} onPress={() => this._onPressActionButton()}>
+          <Text style={Style.actionButtonText}>
+            {actionButtonText.toUpperCase()}
+          </Text>
+        </TouchableHighlight>
+      </View>
+    );
+  },
+  renderClosedContent: function() {
+    return (
+      <View>
+        <Text style={[Style.textBody, {textAlign: 'center', padding: 20}]}>
+          This action is no longer available. 
+        </Text>
+      </View>
+    );
+  },
+  renderCampaignContent: function() {
+    if (!this.props.currentUserSignup.id) {
+      return null;
+    }
+
+    return (
+      <View>
+        <View style={Style.sectionHeader}>
+          <Text style={Style.sectionHeaderText}>
+            {'Do it'.toUpperCase()}
+          </Text>
+        </View>
+        <View style={styles.content}>
+          <Text style={[Style.textBody, styles.paragraph]}>
+            {this.props.campaign.solutionCopy}
+          </Text>
+          <Text style={[Style.textBody, styles.paragraph]}>
+            {this.props.campaign.solutionSupportCopy}
+          </Text>
+          <Text style={[Style.textBody, styles.paragraph]}>
+            When you’re done, submit a pic of yourself in action. #picsoritdidnthappen
+          </Text>
+        </View>
+      </View>
+    );
+  },
+  renderCover: function() {
+    var campaign = this.props.campaign;
+    if (campaign.image_url.length == 0) {
+      campaign.image_url = 'https://placekitten.com/g/600/600';
+    }
+    return (
+      <View>
+        <View style={styles.coverImageContainer}>
+          <Image
+            style={styles.coverImage}
+            source={{uri: campaign.image_url}}>
+            <View style={styles.titleContainer}>
+              <Text style={[Style.textTitle, styles.centeredTitleText]}>
+                {campaign.title.toUpperCase()}
+              </Text>
+            </View>
+          </Image>
+        </View>
+        <Text style={[Style.textSubheading, styles.tagline]}>
+          {campaign.tagline}
+        </Text>
+      </View>
+    );
+  },
+  renderHeader: function() {
+    var content;
+    if (this.props.campaign.status == 'closed') {
+      content= this.renderClosedContent();
+    }
+    else {
+      content = (
+        <View>
+          {this.renderCampaignContent()}
+          {this.renderActionButton()}
+        </View>
+      );
+    }
+    return (
+      <View>
+        {this.renderCover()}
+        {content}
+      </View>
+    );
+  },
+  renderRow: function(rowData) {
+    return (
+      <TouchableHighlight onPress={() => this._onPressRow(rowData.user)}>
+        <View>
+          <ReportbackItemView
+          key={rowData.id}
+          reportbackItem={rowData}
+          reportback={rowData.reportback}
+          campaign={rowData.campaign}
+          user={rowData.user}
+          />
+        </View>
+      </TouchableHighlight>
+    );
+  },
+  _onPressRow: function(user) {
+    CampaignViewController.presentUser(user);
+  }
+});
+
+// @todo: shadownotworking 
+// @see https://github.com/facebook/react-native/issues/449#issuecomment-157874168
+var styles = React.StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  coverImage: {
+    flex: 1,
+    height: 242,
+    alignItems: 'stretch',
+  },
+  titleContainer: {
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    alignItems: 'flex-end',
+    flex: 1,
+    flexDirection: 'row',
+    padding: 20,
+  },
+  centeredTitleText: {
+    color: 'white',
+    flex: 1,
+    flexDirection: 'column',
+    textAlign: 'center',
+  },
+  tagline: {
+    padding: 20,
+    textAlign: 'center',
+  },
+  content: {
+    padding: 8,
+  },
+  paragraph: {
+    paddingBottom: 12,
+  }
+});
+
+
+module.exports = CampaignView;

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -125,12 +125,10 @@ var CampaignView = React.createClass({
       })
       .then((response) => response.json())
       .then((responseData) => {
-        console.log('signup success');
-        console.log(responseData);
         this.setState({
           signup: true,
         });
-        Bridge.signupConfirmMessageForCampaignTitle(this.props.campaign.title);
+        Bridge.displaySignupSuccessMessageWithCampaignTitle(this.props.campaign.title);
       })
       .catch((error) => this.catchError(error))
       .done();

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -14,7 +14,7 @@ import Dimensions from 'Dimensions';
 
 var Style = require('./Style.js');
 var ReportbackItemView = require('./ReportbackItemView.js');
-var CampaignViewController = require('react-native').NativeModules.LDTCampaignViewController;
+var Bridge = require('react-native').NativeModules.LDTReactBridge;
 
 var CampaignView = React.createClass({
   getInitialState: function() {
@@ -130,13 +130,13 @@ var CampaignView = React.createClass({
         this.setState({
           signup: true,
         });
-        CampaignViewController.signupConfirmMessageForCampaignTitle(this.props.campaign.title);
+        Bridge.signupConfirmMessageForCampaignTitle(this.props.campaign.title);
       })
       .catch((error) => this.catchError(error))
       .done();
     }
     else {
-      CampaignViewController.presentProveIt(Number(this.props.campaign.id));
+      Bridge.presentProveIt(Number(this.props.campaign.id));
     }
   },
   renderActionButton: function() {
@@ -260,7 +260,7 @@ var CampaignView = React.createClass({
     );
   },
   _onPressRow: function(user) {
-    CampaignViewController.presentUser(user);
+    Bridge.pushUser(user);
   }
 });
 

--- a/ReactComponents/CauseDetailView.js
+++ b/ReactComponents/CauseDetailView.js
@@ -48,7 +48,9 @@ var CauseDetailView = React.createClass({
             </Text>
           </View>
         </Image>
-        <Text style={[Style.textSubheading, styles.tagline]}>{this.props.cause.tagline}</Text>
+        <Text style={[Style.textSubheading, styles.tagline]}>
+          {this.props.cause.tagline}
+        </Text>
       </View>
     );
   },

--- a/ReactComponents/CauseDetailView.js
+++ b/ReactComponents/CauseDetailView.js
@@ -13,7 +13,7 @@ import React, {
 } from 'react-native';
 
 var Style = require('./Style.js');
-var CauseDetailViewController = require('react-native').NativeModules.LDTCauseDetailViewController;
+var Bridge = require('react-native').NativeModules.LDTReactBridge;
 
 var CauseDetailView = React.createClass({
   getInitialState: function() {
@@ -75,7 +75,7 @@ var CauseDetailView = React.createClass({
     );
   },
   _onPressRow(campaign) {
-    CauseDetailViewController.presentCampaign(campaign.id);
+    Bridge.pushCampaign(campaign.id);
   },
 });
 

--- a/ReactComponents/CauseListView.js
+++ b/ReactComponents/CauseListView.js
@@ -14,7 +14,7 @@ import React, {
 } from 'react-native';
 
 var Style = require('./Style.js');
-var CauseListViewController = require('react-native').NativeModules.LDTCauseListViewController;
+var Bridge = require('react-native').NativeModules.LDTReactBridge;
 
 var CauseListView = React.createClass({
   getInitialState: function() {
@@ -102,7 +102,7 @@ var CauseListView = React.createClass({
     );
   },
   _onPressRow(cause) {
-    CauseListViewController.presentCause(cause);
+    Bridge.pushCause(cause);
   },
   renderRow: function(cause) {
     var causeColorStyle = {backgroundColor: '#' + cause.hex};

--- a/ReactComponents/NewsFeedPost.js
+++ b/ReactComponents/NewsFeedPost.js
@@ -10,7 +10,7 @@ import React, {
 
 var Helpers = require('./Helpers.js');
 var Style = require('./Style.js');
-var NewsFeedViewController = require('react-native').NativeModules.LDTNewsFeedViewController;
+var Bridge = require('react-native').NativeModules.LDTReactBridge;
 
 var NewsFeedPost = React.createClass({
   getInitialState() {
@@ -19,10 +19,10 @@ var NewsFeedPost = React.createClass({
     };
   },
   _onPressActionButton: function() {
-    NewsFeedViewController.presentCampaign(this.props.post.campaign_id);
+    Bridge.pushCampaign(this.props.post.campaign_id);
   },
   _onPressFullArticleButton: function() {
-    NewsFeedViewController.presentFullArticle(this.props.post.id, this.props.post.full_article_url);
+    Bridge.presentNewsArticle(this.props.post.id, this.props.post.full_article_url);
   },
   _onPressImageCreditButton: function() {
     this.setState({

--- a/ReactComponents/ReportbackItemView.js
+++ b/ReactComponents/ReportbackItemView.js
@@ -13,17 +13,21 @@ var Style = require('./Style.js');
 
 var ReportbackItemView = React.createClass({
   render: function() {
-    // We only supporting displaying a single reportbackItem for now.
-    var reportbackItem = this.props.reportback.reportback_items.data[0];
-    var campaign = this.props.reportback.campaign;
+    var reportbackItem = this.props.reportbackItem;
+    var reportback = this.props.reportback;
+    var campaign = this.props.campaign;
     var quantityLabel = campaign.reportback_info.noun + ' ' + campaign.reportback_info.verb;
-    var user = this.props.reportback.user;
+    var user = this.props.user;
+
     // @todo: Need countryName from iOS
-    if (user.first_name.length == 0) {
+    if ((!user.country) || user.country.length == 0) {
+      user.country = '';
+    }
+    if ((!user.country) || user.first_name.length == 0) {
       user.first_name = 'Doer';
     }
-    if (user.photo.length == 0) {
-      this.props.user.avatarURL = 'https://placekitten.com/g/600/600';
+    if ((user.photo && user.photo.length == 0) || (!user.photo)) {
+      user.photo = 'https://placekitten.com/g/600/600';
     }
     // Sanity check:
     if ((!reportbackItem.media) || reportbackItem.media.uri.length == 0) {
@@ -31,7 +35,9 @@ var ReportbackItemView = React.createClass({
     }
     return(
       <View style={styles.container}>
-       <Text style={[Style.textCaption, styles.countryNameText]}>{user.country}</Text>
+       <Text style={[Style.textCaption, styles.countryNameText]}>
+         {user.country.toUpperCase()}
+        </Text>
         <Image
           style={styles.reportbackItemImage}
           source={{uri:reportbackItem.media.uri}}
@@ -42,7 +48,7 @@ var ReportbackItemView = React.createClass({
               {campaign.title}
             </Text>
             <Text style={[Style.textCaptionBold, {textAlign: 'right'}]}>
-              {this.props.reportback.quantity} {quantityLabel}
+              {reportback.quantity} {quantityLabel}
             </Text>
           </View>
           <Text style={Style.textBody}>{reportbackItem.caption}</Text>
@@ -84,6 +90,7 @@ var styles = React.StyleSheet.create({
   countryNameText: {
     textAlign: 'right',
     paddingRight: 8,
+    height: 20,
   },
   avatarImage: {
     width: 50,

--- a/ReactComponents/Style.js
+++ b/ReactComponents/Style.js
@@ -23,6 +23,32 @@ module.exports = StyleSheet.create({
   textColorCtaBlue: {
     color: colorCtaBlue,
   },
+  actionButton: {
+    backgroundColor: colorCtaBlue,
+    borderBottomLeftRadius: 6,
+    borderBottomRightRadius: 6,
+    borderTopLeftRadius: 6,
+    borderTopRightRadius: 6,
+    paddingBottom: 10,
+    paddingTop: 10,
+  },
+  actionButtonText: {
+    color: 'white',
+    textAlign: 'center',
+    fontFamily: fontFamilyBoldName,
+    fontSize: fontSizeBody,
+  },
+  sectionHeader: {
+    backgroundColor: '#F8F8F6',
+  },
+  sectionHeaderText: {
+    textAlign: 'center', 
+    color: colorTextDefault,
+    fontFamily: fontFamilyBoldName,
+    fontSize: fontSizeHeading,
+    padding: 14,
+
+  },
   textCaption: {
     color: colorTextDefault,
     fontFamily: fontFamilyName,

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -79,6 +79,7 @@ var UserView = React.createClass({
           if (!campaign) {
             continue;
           }
+          signup.campaign = campaign;
           var sectionNumber = 0;
           if (signup.reportback) {
             sectionNumber = 1;

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -82,6 +82,9 @@ var UserView = React.createClass({
           var sectionNumber = 0;
           if (signup.reportback) {
             sectionNumber = 1;
+            signup.reportback = signup.reportback_data;
+            signup.reportbackItem = signup.reportback.reportback_items.data[0];
+            signup.user = signup.reportback.user;
           }
           rowIDs[sectionNumber].push(signup.id);
           dataBlob[sectionNumber + ':' + signup.id] = signup;
@@ -212,11 +215,19 @@ var UserView = React.createClass({
       </TouchableHighlight>
     );
   },
-  renderDoneRow: function(signup) {
+  renderDoneRow: function(rowData) {
     return (
-      <ReportbackItemView
-        key={signup.reportback_id}
-        reportback={signup.reportback_data} />
+      <TouchableHighlight onPress={() => this._onPressRow(rowData)}>
+        <View>
+          <ReportbackItemView
+            key={rowData.reportbackItem.id}
+            reportbackItem={rowData.reportbackItem}
+            reportback={rowData.reportback} 
+            campaign={rowData.campaign}
+            user={rowData.user}
+          />
+        </View>
+      </TouchableHighlight>
     );
   },
   _onPressRow(rowData) {

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -14,6 +14,7 @@ import React, {
 
 var Style = require('./Style.js');
 var UserViewController = require('react-native').NativeModules.LDTUserViewController;
+var Bridge = require('react-native').NativeModules.LDTReactBridge;
 var ReportbackItemView = require('./ReportbackItemView.js');
 
 var UserView = React.createClass({
@@ -75,10 +76,13 @@ var UserView = React.createClass({
         for (i = 0; i < signups.length; i++) {
           var signup = signups[i];
           // Filter out inactive campaigns.
+          // @todo Won't need this once we get tagline returned in campaign object
+          // Then we can just inspect the campaign status returned in object
           var campaign = UserViewController.campaigns[signup.campaign.id];
           if (!campaign) {
             continue;
           }
+          // @todo: Filter out any signups where !campaign_run.current
           signup.campaign = campaign;
           var sectionNumber = 0;
           if (signup.reportback) {
@@ -200,7 +204,7 @@ var UserView = React.createClass({
       // Render Prove It button
     }
     return (
-      <TouchableHighlight onPress={() => this._onPressDoingRow(signup)}>
+      <TouchableHighlight onPress={() => this._onPressRow(signup)}>
         <View style={styles.row}>
           <Text style={[Style.textHeading, Style.textColorCtaBlue]}>
             {signup.campaign.title}
@@ -228,10 +232,7 @@ var UserView = React.createClass({
     );
   },
   _onPressRow(rowData) {
-    UserViewController.presentCampaign(Number(rowData.campaign.id));
-  },
-  _onPressDoingRow(rowData) {
-    UserViewController.presentCampaign(Number(rowData.campaign.id));
+    Bridge.pushCampaign(Number(rowData.campaign.id));
   },
 });
 

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -232,14 +232,6 @@ var UserView = React.createClass({
   },
   _onPressDoingRow(rowData) {
     UserViewController.presentCampaign(Number(rowData.campaign.id));
-    return;
-    // @todo Fix me
-    if (this.props.isSelfProfile) {
-      UserViewController.presentProveIt(Number(rowData.campaign.id));
-    }
-    else {
-      UserViewController.presentCampaign(Number(rowData.campaign.id));
-    }
   },
 });
 

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -171,9 +171,6 @@ var UserView = React.createClass({
           style={styles.avatar}
           source={{uri: this.props.user.avatarURL}}
         />
-        <Text style={[Style.textTitle, styles.headerText]}>
-          {this.props.user.displayName.toUpperCase()}
-        </Text>
         <Text style={[Style.textHeading, styles.headerText]}>
           {this.props.user.countryName.toUpperCase()}
         </Text>
@@ -190,7 +187,6 @@ var UserView = React.createClass({
     );
   },
   renderRow: function(rowData) {
-    console.log(rowData);
     if (rowData.reportback) {
       return this.renderDoneRow(rowData);
     }

--- a/index.ios.js
+++ b/index.ios.js
@@ -14,3 +14,6 @@ AppRegistry.registerComponent('CauseDetailView', () => CauseDetailView);
 
 var UserView = require('./ReactComponents/UserView.js');
 AppRegistry.registerComponent('UserView', () => UserView);
+
+var CampaignView = require('./ReactComponents/CampaignView.js');
+AppRegistry.registerComponent('CampaignView', () => CampaignView);


### PR DESCRIPTION
This branch is growing into a monster :japanese_ogre: , but in decent shape to merge in. Here's the dilly:

Theming changes:

* Closes #744 -- Adds `LDTCampaignViewController`, which renders the Campaign Detail in React Native and styles per new designs. Deprecates the `LDTCampaignDetailViewController`.  

* Closes #819: Uniform opaque navigationBar for all screens within our Tab Bar Controller

React Native cleanup:

* Adds a `LDTReactBridge` class to implement the `RCTBridgeModule` in a singular place, and for all React Components to use. Major DRY, and gets the `-(dispatch_queue_t)methodQueue` working, so we don't need to constantly wrap our `RCT_EXPORT_METHOD` code in [`dispatch_async(dispatch_get_main_queue())`](http://stackoverflow.com/questions/28302019/getting-a-this-application-is-modifying-the-autolayout-engine-error)
    * This is likely why I had such trouble getting a `self.bridge.eventDispatcher` working, because we had multiple `RCTBridgeProtocol` implementations ([related SO thread](http://stackoverflow.com/questions/32879266/cant-send-an-event-from-main-thread-method-with-ios-and-react-native?lq=1))

API changes ( #814 ):

* Posts Signup to the new Northstar endpoint `CampaignView.js` using `fetch` because I was running into trouble with posting from `AFNetworking` in native code and updating the `CampaignView` React Component from within the native success callback. This might get way easier now that there's a single `RCTBridgeProtocol`. If we keep this POST within React, we need to display an error message if the Signup request errors.

* Posts Reportback to new Northstar `reportbacks` endpoint, but results in a 500 error. Need to investigate with @DFurnes 

TODO:
* [ ] Cleanup Signup code (either get it working via `DSOAPI` or implement error handling in the `CampaignView`)
* [ ] Get Reportback submit working
* [ ] Display self reportback if it exists. Ideally the Reportback POST response should return a fully loaded Reportback with the Reportback Item media information, so we can render in a success callback. React Native doesn't seem to have support for displaying a `UIImage` from the file system and not too interested in looking into [contrib modules](https://github.com/johanneslumpe/react-native-fs)
* [ ] Filter "Actions Doing" section to only display where the `signup.campaign_run.current == true`
