### PR TITLE
Hotfix for RCTNativeAppEventEmitter not registered

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -164,7 +164,7 @@
                 if (self.userDidPickAvatarPhoto) {
                     [[DSOUserManager sharedInstance].user setPhoto:self.imageView.image];
                     [[DSOUserManager sharedInstance] postAvatarImage:self.imageView.image sendAppEvent:NO completionHandler:^(NSDictionary *completionHandler) {
-                        NSLog(@"Successful user avatar upload: %@", completionHandler);
+                        NSLog(@"Successful user avatar upload.");
                     } errorHandler:^(NSError *error) {
                         NSLog(@"Unsuccessful user avatar upload: %@", error.localizedDescription);
                     }];

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -112,7 +112,8 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     NSString *userID = [SSKeychain passwordForService:self.currentService account:@"UserID"];
     [[DSOAPI sharedInstance] loadUserWithUserId:userID completionHandler:^(DSOUser *user) {
         // If a user is already defined, we're starting session for a different one.
-        // @todo Clean this up. self.user is defined here when a new user registers for first time opening app sends the eventDispatcher -- https://github.com/DoSomething/LetsDoThis-iOS/issues/865
+        // @todo Clean this up. self.user is defined here when a new user registers for first time opening app
+        // @see https://github.com/DoSomething/LetsDoThis-iOS/issues/869
         // The purpose of this eventDispatcher was specifically when user logs out but logs in as someone else
         if (self.user) {
             NSLog(@"sending currentUserChanged eventDispatcher");

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -112,8 +112,14 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
     NSString *userID = [SSKeychain passwordForService:self.currentService account:@"UserID"];
     [[DSOAPI sharedInstance] loadUserWithUserId:userID completionHandler:^(DSOUser *user) {
         // If a user is already defined, we're starting session for a different one.
+        // @todo Clean this up. self.user is defined here when a new user registers for first time opening app sends the eventDispatcher -- https://github.com/DoSomething/LetsDoThis-iOS/issues/865
+        // The purpose of this eventDispatcher was specifically when user logs out but logs in as someone else
         if (self.user) {
+            NSLog(@"sending currentUserChanged eventDispatcher");
             [[self appDelegate].bridge.eventDispatcher sendAppEventWithName:@"currentUserChanged" body:user.dictionary];
+        }
+        else {
+             NSLog(@"Not sending currentUserChanged eventDispatcher");
         }
         self.user = user;
         if (completionHandler) {

--- a/ReactComponents/NewsFeedView.js
+++ b/ReactComponents/NewsFeedView.js
@@ -8,8 +8,12 @@ import React, {
   StyleSheet,
   Text,
   RefreshControl,
-  View
+  View,
+  // Lame way to fix https://github.com/DoSomething/LetsDoThis-iOS/issues/865
+  NativeAppEventEmitter
 } from 'react-native';
+// @see https://github.com/facebook/react-native/issues/5224
+NativeAppEventEmitter;
 
 var Style = require('./Style.js');
 var NewsFeedPost = require('./NewsFeedPost.js');


### PR DESCRIPTION
Uses same approach as https://github.com/facebook/react-native/issues/5224#issuecomment-184843262 to resolve #865 ungracefully.

Adds an empty `NativeAppEventEmitter ` to our initial loaded React Component, `NewsFeedView` to listen to an `eventDispatcher` we shouldn't be firing yet. Real fix here is to cleanup sending `eventDispatcher` within the `DSOUserManager` / cleanup when and how we set the current user. We set in `startSessionWithCompletionHandler` but for a newly registered user, we already set it in `createSessionWithEmail`. Fairly certain it exists in `startSessionWithCompletionHandler` for the scenario when the user is already logged in and begins a new app session.