### PR TITLE
Filter inactive campaign signups on Profile Doing section

### DIFF
--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -69,11 +69,14 @@
 
     [self styleView];
 
-    // Make sure self profile is to to date
-    if (self.isCurrentUserProfile && [DSOUserManager sharedInstance].user) {
-        self.user = [DSOUserManager sharedInstance].user;
-        [self setNavigationItemTitle];
-        self.reactRootView.appProperties = [self appProperties];
+    // Check if user logged out and logged in as someone else.
+    if (self.isCurrentUserProfile) {
+        DSOUser *currentUser = [DSOUserManager sharedInstance].user;
+        if (![currentUser.userID isEqualToString:self.user.userID]) {
+            self.user = [DSOUserManager sharedInstance].user;
+            [self setNavigationItemTitle];
+            self.reactRootView.appProperties = [self appProperties];
+        }
     }
 
     NSString *trackingString;

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -41,7 +41,9 @@ var UserView = React.createClass({
     this.fetchData();
   },
   componentWillUpdate: function() {
-    this.fetchData();
+    // @todo: This isn't right, it's causing fetchData to load millions of times.
+    // We likely to inspect the loaded state in order to determine whether to refresh.
+    // this.fetchData();
   },
   fetchData: function() {
     var options = { 

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -77,14 +77,12 @@ var UserView = React.createClass({
         rowIDs[1] = [];
         for (i = 0; i < signups.length; i++) {
           var signup = signups[i];
-          // Filter out inactive campaigns.
-          // @todo Won't need this once we get tagline returned in campaign object
-          // Then we can just inspect the campaign status returned in object
+          // Sanity check the signup.campaign.id is a valid campaign.
           var campaign = UserViewController.campaigns[signup.campaign.id];
           if (!campaign) {
             continue;
           }
-          // @todo: Filter out any signups where !campaign_run.current
+
           signup.campaign = campaign;
           var sectionNumber = 0;
           if (signup.reportback) {
@@ -92,6 +90,17 @@ var UserView = React.createClass({
             signup.reportback = signup.reportback_data;
             signup.reportbackItem = signup.reportback.reportback_items.data[0];
             signup.user = signup.reportback.user;
+          }
+          else {
+            // Filter out any incomplete signups for non-current campaign runs.
+            if (!signup.campaign_run.current) {
+              continue;
+            }
+            // Also filter any incomplete signups that are for the current run
+            // but the campaign is closed.
+            if (signup.campaign.status != 'active') {
+              continue;
+            }
           }
           rowIDs[sectionNumber].push(signup.id);
           dataBlob[sectionNumber + ':' + signup.id] = signup;


### PR DESCRIPTION
Refs #757 - filter any Signups without Reportbacks which are not current and not closed from the Profile.

Still working out how to determine the relevant Signup for the Campaign view -- fighting with `AFNetworking` in Obj C vs React Native `fetch`, which relates to whether we'll post a Signup via AFNetworking or React (#829)

Also uncovered a bug which was causing the Profile to constantly query the API non-stop, so for now i'm removing the code that's doing that... which means there's bugs around logging in/out, or when you signup for a Campaign but Profile doesn't update. :construction: 

cc @jonuy -- might be useful code/logic.
