### PR TITLE
Fetch current user's activity in CampaignView.componentDidMount

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -53,18 +53,8 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
-//    DSOUser *currentUser = [DSOUserManager sharedInstance].user;
-//    NSString *screenStatus;
-//    if ([currentUser hasCompletedCampaign:self.campaign]) {
-//        screenStatus = @"completed";
-//    }
-//    else if ([currentUser isDoingCampaign:self.campaign]) {
-//        screenStatus = @"proveit";
-//    }
-//    else {
-//        screenStatus = @"pitch";
-//    }
-    // @todo Send screenStatus (or not)
+    // @todo (potentially). track this screen from React Native, since we determine the currentUser state there
+    // Previously we would send campaign/:id/pitch|proveit|completed
     [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"campaign/%ld", (long)self.campaign.campaignID]];
 }
 

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -75,20 +75,13 @@
 
 - (NSDictionary *)appProperties {
     NSDictionary *appProperties;
-    NSString *url = [NSString stringWithFormat:@"%@reportback-items?load_user=true&status=approved,promoted&campaigns=%li", [DSOAPI sharedInstance].phoenixApiURL, (long)self.campaign.campaignID];
-    NSDictionary *currentUserSignupDict;
-    if (self.campaign.currentUserSignup) {
-        currentUserSignupDict = self.campaign.currentUserSignup.dictionary;
-    }
-    else {
-        currentUserSignupDict = [[NSDictionary alloc] init];
-    }
+    NSString *galleryUrl = [NSString stringWithFormat:@"%@reportback-items?load_user=true&status=approved,promoted&campaigns=%li", [DSOAPI sharedInstance].phoenixApiURL, (long)self.campaign.campaignID];
     NSString *signupURLString = [NSString stringWithFormat:@"%@signups?user=%@", [DSOAPI sharedInstance].baseURL, [DSOUserManager sharedInstance].user.userID];
     appProperties = @{
                       @"campaign" : self.campaign.dictionary,
-                      @"galleryUrl" : url,
+                      @"galleryUrl" : galleryUrl,
                       @"signupUrl" : signupURLString,
-                      @"initialSignup" : currentUserSignupDict,
+                      @"currentUser" : [DSOUserManager sharedInstance].user.dictionary,
                       @"apiKey": [DSOAPI sharedInstance].apiKey,
                       @"sessionToken": [DSOUserManager sharedInstance].sessionToken,
                       };

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -53,18 +53,19 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
-    DSOUser *currentUser = [DSOUserManager sharedInstance].user;
-    NSString *screenStatus;
-    if ([currentUser hasCompletedCampaign:self.campaign]) {
-        screenStatus = @"completed";
-    }
-    else if ([currentUser isDoingCampaign:self.campaign]) {
-        screenStatus = @"proveit";
-    }
-    else {
-        screenStatus = @"pitch";
-    }
-    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"campaign/%ld/%@", (long)self.campaign.campaignID, screenStatus]];
+//    DSOUser *currentUser = [DSOUserManager sharedInstance].user;
+//    NSString *screenStatus;
+//    if ([currentUser hasCompletedCampaign:self.campaign]) {
+//        screenStatus = @"completed";
+//    }
+//    else if ([currentUser isDoingCampaign:self.campaign]) {
+//        screenStatus = @"proveit";
+//    }
+//    else {
+//        screenStatus = @"pitch";
+//    }
+    // @todo Send screenStatus (or not)
+    [[GAI sharedInstance] trackScreenView:[NSString stringWithFormat:@"campaign/%ld", (long)self.campaign.campaignID]];
 }
 
 #pragma mark - LDTCampaignViewController

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -84,12 +84,16 @@ RCT_EXPORT_METHOD(postSignup:(NSInteger)campaignID) {
     [SVProgressHUD showWithStatus:@"Signing up..."];
     [[DSOUserManager sharedInstance] signupUserForCampaign:campaign completionHandler:^(DSOCampaignSignup *signup) {
         [SVProgressHUD dismiss];
-        [[self appDelegate].bridge.eventDispatcher sendAppEventWithName:@"currentUserActivity" body:signup.dictionary];
         [LDTMessage displaySuccessMessageInViewController:self.tabBarController title:@"Niiiiice." subtitle:[NSString stringWithFormat:@"You signed up for %@.", campaign.title]];
     } errorHandler:^(NSError *error) {
         [SVProgressHUD dismiss];
         [LDTMessage displayErrorMessageInViewController:self.tabBarController title:error.readableTitle];
     }];
+}
+
+RCT_EXPORT_METHOD(shareReportback:(NSDictionary *)reportbackDict) {
+    // @todo: Present LDTActivityViewController
+    NSLog(@"reportback %@", reportbackDict);
 }
 
 @end

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -104,15 +104,4 @@
     return dict;
 }
 
-- (DSOCampaignSignup *)currentUserSignup {
-    DSOUser *currentUser = [DSOUserManager sharedInstance].user;
-    for (DSOCampaignSignup *signup in currentUser.campaignSignups) {
-        // @todo This needs to also make sure the campaign is not closed, and that signup.campaign_run.current
-        if (self.campaignID == signup.campaign.campaignID) {
-            return signup;
-        }
-    }
-    return nil;
-}
-
 @end

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -107,7 +107,7 @@
 - (DSOCampaignSignup *)currentUserSignup {
     DSOUser *currentUser = [DSOUserManager sharedInstance].user;
     for (DSOCampaignSignup *signup in currentUser.campaignSignups) {
-
+        // @todo This needs to also make sure the campaign is not closed, and that signup.campaign_run.current
         if (self.campaignID == signup.campaign.campaignID) {
             return signup;
         }

--- a/Lets Do This/Models/DSOCampaignSignup.m
+++ b/Lets Do This/Models/DSOCampaignSignup.m
@@ -34,12 +34,9 @@
     self = [super init];
 
     if (self) {
-
         _signupID = [dict valueForKeyAsInt:@"id" nullValue:0];
         _campaign = [[DSOCampaign alloc] initWithDict:dict[@"campaign"]];
         _campaignRun = dict[@"campaign_run"];
-
-        // @todo: Waiting for Reportback object: https://github.com/DoSomething/phoenix/issues/6151
     }
 
     return self;

--- a/Lets Do This/Models/DSOReportbackItem.h
+++ b/Lets Do This/Models/DSOReportbackItem.h
@@ -15,11 +15,13 @@
 @property (nonatomic, assign, readonly) NSInteger reportbackItemID;
 @property (nonatomic, strong) NSString *caption;
 @property (nonatomic, strong, readonly) NSString *status;
+@property (nonatomic, strong, readonly) NSString *imageUri;
 @property (nonatomic, strong) NSURL *imageURL;
 @property (nonatomic, strong) UIImage *image;
 
 - (instancetype)initWithCampaign:(DSOCampaign *)campaign;
 - (instancetype)initWithDict:(NSDictionary *)dict;
+
 + (NSArray *)sortReportbackItemsAsPromotedFirst:(NSArray *)reportbackItems;
 
 @end

--- a/Lets Do This/Models/DSOReportbackItem.m
+++ b/Lets Do This/Models/DSOReportbackItem.m
@@ -16,6 +16,7 @@
 @property (nonatomic, assign, readwrite) NSInteger created;
 @property (nonatomic, assign, readwrite) NSInteger reportbackItemID;
 @property (nonatomic, strong, readwrite) NSString *status;
+@property (nonatomic, strong, readwrite) NSString *imageUri;
 
 @end
 
@@ -43,8 +44,8 @@
         _created = [[dict valueForKeyPath:@"reportback"] valueForKeyAsInt:@"created_at" nullValue:0];
         _caption = [dict valueForKeyAsString:@"caption"];
         _status = [dict valueForKeyAsString:@"status"];
-        NSString *imagePath = [[dict valueForKeyPath:@"media"] valueForKeyAsString:@"uri" nullValue:nil];
-        _imageURL = [NSURL URLWithString:imagePath];
+        _imageUri = [[dict valueForKeyPath:@"media"] valueForKeyAsString:@"uri" nullValue:nil];
+        _imageURL = [NSURL URLWithString:self.imageUri];
         _user = [[DSOUser alloc] initWithDict:dict[@"user"]];
         NSInteger campaignID = [[dict valueForKeyPath:@"campaign.id"] intValue];
         NSString *campaignTitle = [dict[@"campaign"] valueForKeyAsString:@"title" nullValue:nil];

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -8,12 +8,10 @@
 
 #import "DSOCampaign.h"
 
-@class DSOCampaignSignup;
 @class DSOUser;
 
 @interface DSOUser : NSObject
 
-@property (nonatomic, strong, readonly) NSArray *campaignSignups;
 @property (nonatomic, strong, readonly) NSDictionary *dictionary;
 @property (nonatomic, assign, readonly) NSInteger phoenixID;
 @property (nonatomic, strong, readonly) NSString *avatarURL;
@@ -30,14 +28,7 @@
 - (instancetype)initWithDict:(NSDictionary *)dict;
 - (void)setPhoto:(UIImage *)image;
 
-// Removes all the user's campaignSignups, used when syncing.
-- (void)removeAllCampaignSignups;
-// Adds given campaignSignup to the user's campaignSignups.
-- (void)addCampaignSignup:(DSOCampaignSignup *)campaignSignup;
-
 // Checks if the User is the logged-in User.
 - (BOOL)isLoggedInUser;
-- (BOOL)isDoingCampaign:(DSOCampaign *)campaign;
-- (BOOL)hasCompletedCampaign:(DSOCampaign *)campaign;
 
 @end

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -62,11 +62,12 @@
 #pragma mark - Accessors
 
 - (NSDictionary *)dictionary {
+     // Keys match API properties
     return @{
              @"id" : self.userID,
-             @"displayName" : self.displayName,
-             @"countryName" : self.countryName,
-             @"avatarURL": self.avatarURL
+             @"first_name" : self.displayName,
+             @"country" : self.countryName,
+             @"photo": self.avatarURL
              };
 }
 

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -14,7 +14,6 @@
 @interface DSOUser()
 
 @property (nonatomic, assign, readwrite) NSInteger phoenixID;
-@property (nonatomic, strong, readwrite) NSMutableArray *mutableCampaignSignups;
 @property (nonatomic, strong, readwrite) NSString *avatarURL;
 @property (nonatomic, strong, readwrite) NSString *countryCode;
 @property (nonatomic, strong, readwrite) NSString *displayName;
@@ -47,7 +46,6 @@
         _email = dict[@"email"];
         _phoenixID = [dict valueForKeyAsInt:@"drupal_id" nullValue:0];
         _sessionToken = dict[@"session_token"];
-        _mutableCampaignSignups = [[NSMutableArray alloc] init];
         _avatarURL = [dict valueForKeyAsString:@"photo" nullValue:@""];
         if (dict[@"photo"]) {
             [[SDWebImageManager sharedManager] downloadImageWithURL:dict[@"photo"] options:0 progress:0 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL){
@@ -91,14 +89,6 @@
 	return _photo;
 }
 
-- (NSArray *)campaignSignups {
-    return [self.mutableCampaignSignups copy];
-}
-
-- (void)removeAllCampaignSignups {
-    [self.mutableCampaignSignups removeAllObjects];
-}
-
 - (void)setPhoto:(UIImage *)photo {
     _photo = photo;
     if ([self isLoggedInUser] && photo) {
@@ -139,39 +129,8 @@
     return self.userID;
 }
 
-- (void)addCampaignSignup:(DSOCampaignSignup *)campaignSignup {
-    [self.mutableCampaignSignups addObject:campaignSignup];
-}
-
 - (BOOL)isLoggedInUser {
     return [self.userID isEqualToString:[DSOUserManager sharedInstance].user.userID];
-}
-
-- (BOOL)isDoingCampaign:(DSOCampaign *)campaign {
-    for (DSOCampaignSignup *signup in self.campaignSignups) {
-        if (campaign.campaignID == signup.campaign.campaignID) {
-            if (signup.reportbackItem) {
-                // By doing, we mean they haven't completed it yet.
-                // So no, the user is not Doing it.
-                return NO;
-            }
-            return YES;
-        }
-    }
-    return NO;
-}
-
-- (BOOL)hasCompletedCampaign:(DSOCampaign *)campaign {
-    for (DSOCampaignSignup *signup in self.campaignSignups) {
-        if (campaign.campaignID == signup.campaign.campaignID) {
-            if (signup.reportbackItem) {
-                return YES;
-            }
-            // Nope, haven't completed the campaign yet
-            return NO;
-        }
-    }
-    return NO;
 }
 
 @end

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -46,8 +46,6 @@
 
 - (void)loadReportbackItemsForCampaigns:(NSArray *)campaigns status:(NSString *)status completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)loadCampaignSignupsForUser:(DSOUser *)user completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
 - (NSString *)profileURLforUser:(DSOUser *)user;
 
 @end

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -302,25 +302,6 @@
       }];
 }
 
-- (void)loadCampaignSignupsForUser:(DSOUser *)user completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    NSString *url = [self profileURLforUser:user];
-    [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
-        NSMutableArray *campaignSignups = [[NSMutableArray alloc] init];
-        for (NSDictionary *campaignSignupDict in responseObject[@"data"]) {
-            DSOCampaignSignup *signup = [[DSOCampaignSignup alloc] initWithDict:campaignSignupDict];
-            [campaignSignups addObject:signup];
-        }
-        if (completionHandler) {
-            completionHandler(campaignSignups);
-        }
-    } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
-        if (errorHandler) {
-            errorHandler(error);
-        }
-    }];
-}
-
 - (void)logError:(NSError *)error methodName:(NSString *)methodName URLString:(NSString *)URLString {
     NSLog(@"\n*** DSOAPI ****\n\nError %li: %@\n%@\n%@ \n\n", (long)error.code, error.localizedDescription, methodName, URLString);
 }

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -37,7 +37,6 @@
 #define LDTSERVERKEYNAME @"northstarLiveKey"
 #endif
 
-
 @interface DSOAPI()
 
 @property (nonatomic, strong, readwrite) NSString *apiKey;
@@ -204,7 +203,7 @@
 
     [self POST:url parameters:params success:^(NSURLSessionDataTask *task, id responseObject) {
         if (completionHandler) {
-            completionHandler(responseObject);
+            completionHandler(responseObject[@"data"]);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
         [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -32,9 +32,6 @@
 // Returns whether an authenticated user session has been saved.
 - (BOOL)userHasCachedSession;
 
-// Loads the campaignSignups for given user for all activeCampaigns.
-- (void)loadActiveCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
 // Logs out the user and deletes the saved session tokens. Called when User logs out from Settings screen.
 - (void)endSessionWithCompletionHandler:(void(^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -112,27 +112,6 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     NSString *userID = [SSKeychain passwordForService:self.currentService account:@"UserID"];
     [[DSOAPI sharedInstance] loadUserWithUserId:userID completionHandler:^(DSOUser *user) {
         self.user = user;
-        [self loadActiveCampaignSignupsForUser:self.user completionHandler:^{
-            // @todo: Send LDTAppDelegate.bridge.eventDispatcher to refresh a User's Profile from signing out and then signing in as a different user.
-            if (completionHandler) {
-                completionHandler();
-            }
-        } errorHandler:^(NSError *error) {
-            errorHandler(error);
-        }];
-    } errorHandler:^(NSError *error) {
-        if (errorHandler) {
-            errorHandler(error);
-        }
-    }];
-}
-
-- (void)loadActiveCampaignSignupsForUser:(DSOUser *)user completionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    [[DSOAPI sharedInstance] loadCampaignSignupsForUser:user completionHandler:^(NSArray *campaignSignups) {
-        [user removeAllCampaignSignups];
-        for (DSOCampaignSignup *signup in campaignSignups) {
-            [user addCampaignSignup:signup];
-        }
         if (completionHandler) {
             completionHandler();
         }

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -166,26 +166,6 @@ var CampaignView = React.createClass({
       Bridge.presentProveIt(Number(this.props.campaign.id));
     }
   },
-  renderSelfReportback: function() {
-    var reportbackItem = {
-      media: {
-        uri: this.state.reportback.imageUrl,
-      },
-      caption: this.state.reportback.caption,
-    };
-
-    return (
-      <View>
-        <ReportbackItemView
-        key={this.state.reportback.id}
-        reportbackItem={this.state.reportback.reportback_items.data[0]}
-        reportback={this.state.reportback}
-        campaign={this.props.campaign}
-        user={this.props.currentUser}
-        />
-      </View>
-    );
-  },
   renderActionButton: function() {
     var actionButtonText;
     if (this.state.reportback.id) {
@@ -232,7 +212,14 @@ var CampaignView = React.createClass({
 
     var selfReportback;
     if (this.state.reportback.id) {
-      selfReportback = this.renderSelfReportback();
+      selfReportback = (
+        <ReportbackItemView
+        key={this.state.reportback.id}
+        reportbackItem={this.state.reportback.reportback_items.data[0]}
+        reportback={this.state.reportback}
+        campaign={this.props.campaign}
+        user={this.props.currentUser}
+        />);
     }
     return (
       <View>

--- a/ReactComponents/ReportbackItemView.js
+++ b/ReactComponents/ReportbackItemView.js
@@ -26,7 +26,7 @@ var ReportbackItemView = React.createClass({
     if ((!user.country) || user.country.length == 0) {
       user.country = '';
     }
-    if ((!user.country) || user.first_name.length == 0) {
+    if ((!user.first_name) || user.first_name.length == 0) {
       user.first_name = 'Doer';
     }
     if ((user.photo && user.photo.length == 0) || (!user.photo)) {

--- a/ReactComponents/ReportbackItemView.js
+++ b/ReactComponents/ReportbackItemView.js
@@ -16,7 +16,10 @@ var ReportbackItemView = React.createClass({
     var reportbackItem = this.props.reportbackItem;
     var reportback = this.props.reportback;
     var campaign = this.props.campaign;
-    var quantityLabel = campaign.reportback_info.noun + ' ' + campaign.reportback_info.verb;
+    var quantityLabel;
+    if (campaign.reportback_info) {
+      quantityLabel = campaign.reportback_info.noun + ' ' + campaign.reportback_info.verb;
+    }
     var user = this.props.user;
 
     // @todo: Need countryName from iOS

--- a/ReactComponents/Style.js
+++ b/ReactComponents/Style.js
@@ -39,7 +39,7 @@ module.exports = StyleSheet.create({
     fontSize: fontSizeBody,
   },
   sectionHeader: {
-    backgroundColor: '#F8F8F6',
+    backgroundColor: '#EEEEEE',
   },
   sectionHeaderText: {
     textAlign: 'center', 

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -48,9 +48,11 @@ var UserView = React.createClass({
     this.fetchData();
   },
   componentWillUnmount: function() {
-    this.subscription.remove();
+    if (typeof this.subscription != "undefined") {
+      this.subscription.remove();
+    }
   },
-  handleEvent: function(reminder) {
+  handleEvent: function(campaignActivity) {
     this.fetchData();
   },
   fetchData: function() {
@@ -87,7 +89,6 @@ var UserView = React.createClass({
       var sectionNumber = 0;
       if (signup.reportback) {
         sectionNumber = 1;
-        signup.reportback = signup.reportback_data;
         signup.reportbackItem = signup.reportback.reportback_items.data[0];
       }
       else {
@@ -171,13 +172,12 @@ var UserView = React.createClass({
     );
   },
   renderHeader: function() {
-    var avatarURL = this.props.user.avatarURL;
-    if (avatarURL.length == 0) {
-      this.props.user.avatarURL = 'https://placekitten.com/g/600/600';
+    if (this.props.user.photo.length == 0) {
+      this.props.user.photo = 'https://placekitten.com/g/600/600';
     }
     var headerText = null;
-    if (this.props.user.countryName.length > 0) {
-      headerText = this.props.user.countryName.toUpperCase();
+    if (this.props.user.country.length > 0) {
+      headerText = this.props.user.country.toUpperCase();
     }
     return (
       <View>
@@ -187,7 +187,7 @@ var UserView = React.createClass({
           <View style={styles.headerContainer}>
              <Image
                style={styles.avatar}
-               source={{uri: this.props.user.avatarURL}}
+               source={{uri: this.props.user.photo}}
              />
              <Text style={[Style.textHeading, styles.headerText]}>
                {headerText}
@@ -199,8 +199,8 @@ var UserView = React.createClass({
   },
   renderSectionHeader(sectionData, sectionID) {
     return (
-      <View style={styles.sectionContainer}>
-        <Text style={[Style.textHeading, {textAlign: 'center'}]}>
+      <View style={Style.sectionHeader}>
+        <Text style={Style.sectionHeaderText}>
           {sectionData.toUpperCase()}
         </Text>
       </View>
@@ -237,7 +237,7 @@ var UserView = React.createClass({
             reportbackItem={rowData.reportbackItem}
             reportback={rowData.reportback} 
             campaign={rowData.campaign}
-            user={rowData.user}
+            user={this.props.user}
           />
         </View>
       </TouchableHighlight>
@@ -266,10 +266,6 @@ var styles = React.StyleSheet.create({
     flex: 1,
     height: 160,
     alignItems: 'stretch',    
-  },
-  sectionContainer: {
-    backgroundColor: '#F8F8F6',
-    padding: 14,
   },
   avatar: {
     width: 100,


### PR DESCRIPTION
Queries the `signups` endpoint upon loading a `CampaignView`, and adds case to listen for a Reportback object sent from the `LDTAppDelegate.bridge` and display the Self Reportback accordingly (closes #757). This prevents a scenario where the User may signup for a campaign on the web after the app launches and an older campaign status is cached (user would have need to force quit).

Removes the `DSOUser.campaignSignups` property - was running into a lot of trouble keeping this up to date, and not worth the headache of parsing through inactive campaign runs locally for not much gain. This allows us to simplify things and kill lots of code! :fire: 

Refs #807 - completes Doing section for public profile, just need to add Share Photo button (see below)

Closes #814

TODO:
* [ ] Share your photo button needs to work, and get added to the Self Profile as well