### PR TITLE
Removes deprecated local avatar storage

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -162,7 +162,6 @@
             [[DSOUserManager sharedInstance] createSessionWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
                 
                 if (self.userDidPickAvatarPhoto) {
-                    [[DSOUserManager sharedInstance].user setPhoto:self.imageView.image];
                     [[DSOUserManager sharedInstance] postAvatarImage:self.imageView.image sendAppEvent:NO completionHandler:^(NSDictionary *completionHandler) {
                         NSLog(@"Successful user avatar upload.");
                     } errorHandler:^(NSError *error) {

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -26,7 +26,6 @@
 @property (nonatomic, strong, readonly) UIImage *photo;
 
 - (instancetype)initWithDict:(NSDictionary *)dict;
-- (void)setPhoto:(UIImage *)image;
 
 // Checks if the User is the logged-in User.
 - (BOOL)isLoggedInUser;

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -21,13 +21,10 @@
 @property (nonatomic, strong, readwrite) NSString *mobile;
 @property (nonatomic, strong, readwrite) NSString *sessionToken;
 @property (nonatomic, strong, readwrite) NSString *userID;
-@property (nonatomic, strong, readwrite) UIImage *photo;
 
 @end
 
 @implementation DSOUser
-
-@synthesize photo = _photo;
 
 - (instancetype)initWithDict:(NSDictionary *)dict {
     self = [super init];
@@ -46,11 +43,6 @@
         _phoenixID = [dict valueForKeyAsInt:@"drupal_id" nullValue:0];
         _sessionToken = dict[@"session_token"];
         _avatarURL = [dict valueForKeyAsString:@"photo" nullValue:@""];
-        if (dict[@"photo"]) {
-            [[SDWebImageManager sharedManager] downloadImageWithURL:dict[@"photo"] options:0 progress:0 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL){
-                 _photo = image;
-             }];
-        }
     }
 
     return self;
@@ -66,33 +58,6 @@
              @"country" : self.countryName,
              @"photo": self.avatarURL
              };
-}
-
-- (UIImage *)photo {
-    if (!_photo) {
-        // If this user is the logged in user, the photo's path exists, and the file exists, return the locally saved file.
-        if ([self isLoggedInUser]) {
-            UIImage *photo = [[DSOUserManager sharedInstance] retrieveAvatar];
-            if (photo) {
-                _photo = photo;
-            }
-            else {
-                _photo = [UIImage imageNamed:@"Default Avatar"];
-            }
-        }
-        else {
-            _photo = [UIImage imageNamed:@"Default Avatar"];
-        }
-	}
-	
-	return _photo;
-}
-
-- (void)setPhoto:(UIImage *)photo {
-    _photo = photo;
-    if ([self isLoggedInUser] && photo) {
-        [[DSOUserManager sharedInstance] storeAvatar:photo];
-    }
 }
 
 - (NSString *)countryName {

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -51,10 +51,4 @@
 
 -(void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler ;
 
-// Stores the user's avatar image within the filesystem. 
-- (void)storeAvatar:(UIImage *)photo;
-
-// Retrieves the user's avatar image from the filesystem. Returns nil if photo doesn't exist.
-- (UIImage *)retrieveAvatar;
-
 @end

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -13,9 +13,6 @@
 #import "LDTAppDelegate.h"
 #import <RCTEventDispatcher.h>
 
-NSString *const avatarFileNameString = @"LDTStoredAvatar.jpeg";
-NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
-
 @interface DSOUserManager()
 
 @property (strong, nonatomic, readwrite) DSOUser *user;
@@ -136,7 +133,6 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
 - (void)endSession {
     [SSKeychain deletePasswordForService:self.currentService account:@"Session"];
     [SSKeychain deletePasswordForService:self.currentService account:@"UserID"];
-    [self deleteAvatar];
     self.user = nil;
 }
 
@@ -245,47 +241,6 @@ NSString *const avatarStorageKey = @"storedAvatarPhotoPath";
             errorHandler(error);
         }
     }];
-}
-
-#pragma mark - Avatar CRUD
-
-- (void)storeAvatar:(UIImage *)photo {
-    NSData *photoData = UIImageJPEGRepresentation(photo, 1.0);
-    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    NSString *storedAvatarPhotoPath = [documentsDirectory stringByAppendingPathComponent:avatarFileNameString];
-    NSUserDefaults *storedUserDefaults = [NSUserDefaults standardUserDefaults];
-    
-    if (![photoData writeToFile:storedAvatarPhotoPath atomically:NO]) {
-        NSLog((@"Failed to persist photo data to disk"));
-    }
-    else {
-        [storedUserDefaults setObject:storedAvatarPhotoPath forKey:avatarStorageKey];
-        [storedUserDefaults synchronize];
-    }
-}
-
-- (UIImage *)retrieveAvatar {
-    NSString *storedAvatarPhotoPath = [[NSUserDefaults standardUserDefaults] objectForKey:avatarStorageKey];
-    if (storedAvatarPhotoPath) {
-        return [UIImage imageWithContentsOfFile:storedAvatarPhotoPath];
-    }
-    return nil;
-}
-
-- (void) deleteAvatar {
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    NSString *filePath = [documentsDirectory stringByAppendingPathComponent:avatarFileNameString];
-    NSError *error;
-    
-    if ([fileManager fileExistsAtPath:filePath]) {
-        if ([fileManager removeItemAtPath:filePath error:&error]) {
-            NSLog(@"Successfully deleted file: %@ ", avatarFileNameString);
-        }
-        else {
-            NSLog(@"Could not delete file: %@ ",[error localizedDescription]);
-        }
-    }
 }
 
 @end


### PR DESCRIPTION
With the avatar API feeling better, there isn't much need for local storage anymore -- which is originally in place to avoid non-updating issues.  Removing this for the sake of having less code to worry about..and not easily being able to access local filesystem in React Native.

Completes todo in https://github.com/DoSomething/LetsDoThis-iOS/pull/866#issuecomment-189127298