### PR TITLE
Upgrade React Native to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/DoSomething/LetsDoThis-iOS#readme",
   "dependencies": {
-    "react-native": "^0.18.1"
+    "react-native": "^0.19.0"
   }
 }


### PR DESCRIPTION
Closes #777

Tried to upgrade to 0.20 which came out this week but was getting errors upon build, which is disturbing but doesn't seem like something we need to worry about just yet.

@jonuy @lkpttn You'll need to run [`npm install --save react-native@0.19`](https://facebook.github.io/react-native/docs/upgrading.html) in your terminal in order for `npm start` to work.
