### PR TITLE
Share Reportback

### DIFF
--- a/Lets Do This/Controllers/LDTActivityViewController.h
+++ b/Lets Do This/Controllers/LDTActivityViewController.h
@@ -8,6 +8,6 @@
 
 @interface LDTActivityViewController : UIActivityViewController
 
-- (instancetype)initWithReportbackItem:(DSOReportbackItem *)reportbackItem image:(UIImage *)image;
+- (instancetype)initWithShareMessage:(NSString *)shareMessage shareImage:(UIImage *)shareImage gaiActionName:(NSString *)gaiActionName;
 
 @end

--- a/Lets Do This/Controllers/LDTActivityViewController.m
+++ b/Lets Do This/Controllers/LDTActivityViewController.m
@@ -15,12 +15,17 @@
 
 @implementation LDTActivityViewController
 
-- (instancetype)initWithReportbackItem:(DSOReportbackItem *)reportbackItem image:(UIImage *)image {
+- (instancetype)initWithShareMessage:(NSString *)shareMessage shareImage:(UIImage *)shareImage gaiActionName:(NSString *)gaiActionName {
 
-    DSOCampaign *campaign = reportbackItem.campaign;
-    NSString *shareMessage = [NSString stringWithFormat:@"BAM. I just rocked the %@ campaign on the Let's Do This app and %@ %ld %@. Wanna do it with me? https://itunes.apple.com/app/id998995766", campaign.title, campaign.reportbackVerb, (long)reportbackItem.quantity, campaign.reportbackNoun];
-
-    self = [super initWithActivityItems:@ [shareMessage, image] applicationActivities:nil];
+    NSString *shareMessageWithLink = [NSString stringWithFormat:@"%@ https://itunes.apple.com/app/id998995766", shareMessage];
+    NSArray *activityItems;
+    if (shareImage) {
+        activityItems = @[shareMessageWithLink, shareImage];
+    }
+    else {
+        activityItems = @[shareMessageWithLink];
+    }
+    self = [super initWithActivityItems:activityItems applicationActivities:nil];
 
     if (self) {
         self.excludedActivityTypes = @[UIActivityTypeAssignToContact, UIActivityTypeAddToReadingList];
@@ -29,7 +34,7 @@
             NSArray *activityTypeComponents = [activityType componentsSeparatedByString:@"."];
             // retrieves and later lowercases end of activityType, i.e. "facebook"
             NSString *activityString = activityTypeComponents[activityTypeComponents.count-1];
-            [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"share photo" label:activityString.lowercaseString value:nil];
+            [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:gaiActionName label:activityString.lowercaseString value:nil];
         }];
     }
 

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -16,6 +16,8 @@
 #import "LDTCauseDetailViewController.h"
 #import "LDTNewsArticleViewController.h"
 #import "LDTMessage.h"
+#import <SDWebImage/UIImageView+WebCache.h>
+#import "LDTActivityViewController.h"
 
 
 @interface LDTReactBridge() <RCTBridgeModule>
@@ -91,9 +93,16 @@ RCT_EXPORT_METHOD(postSignup:(NSInteger)campaignID) {
     }];
 }
 
-RCT_EXPORT_METHOD(shareReportback:(NSDictionary *)reportbackDict) {
-    // @todo: Present LDTActivityViewController
-    NSLog(@"reportback %@", reportbackDict);
+RCT_EXPORT_METHOD(shareReportback:(NSString *)shareMessage shareImageUrl:(NSString *)shareImageUrl) {
+    NSURL *url = [NSURL URLWithString:shareImageUrl];
+    // This is weaksauce but we otherwise don't have a way to pass the downloaded image from React Native back into Obj C.
+    // @see https://github.com/facebook/react-native/issues/201
+    [SVProgressHUD showWithStatus:@"Loading..." maskType:SVProgressHUDMaskTypeNone];
+    [[SDWebImageManager sharedManager] downloadImageWithURL:url options:0 progress:0 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL){
+        [SVProgressHUD dismiss];
+        LDTActivityViewController *activityViewController = [[LDTActivityViewController alloc] initWithShareMessage:shareMessage shareImage:image gaiActionName:@"share photo"];
+        [[self tabBarController] presentViewController:activityViewController animated:YES completion:nil];
+    }];
 }
 
 @end

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -156,10 +156,7 @@ var CampaignView = React.createClass({
     );
   },
   _onPressActionButton: function() {
-    if (this.state.reportback.id) {
-      Bridge.shareReportback(this.state.reportback);
-    }
-    else if (!this.state.signup) {
+    if (!this.state.signup) {
       Bridge.postSignup(Number(this.props.campaign.id));
     }
     else {
@@ -169,7 +166,7 @@ var CampaignView = React.createClass({
   renderActionButton: function() {
     var actionButtonText;
     if (this.state.reportback.id) {
-      actionButtonText = 'Share your photo';
+      return null;
     }
     else if (this.state.signup) {
       actionButtonText = 'Prove it';
@@ -214,12 +211,14 @@ var CampaignView = React.createClass({
     if (this.state.reportback.id) {
       selfReportback = (
         <ReportbackItemView
-        key={this.state.reportback.id}
-        reportbackItem={this.state.reportback.reportback_items.data[0]}
-        reportback={this.state.reportback}
-        campaign={this.props.campaign}
-        user={this.props.currentUser}
-        />);
+          key={this.state.reportback.id}
+          reportbackItem={this.state.reportback.reportback_items.data[0]}
+          reportback={this.state.reportback}
+          campaign={this.props.campaign}
+          user={this.props.currentUser}
+          share={true}
+        />
+      );
     }
     return (
       <View>
@@ -296,11 +295,12 @@ var CampaignView = React.createClass({
       <TouchableHighlight onPress={() => this._onPressRow(rowData.user)}>
         <View>
           <ReportbackItemView
-          key={rowData.id}
-          reportbackItem={rowData}
-          reportback={rowData.reportback}
-          campaign={rowData.campaign}
-          user={rowData.user}
+            key={rowData.id}
+            reportbackItem={rowData}
+            reportback={rowData.reportback}
+            campaign={rowData.campaign}
+            user={rowData.user}
+            share={false}
           />
         </View>
       </TouchableHighlight>

--- a/ReactComponents/ReportbackItemView.js
+++ b/ReactComponents/ReportbackItemView.js
@@ -10,6 +10,7 @@ import React, {
 import Dimensions from 'Dimensions';
 
 var Style = require('./Style.js');
+var Bridge = require('react-native').NativeModules.LDTReactBridge;
 
 var ReportbackItemView = React.createClass({
   render: function() {
@@ -36,6 +37,16 @@ var ReportbackItemView = React.createClass({
     if ((!reportbackItem.media) || reportbackItem.media.uri.length == 0) {
       reportbackItem.media.uri = 'https://placekitten.com/g/600/600';
     }
+    var shareButton = null;
+    if (this.props.share) {
+      shareButton = (
+        <TouchableHighlight style={[Style.actionButton, {padding: 8, marginTop: 16,}]} onPress={() => this._onPressShareButton()}>
+          <Text style={Style.actionButtonText}>
+            {"Share your photo".toUpperCase()}
+          </Text>
+        </TouchableHighlight>
+      );
+    }
     return(
       <View style={styles.container}>
        <Text style={[Style.textCaption, styles.countryNameText]}>
@@ -55,6 +66,7 @@ var ReportbackItemView = React.createClass({
             </Text>
           </View>
           <Text style={Style.textBody}>{reportbackItem.caption}</Text>
+          {shareButton}
         </View>
         <View style={styles.userContainer}>
           <Image
@@ -67,6 +79,9 @@ var ReportbackItemView = React.createClass({
         </View>
       </View>
     );
+  },
+  _onPressShareButton: function() {
+    Bridge.shareReportback(this.props.reportback);
   }
 });
 

--- a/ReactComponents/ReportbackItemView.js
+++ b/ReactComponents/ReportbackItemView.js
@@ -39,8 +39,11 @@ var ReportbackItemView = React.createClass({
     }
     var shareButton = null;
     if (this.props.share) {
-      shareButton = (
-        <TouchableHighlight style={[Style.actionButton, {padding: 8, marginTop: 16,}]} onPress={() => this._onPressShareButton()}>
+      var shareButton = (
+        <TouchableHighlight 
+          style={[Style.actionButton, {padding: 8, marginTop: 16,}]} 
+          onPress={() => Bridge.shareReportback(this.getShareMessage(), reportbackItem.media.uri)}
+          >
           <Text style={Style.actionButtonText}>
             {"Share your photo".toUpperCase()}
           </Text>
@@ -80,9 +83,14 @@ var ReportbackItemView = React.createClass({
       </View>
     );
   },
-  _onPressShareButton: function() {
-    Bridge.shareReportback(this.props.reportback);
-  }
+  getShareMessage: function() {
+    var campaign = this.props.campaign;
+    var message = "BAM. I just rocked the " + campaign.title + " campaign on the ";
+    message += "DoSomething app and " + campaign.reportback_info.verb + " ";
+    message += this.props.reportback.quantity.toString() + " ";
+    message += campaign.reportback_info.noun + ". Wanna do it with me?";
+    return message;
+  },
 });
 
 var styles = React.StyleSheet.create({

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -238,6 +238,7 @@ var UserView = React.createClass({
             reportback={rowData.reportback} 
             campaign={rowData.campaign}
             user={this.props.user}
+            share={this.props.isSelfProfile}
           />
         </View>
       </TouchableHighlight>


### PR DESCRIPTION
* Resolves #807 (and the `TODO` in #844) with last remaining feature to port over into RN -- Share photo functionality.
    * Unfortunately there's not an easy way to pass the downloaded image from React Native back into Obj C, so for now the bad news is we have to re-download the image to disk upon clicking the Share button (the good news is that its then cached). Can revisit this again later, possibly check for and download reportbacks upon sign in as a background task... 
* Repurposes the `LDTActivityViewController` for re-use in News screen 