### PR TITLE
Use Helpers.convertUnicode when sharing News headline

### DIFF
--- a/ReactComponents/NewsFeedPost.js
+++ b/ReactComponents/NewsFeedPost.js
@@ -40,7 +40,7 @@ var NewsFeedPost = React.createClass({
             style={[Style.textBodyBold, Style.textColorCtaBlue, styles.fullArticleButton]}>
               Read the full article
           </Text>
-          <TouchableHighlight onPress={() => Bridge.shareNewsHeadline(post.id, post.title)}>
+          <TouchableHighlight onPress={() => Bridge.shareNewsHeadline(post.id, Helpers.convertUnicode(post.title))}>
             <View style={styles.shareButton}>
               <Image
                 style={styles.shareButtonImage}


### PR DESCRIPTION
Refs #740 -- without the `Helpers.convertUnicode`, special characters are funky per #753 