### PR TITLE
Fixes Epic Fail on app launch

### DIFF
--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -81,26 +81,9 @@
         else {
             [self presentUserConnectViewController];
         }
-;
     }
     else {
-        if ([DSOUserManager sharedInstance].activeCampaigns.count == 0) {
-            [[DSOUserManager sharedInstance] loadCurrentUserAndActiveCampaignsWithCompletionHander:^(NSArray *activeCampaigns) {
-                [[NSNotificationCenter defaultCenter] postNotificationName:@"activeCampaignsLoaded" object:self];
-            } errorHandler:^(NSError *error) {
-                [[NSNotificationCenter defaultCenter] postNotificationName:@"epicFail" object:self];
-                // If we receieve HTTP 401 error:
-                if (error.code == -1011) {
-                    // Session is borked, so we'll get a 401 when we try to logout too with endSessionWithCompletionHandler:erroHandler, therefore just use endSession.
-                    [[DSOUserManager sharedInstance] endSession];
-                    [self presentUserConnectViewController];
-                }
-                else {
-                    [self presentEpicFailForError:error];
-                }
-
-            }];
-        }
+        [self loadAppData];
     }
 }
 
@@ -109,6 +92,25 @@
 - (void)pushViewController:(UIViewController *)viewController {
     UINavigationController *navigationController = self.childViewControllers[self.selectedIndex];
     [navigationController pushViewController:viewController animated:YES];
+}
+
+- (void)loadAppData {
+    if ([DSOUserManager sharedInstance].activeCampaigns.count == 0) {
+        [[DSOUserManager sharedInstance] loadCurrentUserAndActiveCampaignsWithCompletionHander:^(NSArray *activeCampaigns) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"activeCampaignsLoaded" object:self];
+        } errorHandler:^(NSError *error) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"epicFail" object:self];
+            // If we receieve HTTP 401 error:
+            if (error.code == -1011) {
+                // Session is borked, so we'll get a 401 when we try to logout too with endSessionWithCompletionHandler:erroHandler, therefore just use endSession.
+                [[DSOUserManager sharedInstance] endSession];
+                [self presentUserConnectViewController];
+            }
+            else {
+                [self presentEpicFailForError:error];
+            }
+        }];
+    }
 }
 
 - (void)reloadCurrentUser {
@@ -187,6 +189,14 @@
         LDTSubmitReportbackViewController *destVC = [[LDTSubmitReportbackViewController alloc] initWithCampaign:self.proveItCampaign reportbackItemImage:selectedImage];
         UINavigationController *destNavVC = [[UINavigationController alloc] initWithRootViewController:destVC];
         [self presentViewController:destNavVC animated:YES completion:nil];
+    }];
+}
+
+#pragma mark - LDTEpicFailSubmitButtonDelegate
+
+- (void)didClickSubmitButton:(LDTEpicFailViewController *)vc {
+    [self.presentedViewController dismissViewControllerAnimated:YES completion:^{
+        [self loadAppData];
     }];
 }
 

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -96,10 +96,11 @@
 
 - (void)loadAppData {
     if ([DSOUserManager sharedInstance].activeCampaigns.count == 0) {
+        [SVProgressHUD showWithStatus:@"Loading actions..."];
         [[DSOUserManager sharedInstance] loadCurrentUserAndActiveCampaignsWithCompletionHander:^(NSArray *activeCampaigns) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:@"activeCampaignsLoaded" object:self];
+            [SVProgressHUD dismiss];
         } errorHandler:^(NSError *error) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:@"epicFail" object:self];
+            [SVProgressHUD dismiss];
             // If we receieve HTTP 401 error:
             if (error.code == -1011) {
                 // Session is borked, so we'll get a 401 when we try to logout too with endSessionWithCompletionHandler:erroHandler, therefore just use endSession.
@@ -130,8 +131,6 @@
     UINavigationController *navVC = [[UINavigationController alloc] initWithRootViewController:epicFailVC];
     [navVC styleNavigationBar:LDTNavigationBarStyleNormal];
     [self presentViewController:navVC animated:YES completion:nil];
-    // @TODO: cleanup - this is dismissing the SVProgressHUD called dfrom DSOUserManager
-    [SVProgressHUD dismiss];
 }
 
 - (void)presentUserConnectViewController {

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -184,7 +184,6 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 }
 
 - (void)loadCurrentUserAndActiveCampaignsWithCompletionHander:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    [SVProgressHUD showWithStatus:@"Loading actions..."];
     [[DSOAPI sharedInstance] loadAllCampaignsWithCompletionHandler:^(NSArray *campaigns) {
         NSLog(@"loadAllCampaignsWithCompletionHandler");
         if (campaigns.count == 0) {
@@ -198,18 +197,15 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 
         [self startSessionWithCompletionHandler:^ {
             NSLog(@"syncCurrentUserWithCompletionHandler");
-            [SVProgressHUD dismiss];
             if (completionHandler) {
                 completionHandler(self.activeCampaigns);
             }
         } errorHandler:^(NSError *error) {
-            [SVProgressHUD dismiss];
             if (errorHandler) {
                 errorHandler(error);
             }
         }];
     } errorHandler:^(NSError *error) {
-        [SVProgressHUD dismiss];
         if (errorHandler) {
             errorHandler(error);
         }


### PR DESCRIPTION
The Epic Fail presented upon app launch doesn't allow you to Try Again (bug introduced when we removed the Main Feed in #725)

Closes #731: catches any network errors upon loading all campaigns and the current User in the `LDTTabBarController -(void)viewDidAppear:`

Nice to have: 
Better UX. Clicking "Try again" closes the modal, which then pops up again upon error, which also throws a `Warning: Attempt to present <UINavigationController: 0x7ff1e486fa00> on <LDTTabBarController: 0x7ff1e3d21f10> whose view is not in the window hierarchy!` Created #856 so the issue isn't gone forever.