### PR TITLE
Update avatar

### DIFF
--- a/Lets Do This/Controllers/Base/LDTTabBarController.h
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.h
@@ -8,7 +8,9 @@
 
 @interface LDTTabBarController : UITabBarController
 
--(void)reloadCurrentUser;
+- (void)reloadCurrentUser;
+
+- (void)presentAvatarAlertController;
 
 - (void)presentReportbackAlertControllerForCampaignID:(NSInteger)campaignID;
 

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -227,15 +227,12 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
         UIImage *selectedImage = info[UIImagePickerControllerEditedImage];
         if (self.selectedImageType == LDTSelectedImageTypeAvatar) {
             [SVProgressHUD showWithStatus:@"Uploading..."];
-            NSString *userID = [DSOUserManager sharedInstance].user.userID;
-            [[DSOAPI sharedInstance] postUserAvatarWithUserId:userID avatarImage:selectedImage completionHandler:^(id responseObject) {
-                [SVProgressHUD dismiss];
-                [LDTMessage displaySuccessMessageWithTitle:@"Hey good lookin'." subtitle:@"You've successfully changed your profile photo. It may take a few minutes to update."];
+            [[DSOUserManager sharedInstance] postAvatarImage:selectedImage sendAppEvent:YES completionHandler:^(NSDictionary *completionHandler) {
                 // The response.data.photo is not updating with the new file for existing user avatars :(
                 // @see https://github.com/DoSomething/northstar/issues/211
-                NSLog(@"Successful user avatar upload: %@", responseObject);
-                // @todo Send RCTBridge eventDispatcher with new photo URL
-            } errorHandler:^(NSError * error) {
+                [SVProgressHUD dismiss];
+                [LDTMessage displaySuccessMessageWithTitle:@"Hey good lookin'." subtitle:@"You've successfully changed your profile photo. It may take a few minutes to update."];
+            } errorHandler:^(NSError *error) {
                 [SVProgressHUD dismiss];
                 [LDTMessage displayErrorMessageForError:error];
             }];

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -231,7 +231,7 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
                 // The response.data.photo is not updating with the new file for existing user avatars :(
                 // @see https://github.com/DoSomething/northstar/issues/211
                 [SVProgressHUD dismiss];
-                [LDTMessage displaySuccessMessageWithTitle:@"Hey good lookin'." subtitle:@"You've successfully changed your profile photo. It may take a few minutes to update."];
+                [LDTMessage displaySuccessMessageWithTitle:@"Hey good lookin'." subtitle:@"You've successfully changed your profile photo."];
             } errorHandler:^(NSError *error) {
                 [SVProgressHUD dismiss];
                 [LDTMessage displayErrorMessageForError:error];

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -69,6 +69,10 @@ RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {
     [self.tabBarController presentReportbackAlertControllerForCampaignID:campaignID];
 }
 
+RCT_EXPORT_METHOD(presentAvatarAlertController) {
+    [self.tabBarController presentAvatarAlertController];
+}
+
 RCT_EXPORT_METHOD(pushCause:(NSDictionary *)causeDict) {
     DSOCause *cause = [[DSOCause alloc] initWithNewsDict:causeDict];
     LDTCauseDetailViewController *causeDetailViewController = [[LDTCauseDetailViewController alloc] initWithCause:cause];

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -163,10 +163,9 @@
                 
                 if (self.userDidPickAvatarPhoto) {
                     [[DSOUserManager sharedInstance].user setPhoto:self.imageView.image];
-
-                    [[DSOAPI sharedInstance] postUserAvatarWithUserId:[DSOUserManager sharedInstance].user.userID avatarImage:self.imageView.image completionHandler:^(id responseObject) {
-                        NSLog(@"Successful user avatar upload: %@", responseObject);
-                    } errorHandler:^(NSError * error) {
+                    [[DSOUserManager sharedInstance] postAvatarImage:self.imageView.image sendAppEvent:NO completionHandler:^(NSDictionary *completionHandler) {
+                        NSLog(@"Successful user avatar upload: %@", completionHandler);
+                    } errorHandler:^(NSError *error) {
                         NSLog(@"Unsuccessful user avatar upload: %@", error.localizedDescription);
                     }];
                 }

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -14,7 +14,7 @@
 
 @property (nonatomic, strong, readonly) NSDictionary *dictionary;
 @property (nonatomic, assign, readonly) NSInteger phoenixID;
-@property (nonatomic, strong, readonly) NSString *avatarURL;
+@property (nonatomic, strong) NSString *avatarURL;
 @property (nonatomic, strong, readonly) NSString *countryCode;
 @property (nonatomic, strong, readonly) NSString *countryName;
 @property (nonatomic, strong, readonly) NSString *displayName;

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -14,7 +14,6 @@
 @interface DSOUser()
 
 @property (nonatomic, assign, readwrite) NSInteger phoenixID;
-@property (nonatomic, strong, readwrite) NSString *avatarURL;
 @property (nonatomic, strong, readwrite) NSString *countryCode;
 @property (nonatomic, strong, readwrite) NSString *displayName;
 @property (nonatomic, strong, readwrite) NSString *email;

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -30,7 +30,7 @@
 
 - (void)logoutWithCompletionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)postUserAvatarWithUserId:(NSString *)userID avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+- (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postReportbackItem:(DSOReportbackItem *)reportbackItem completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -140,10 +140,10 @@
     }];
 }
 
-- (void)postUserAvatarWithUserId:(NSString *)userID avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    NSString *url = [NSString stringWithFormat:@"users/%@/avatar", userID];
+- (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    NSString *url = [NSString stringWithFormat:@"users/%@/avatar", user.userID];
     NSData *imageData = UIImageJPEGRepresentation(avatarImage, 1.0);
-    NSString *fileNameForImage = [NSString stringWithFormat:@"User_%@_ProfileImage", userID];
+    NSString *fileNameForImage = [NSString stringWithFormat:@"User_%@_ProfileImage", user.userID];
     
     [self POST:url parameters:nil constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
         [formData appendPartWithFileData:imageData name:@"photo" fileName:fileNameForImage mimeType:@"image/jpeg"];

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -49,6 +49,8 @@
 
 - (void)loadCurrentUserAndActiveCampaignsWithCompletionHander:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+-(void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler ;
+
 // Stores the user's avatar image within the filesystem. 
 - (void)storeAvatar:(UIImage *)photo;
 

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -189,7 +189,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 }
 
 -(void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    [[DSOAPI sharedInstance] postUserAvatarWithUserId:[DSOUserManager sharedInstance].user.userID avatarImage:avatarImage completionHandler:^(id responseObject) {
+    [[DSOAPI sharedInstance] postAvatarForUser:[DSOUserManager sharedInstance].user avatarImage:avatarImage completionHandler:^(id responseObject) {
 
         NSDictionary *responseDict = responseObject[@"data"];
         self.user.avatarURL = responseDict[@"photo"];

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -153,6 +153,7 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 - (void)signupUserForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     [[DSOAPI sharedInstance] postSignupForCampaign:campaign completionHandler:^(DSOCampaignSignup *signup) {
         [[GAI sharedInstance] trackEventWithCategory:@"campaign" action:@"submit signup" label:[NSString stringWithFormat:@"%li", (long)campaign.campaignID] value:nil];
+        // @todo Just send raw response vs signup.dictionary to avoid potential bugs like
         [[self appDelegate].bridge.eventDispatcher sendAppEventWithName:@"currentUserActivity" body:signup.dictionary];
         if (completionHandler) {
             completionHandler(signup);
@@ -185,6 +186,29 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
         }
     }
     return nil;
+}
+
+-(void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    [[DSOAPI sharedInstance] postUserAvatarWithUserId:[DSOUserManager sharedInstance].user.userID avatarImage:avatarImage completionHandler:^(id responseObject) {
+
+        NSDictionary *responseDict = responseObject[@"data"];
+        self.user.avatarURL = responseDict[@"photo"];
+        // Not needed when we first start a session.
+        if (sendAppEvent) {
+          NSLog(@"Sending avatar eventDispatcher");
+          [[self appDelegate].bridge.eventDispatcher sendAppEventWithName:@"currentUserAvatar" body:responseDict];
+        }
+        else {
+            NSLog(@"Not sending avatar eventDispatcher");
+        }
+        if (completionHandler) {
+            completionHandler(responseDict);
+        }
+    } errorHandler:^(NSError * error) {
+        if (errorHandler) {
+            errorHandler(error);
+        }
+    }];
 }
 
 - (void)loadCurrentUserAndActiveCampaignsWithCompletionHander:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -40,6 +40,7 @@ var UserView = React.createClass({
       error: null,
       // Because selfProfile can change user data, we need to store user in state.
       user: this.props.user,
+      photo: this.props.user.photo,
     };
   },
   componentDidMount: function() {
@@ -75,8 +76,9 @@ var UserView = React.createClass({
     this.fetchData();
   },
   handleUserAvatarEvent: function(response) {
-    console.log("handleUserAvatarEvent: " + response.photo);
-    this.state.user.photo = response.photo;
+    this.setState({
+      photo: response.photo + '?time=' + Date.now(),
+    });
   },
   fetchData: function() {
     this.setState({
@@ -225,10 +227,11 @@ var UserView = React.createClass({
     );
   },
   renderHeader: function() {
-    if (this.state.user.photo.length == 0) {
+    if (this.state.photo.length == 0) {
       // @todo: default avatar
-      this.state.user.photo = 'https://placekitten.com/g/600/600';
+      this.state.photo = 'https://placekitten.com/g/600/600';
     }
+    var url = this.state.photo + '?time=' + Date.now()
     var headerText = null;
     if (this.state.user.country.length > 0) {
       headerText = this.state.user.country.toUpperCase();
@@ -236,7 +239,7 @@ var UserView = React.createClass({
     var avatar = (
       <Image
         style={styles.avatar}
-        source={{uri: this.state.user.photo}}
+        source={{uri: url}}
       />
     );
     if (this.props.isSelfProfile) {

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -44,7 +44,7 @@ var UserView = React.createClass({
   },
   componentDidMount: function() {
     if (this.props.isSelfProfile) {
-      this.subscription = NativeAppEventEmitter.addListener(
+      this.userActivitySubscription = NativeAppEventEmitter.addListener(
         'currentUserActivity',
         (signup) => this.handleUserActivityEvent(signup),
       );
@@ -52,15 +52,18 @@ var UserView = React.createClass({
         'currentUserChanged',
         (user) => this.handleUserChangedEvent(user),
       );
+      this.userAvatarSubscription = NativeAppEventEmitter.addListener(
+        'currentUserAvatar',
+        (response) => this.handleUserAvatarEvent(response),
+      );
     }
     this.fetchData();
   },
   componentWillUnmount: function() {
-    if (typeof this.subscription != "undefined") {
-      this.subscription.remove();
-    }
-    if (typeof this.userChangedSubscription != "undefined") {
+    if (this.props.isSelfProfile) {
+      this.userActivitySubscription.remove();
       this.userChangedSubscription.remove();
+      this.userAvatarSubscription.remove();
     }
   },
   handleUserChangedEvent: function(user) {
@@ -70,6 +73,10 @@ var UserView = React.createClass({
   },
   handleUserActivityEvent: function(campaignActivity) {
     this.fetchData();
+  },
+  handleUserAvatarEvent: function(response) {
+    console.log("handleUserAvatarEvent: " + response.photo);
+    this.state.user.photo = response.photo;
   },
   fetchData: function() {
     this.setState({

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -226,16 +226,26 @@ var UserView = React.createClass({
     if (this.state.user.country.length > 0) {
       headerText = this.state.user.country.toUpperCase();
     }
+    var avatar = (
+      <Image
+        style={styles.avatar}
+        source={{uri: this.state.user.photo}}
+      />
+    );
+    if (this.props.isSelfProfile) {
+      avatar = (
+        <TouchableHighlight onPress={() => Bridge.presentAvatarAlertController()}>
+          {avatar}
+        </TouchableHighlight>
+      );
+    }
     return (
       <View>
         <Image
           style={styles.headerBackgroundImage}
           source={require('image!Gradient Background')}>
           <View style={styles.headerContainer}>
-             <Image
-               style={styles.avatar}
-               source={{uri: this.state.user.photo}}
-             />
+            {avatar}
              <Text style={[Style.textHeading, styles.headerText]}>
                {headerText}
              </Text>


### PR DESCRIPTION
Closes #817: restores functionality to allows user to update their avatar, but doesn't actually seem to update it when an avatar already exists (Refs https://github.com/DoSomething/northstar/issues/272#issuecomment-189073894, https://github.com/DoSomething/northstar/issues/211)

We stored the user's avatar locally to avoid this issue when rendering the Profile with Obj C, but unfortunately moving the Profile to React Native doesn't allow us to access the file easily. Not too keen to take our chances on [3rd party solutions](https://github.com/johanneslumpe/react-native-fs)

Found #865 while testing this (not introduced by the `userAvatarSubscription` as I had initially thought)