### PR TITLE
DSOUserManager cleanup

### DIFF
--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -149,7 +149,7 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
 
 - (void)presentReportbackAlertControllerForCampaignID:(NSInteger)campaignID {
     self.selectedImageType = LDTSelectedImageTypeReportback;
-    DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
+    DSOCampaign *campaign = [[DSOUserManager sharedInstance] campaignWithID:campaignID];
     self.proveItCampaign = campaign;
     UIAlertController *reportbackPhotoAlertController = [UIAlertController alertControllerWithTitle:@"Pics or it didn't happen!" message:nil                                                              preferredStyle:UIAlertControllerStyleActionSheet];
     UIAlertAction *cameraAlertAction;

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -103,6 +103,7 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
 }
 
 - (void)loadCurrentUser {
+    [SVProgressHUD showWithStatus:@"Loading..."];
     NSLog(@"LDTTabBarController.loadCurrentUser");
     [[DSOUserManager sharedInstance] continueSessionWithCompletionHandler:^(void){
          [SVProgressHUD dismiss];
@@ -124,11 +125,7 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
     // @todo Pop all child view controllers, not just first.
     UINavigationController *initialVC = (UINavigationController *)self.viewControllers[0];
     [initialVC popToRootViewControllerAnimated:YES];
-    [[DSOUserManager sharedInstance] continueSessionWithCompletionHandler:^ {
-        NSLog(@"syncCurrentUserWithCompletionHandler");
-    } errorHandler:^(NSError *error) {
-        [self presentEpicFailForError:error];
-    }];
+    [self loadCurrentUser];
 }
 
 - (void)presentEpicFailForError:(NSError *)error {

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -101,30 +101,35 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
 }
 
 - (void)loadAppData {
-    if ([DSOUserManager sharedInstance].activeCampaigns.count == 0) {
-        [SVProgressHUD showWithStatus:@"Loading actions..."];
-        [[DSOUserManager sharedInstance] loadCurrentUserAndActiveCampaignsWithCompletionHander:^(NSArray *activeCampaigns) {
-            [SVProgressHUD dismiss];
-        } errorHandler:^(NSError *error) {
-            [SVProgressHUD dismiss];
-            // If we receieve HTTP 401 error:
-            if (error.code == -1011) {
-                // Session is borked, so we'll get a 401 when we try to logout too with endSessionWithCompletionHandler:erroHandler, therefore just use endSession.
-                [[DSOUserManager sharedInstance] endSession];
-                [self presentUserConnectViewController];
-            }
-            else {
-                [self presentEpicFailForError:error];
-            }
-        }];
-    }
+    [[DSOUserManager sharedInstance] continueSessionWithCompletionHandler:^(void){
+         [SVProgressHUD dismiss];
+    } errorHandler:^(NSError *error) {
+        [SVProgressHUD dismiss];
+        // If we receieve HTTP 401 error:
+        if (error.code == -1011) {
+            // Session is borked, so we'll get a 401 when we try to logout too with endSessionWithCompletionHandler:erroHandler, therefore just use endSession.
+            [[DSOUserManager sharedInstance] endSession];
+            [self presentUserConnectViewController];
+        }
+        else {
+            [self presentEpicFailForError:error];
+        }
+    }];
+//    if ([DSOUserManager sharedInstance].activeCampaigns.count == 0) {
+//        [SVProgressHUD showWithStatus:@"Loading actions..."];
+//        [[DSOUserManager sharedInstance] loadCurrentUserAndActiveCampaignsWithCompletionHander:^(NSArray *activeCampaigns) {
+//            [SVProgressHUD dismiss];
+//        } errorHandler:^(NSError *error) {
+//
+//        }];
+//    }
 }
 
 - (void)reloadCurrentUser {
     // @todo Pop all child view controllers, not just first.
     UINavigationController *initialVC = (UINavigationController *)self.viewControllers[0];
     [initialVC popToRootViewControllerAnimated:YES];
-    [[DSOUserManager sharedInstance] startSessionWithCompletionHandler:^ {
+    [[DSOUserManager sharedInstance] continueSessionWithCompletionHandler:^ {
         NSLog(@"syncCurrentUserWithCompletionHandler");
     } errorHandler:^(NSError *error) {
         [self presentEpicFailForError:error];

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -89,7 +89,9 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
         }
     }
     else {
-        [self loadAppData];
+        if (![DSOUserManager sharedInstance].user) {
+            [self loadCurrentUser];
+        }
     }
 }
 
@@ -100,7 +102,8 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
     [navigationController pushViewController:viewController animated:YES];
 }
 
-- (void)loadAppData {
+- (void)loadCurrentUser {
+    NSLog(@"LDTTabBarController.loadCurrentUser");
     [[DSOUserManager sharedInstance] continueSessionWithCompletionHandler:^(void){
          [SVProgressHUD dismiss];
     } errorHandler:^(NSError *error) {
@@ -115,14 +118,6 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
             [self presentEpicFailForError:error];
         }
     }];
-//    if ([DSOUserManager sharedInstance].activeCampaigns.count == 0) {
-//        [SVProgressHUD showWithStatus:@"Loading actions..."];
-//        [[DSOUserManager sharedInstance] loadCurrentUserAndActiveCampaignsWithCompletionHander:^(NSArray *activeCampaigns) {
-//            [SVProgressHUD dismiss];
-//        } errorHandler:^(NSError *error) {
-//
-//        }];
-//    }
 }
 
 - (void)reloadCurrentUser {
@@ -252,7 +247,7 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
 
 - (void)didClickSubmitButton:(LDTEpicFailViewController *)vc {
     [self.presentedViewController dismissViewControllerAnimated:YES completion:^{
-        [self loadAppData];
+        [self loadCurrentUser];
     }];
 }
 

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -50,7 +50,7 @@
 
     // Check for campaign in local storage:
     BOOL isCampaignStoredLocally = NO;
-    DSOCampaign *localCampaign = [[DSOUserManager sharedInstance] activeCampaignWithId:self.campaign.campaignID];
+    DSOCampaign *localCampaign = [[DSOUserManager sharedInstance] campaignWithID:self.campaign.campaignID];
     if (localCampaign) {
         self.campaign = localCampaign;
         self.title = self.campaign.title.uppercaseString;

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -40,7 +40,6 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-
     [self styleView];
 
     NSString *galleryUrl = [NSString stringWithFormat:@"%@reportback-items?load_user=true&status=approved,promoted&campaigns=%li", [DSOAPI sharedInstance].phoenixApiURL, (long)self.campaign.campaignID];

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -13,6 +13,7 @@
 #import "GAI+LDT.h"
 #import "LDTTheme.h"
 #import <RCTRootView.h>
+#import <RCTEventDispatcher.h>
 
 @interface LDTCampaignViewController () < UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
@@ -39,15 +40,47 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    self.title = self.campaign.title.uppercaseString;
+
     [self styleView];
 
-    self.imagePickerController = [[UIImagePickerController alloc] init];
-    self.imagePickerController.delegate = self;
-    self.imagePickerController.allowsEditing = YES;
+    NSString *galleryUrl = [NSString stringWithFormat:@"%@reportback-items?load_user=true&status=approved,promoted&campaigns=%li", [DSOAPI sharedInstance].phoenixApiURL, (long)self.campaign.campaignID];
+    NSString *signupURLString = [NSString stringWithFormat:@"%@signups?user=%@", [DSOAPI sharedInstance].baseURL, [DSOUserManager sharedInstance].user.userID];
+    NSDictionary *appProperties;
+    NSDictionary *campaignDict = [[NSDictionary alloc] init];
 
-    self.reactRootView = [[RCTRootView alloc] initWithBridge:((LDTAppDelegate *)[UIApplication sharedApplication].delegate).bridge moduleName:@"CampaignView" initialProperties:[self appProperties]];
+    // Check for campaign in local storage:
+    BOOL isCampaignStoredLocally = NO;
+    DSOCampaign *localCampaign = [[DSOUserManager sharedInstance] activeCampaignWithId:self.campaign.campaignID];
+    if (localCampaign) {
+        self.campaign = localCampaign;
+        self.title = self.campaign.title.uppercaseString;
+        campaignDict = self.campaign.dictionary;
+        isCampaignStoredLocally = YES;
+        NSLog(@"[LDTCampaignViewController] Loading Campaign ID %li from local storage." , (long)self.campaign.campaignID);
+    }
+
+    appProperties = @{
+                      @"id" : [NSNumber numberWithInteger:self.campaign.campaignID],
+                      @"campaign" : campaignDict,
+                      @"galleryUrl" : galleryUrl,
+                      @"signupUrl" : signupURLString,
+                      @"currentUser" : [DSOUserManager sharedInstance].user.dictionary,
+                      @"apiKey": [DSOAPI sharedInstance].apiKey,
+                      @"sessionToken": [DSOUserManager sharedInstance].sessionToken,
+                      };
+    self.reactRootView = [[RCTRootView alloc] initWithBridge:((LDTAppDelegate *)[UIApplication sharedApplication].delegate).bridge moduleName:@"CampaignView" initialProperties: appProperties];
     self.view = self.reactRootView;
+
+    if (!isCampaignStoredLocally) {
+        [[DSOUserManager sharedInstance] loadAndStoreCampaignWithID:self.campaign.campaignID completionHandler:^(DSOCampaign *loadedCampaign) {
+            self.campaign = loadedCampaign;
+            self.title = self.campaign.title.uppercaseString;
+            LDTAppDelegate *appDelegate = (LDTAppDelegate *)[UIApplication sharedApplication].delegate;
+            [appDelegate.bridge.eventDispatcher sendAppEventWithName:@"campaignLoaded" body:self.campaign.dictionary];
+        } errorHandler:^(NSError *error) {
+            // @todo Send error to react native.. but need a way to refresh (user could always just navigate back and tap campaign again though).
+        }];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -62,21 +95,6 @@
 
 - (void)styleView {
     [self styleBackBarButton];
-}
-
-- (NSDictionary *)appProperties {
-    NSDictionary *appProperties;
-    NSString *galleryUrl = [NSString stringWithFormat:@"%@reportback-items?load_user=true&status=approved,promoted&campaigns=%li", [DSOAPI sharedInstance].phoenixApiURL, (long)self.campaign.campaignID];
-    NSString *signupURLString = [NSString stringWithFormat:@"%@signups?user=%@", [DSOAPI sharedInstance].baseURL, [DSOUserManager sharedInstance].user.userID];
-    appProperties = @{
-                      @"campaign" : self.campaign.dictionary,
-                      @"galleryUrl" : galleryUrl,
-                      @"signupUrl" : signupURLString,
-                      @"currentUser" : [DSOUserManager sharedInstance].user.dictionary,
-                      @"apiKey": [DSOAPI sharedInstance].apiKey,
-                      @"sessionToken": [DSOUserManager sharedInstance].sessionToken,
-                      };
-    return appProperties;
 }
 
 @end

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -68,17 +68,22 @@
                       @"apiKey": [DSOAPI sharedInstance].apiKey,
                       @"sessionToken": [DSOUserManager sharedInstance].sessionToken,
                       };
-    self.reactRootView = [[RCTRootView alloc] initWithBridge:((LDTAppDelegate *)[UIApplication sharedApplication].delegate).bridge moduleName:@"CampaignView" initialProperties: appProperties];
+    __block LDTAppDelegate *appDelegate = (LDTAppDelegate *)[UIApplication sharedApplication].delegate;
+    self.reactRootView = [[RCTRootView alloc] initWithBridge:appDelegate.bridge moduleName:@"CampaignView" initialProperties: appProperties];
     self.view = self.reactRootView;
 
     if (!isCampaignStoredLocally) {
         [[DSOUserManager sharedInstance] loadAndStoreCampaignWithID:self.campaign.campaignID completionHandler:^(DSOCampaign *loadedCampaign) {
             self.campaign = loadedCampaign;
             self.title = self.campaign.title.uppercaseString;
-            LDTAppDelegate *appDelegate = (LDTAppDelegate *)[UIApplication sharedApplication].delegate;
             [appDelegate.bridge.eventDispatcher sendAppEventWithName:@"campaignLoaded" body:self.campaign.dictionary];
         } errorHandler:^(NSError *error) {
-            // @todo Send error to react native.. but need a way to refresh (user could always just navigate back and tap campaign again though).
+            NSLog(@"Error loading campaign.");
+            NSDictionary *eventDict = @{
+                                        @"id" : [NSNumber numberWithInteger:self.campaign.campaignID],
+                                    @"error": @YES,
+                                    };
+            [appDelegate.bridge.eventDispatcher sendAppEventWithName:@"campaignLoaded" body:eventDict];
         }];
     }
 }

--- a/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
+++ b/Lets Do This/Controllers/Cause/LDTCauseDetailViewController.m
@@ -42,20 +42,14 @@
     [self styleView];
     self.title = self.cause.title.uppercaseString;
 
-    self.campaigns = [[NSMutableArray alloc] init];
+    NSString *campaignsUrl = [NSString stringWithFormat:@"%@campaigns?term_ids=%li", [DSOAPI sharedInstance].phoenixApiURL, (long)self.cause.causeID];
+    NSDictionary *props = @{
+                            @"cause" : self.cause.dictionary,
+                            @"campaignsUrl": campaignsUrl,
+                            };
     NSURL *jsCodeLocation = ((LDTAppDelegate *)[UIApplication sharedApplication].delegate).jsCodeLocation;
-    NSDictionary *initialProperties = @{@"cause" : self.cause.dictionary, @"campaigns": [self.campaigns copy]};
-    RCTRootView *rootView =[[RCTRootView alloc] initWithBundleURL:jsCodeLocation moduleName: @"CauseDetailView" initialProperties:initialProperties launchOptions:nil];
+    RCTRootView *rootView =[[RCTRootView alloc] initWithBundleURL:jsCodeLocation moduleName: @"CauseDetailView" initialProperties:props launchOptions:nil];
     self.view = rootView;
-
-    NSArray *activeCampaigns = [DSOUserManager sharedInstance].activeCampaigns;
-
-    for (DSOCampaign *campaign in activeCampaigns) {
-        if (campaign.cause.causeID == self.cause.causeID && [campaign.status isEqualToString:@"active"]) {
-            [self.campaigns addObject:campaign.dictionary];
-        }
-    }
-    rootView.appProperties = @{@"cause" : self.cause.dictionary, @"campaigns": [self.campaigns copy]};
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -81,7 +81,7 @@ RCT_EXPORT_METHOD(presentNewsArticle:(NSInteger)newsPostID urlString:(NSString *
 }
 
 RCT_EXPORT_METHOD(postSignup:(NSInteger)campaignID) {
-    DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
+    DSOCampaign *campaign = [[DSOUserManager sharedInstance] campaignWithID:campaignID];
     [SVProgressHUD showWithStatus:@"Signing up..."];
     [[DSOUserManager sharedInstance] signupUserForCampaign:campaign completionHandler:^(DSOCampaignSignup *signup) {
         [SVProgressHUD dismiss];

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -55,12 +55,7 @@ RCT_EXPORT_METHOD(pushUser:(NSDictionary *)userDict) {
 }
 
 RCT_EXPORT_METHOD(pushCampaign:(NSInteger)campaignID) {
-    DSOCampaign *campaign = [[DSOUserManager sharedInstance] activeCampaignWithId:campaignID];
-    if (!campaign) {
-        NSString *message = [NSString stringWithFormat:@"Error occured: invalid Campaign ID %li", (long)campaignID];
-        [LDTMessage displayErrorMessageInViewController:self.tabBarController title:message];
-        return;
-    }
+    DSOCampaign *campaign = [[DSOCampaign alloc] initWithCampaignID:campaignID];
     LDTCampaignViewController *viewController = [[LDTCampaignViewController alloc] initWithCampaign:campaign];
     [self.tabBarController pushViewController:viewController];
 }

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -9,8 +9,6 @@
 #import "LDTUserViewController.h"
 #import "LDTTheme.h"
 #import "LDTTabBarController.h"
-#import "LDTCampaignViewController.h"
-#import "LDTSubmitReportbackViewController.h"
 #import "LDTSettingsViewController.h"
 #import "GAI+LDT.h"
 #import "LDTAppDelegate.h"

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -105,7 +105,7 @@
         sessionToken = [DSOUserManager sharedInstance].sessionToken;
     }
     appProperties = @{
-           @"user" : self.user.dictionary,
+           @"user" : userDict,
            @"baseUrl" : [NSString stringWithFormat:@"%@", [DSOAPI sharedInstance].baseURL],
            @"isSelfProfile" : [NSNumber numberWithBool:self.isCurrentUserProfile],
            @"apiKey": [DSOAPI sharedInstance].apiKey,

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -28,6 +28,7 @@
 @property (strong, nonatomic, readonly) NSString *type;
 @property (strong, nonatomic, readonly) NSURL *coverImageURL;
 
+- (instancetype)initWithCampaignID:(NSInteger)campaignID;
 - (instancetype)initWithCampaignID:(NSInteger)campaignID title:(NSString *)title;
 - (instancetype)initWithDict:(NSDictionary*)values;
 

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -33,6 +33,16 @@
 
 @implementation DSOCampaign
 
+- (instancetype)initWithCampaignID:(NSInteger)campaignID {
+    self = [super init];
+
+    if (self) {
+        _campaignID = campaignID;
+    }
+    return self;
+}
+
+
 - (instancetype)initWithCampaignID:(NSInteger)campaignID title:(id)title {
     self = [super init];
 
@@ -48,7 +58,7 @@
 
     if (self) {
         _campaignID = [values valueForKeyAsInt:@"id" nullValue:0];
-        _title = [values valueForKeyAsString:@"title" nullValue:nil];
+        _title = [values valueForKeyAsString:@"title" nullValue:@""];
         _status = [values valueForKeyAsString:@"status" nullValue:@"closed"];
         _type = [values valueForKeyAsString:@"type" nullValue:@""];
         NSDictionary *causeDict = [values valueForKeyPath:@"causes.primary"];

--- a/Lets Do This/Models/DSOReportbackItem.m
+++ b/Lets Do This/Models/DSOReportbackItem.m
@@ -57,7 +57,7 @@
 
 - (DSOCampaign *)campaign {
     // Return fully loaded DSOCampaign if its an activeCampaign.
-    DSOCampaign *activeCampaign = [[DSOUserManager sharedInstance] activeCampaignWithId:_campaign.campaignID];
+    DSOCampaign *activeCampaign = [[DSOUserManager sharedInstance] campaignWithID:_campaign.campaignID];
     if (activeCampaign) {
         return activeCampaign;
     }

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -34,17 +34,11 @@
 
 - (void)postReportbackItem:(DSOReportbackItem *)reportbackItem completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)loadUserWithUserId:(NSString *)userID completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+- (void)loadUserWithID:(NSString *)userID completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)loadCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
-// Potentially temporary method, exploring loading all Campaigns into memory.
-- (void)loadAllCampaignsWithCompletionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
-// Will soon be deprecated - GH #714
-- (void)loadCampaignsForTermIds:(NSArray *)termIds completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)loadReportbackItemsForCampaigns:(NSArray *)campaigns status:(NSString *)status completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -38,6 +38,8 @@
 
 - (void)postSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+- (void)loadCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+
 // Potentially temporary method, exploring loading all Campaigns into memory.
 - (void)loadAllCampaignsWithCompletionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -248,6 +248,22 @@
     }];
 }
 
+- (void)loadCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    NSString *url = [NSString stringWithFormat:@"%@campaigns/%li", self.phoenixApiURL, (long)campaignID];
+
+    [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
+        DSOCampaign *campaign = [[DSOCampaign alloc] initWithDict:responseObject[@"data"]];
+        if (completionHandler) {
+            completionHandler(campaign);
+        }
+    } failure:^(NSURLSessionDataTask *task, NSError *error) {
+        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
+        if (errorHandler) {
+            errorHandler(error);
+        }
+    }];
+}
+
 - (void)loadCampaignsForTermIds:(NSArray *)termIds completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSMutableArray *termIdStrings = [[NSMutableArray alloc] init];
     for (NSNumber *termID in termIds) {

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -213,7 +213,7 @@
     }];
 }
 
-- (void)loadUserWithUserId:(NSString *)userID completionHandler:(void (^)(DSOUser *))completionHandler errorHandler:(void (^)(NSError *))errorHandler {
+- (void)loadUserWithID:(NSString *)userID completionHandler:(void (^)(DSOUser *))completionHandler errorHandler:(void (^)(NSError *))errorHandler {
     NSString *url = [NSString stringWithFormat:@"users/_id/%@", userID];
     [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
           DSOUser *user = [[DSOUser alloc] initWithDict:responseObject[@"data"]];
@@ -228,63 +228,25 @@
       }];
 }
 
-- (void)loadAllCampaignsWithCompletionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    NSString *url = [NSString stringWithFormat:@"%@campaigns?count=300", self.phoenixApiURL];
-
-    [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
-        NSMutableArray *campaigns = [[NSMutableArray alloc] init];
-        for (NSDictionary* campaignDict in responseObject[@"data"]) {
-            DSOCampaign *campaign = [[DSOCampaign alloc] initWithDict:campaignDict];
-            [campaigns addObject:campaign];
-        }
-        if (completionHandler) {
-            completionHandler(campaigns);
-        }
-    } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
-        if (errorHandler) {
-            errorHandler(error);
-        }
-    }];
-}
-
 - (void)loadCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *url = [NSString stringWithFormat:@"%@campaigns/%li", self.phoenixApiURL, (long)campaignID];
 
     [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         DSOCampaign *campaign = [[DSOCampaign alloc] initWithDict:responseObject[@"data"]];
-        if (completionHandler) {
-            completionHandler(campaign);
+        // API returns 200 if campaign is not found, so check for valid ID.
+        if (campaign.campaignID == 0) {
+            NSMutableDictionary *errorDetails = [[NSMutableDictionary alloc] init];
+            errorDetails[NSLocalizedDescriptionKey] = @"Action not found.";
+            NSError *error = [NSError errorWithDomain:@"world" code:200 userInfo:errorDetails];
+            if (errorHandler) {
+                errorHandler(error);
+            }
         }
-    } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
-        if (errorHandler) {
-            errorHandler(error);
+        else {
+            if (completionHandler) {
+                completionHandler(campaign);
+            }
         }
-    }];
-}
-
-- (void)loadCampaignsForTermIds:(NSArray *)termIds completionHandler:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    NSMutableArray *termIdStrings = [[NSMutableArray alloc] init];
-    for (NSNumber *termID in termIds) {
-        [termIdStrings addObject:[termID stringValue]];
-    }
-
-    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-    [dateFormat setDateFormat:@"yyyy-MM-dd"];
-    NSString *mobileAppDateString = [dateFormat stringFromDate:[NSDate date]];
-
-    NSString *url = [NSString stringWithFormat:@"%@campaigns.json?mobile_app=true&mobile_app_date=%@&term_ids=%@", self.phoenixApiURL, mobileAppDateString, [termIdStrings componentsJoinedByString:@","]];
-
-    [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
-          NSMutableArray *campaigns = [[NSMutableArray alloc] init];
-          for (NSDictionary* campaignDict in responseObject[@"data"]) {
-              DSOCampaign *campaign = [[DSOCampaign alloc] initWithDict:campaignDict];
-              [campaigns addObject:campaign];
-          }
-          if (completionHandler) {
-              completionHandler(campaigns);
-          }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
         [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
         if (errorHandler) {

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -44,11 +44,11 @@
 // Posts a Reportback Item for the current user, and updates activity.
 - (void)postUserReportbackItem:(DSOReportbackItem *)reportbackItem completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+-(void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler ;
+
 // Returns DSOCampaign for a given Campaign id if it exists in the activeCampaigns property.
 - (DSOCampaign *)activeCampaignWithId:(NSInteger)campaignID;
 
-- (void)loadCurrentUserAndActiveCampaignsWithCompletionHander:(void(^)(NSArray *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
--(void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler ;
+- (void)loadAndStoreCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 @end

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -16,10 +16,6 @@
 // Stores session token for authenticated API requests.
 @property (strong, nonatomic, readonly) NSString *sessionToken;
 
-// Stores all active DSOCampaigns to display.
-@property (strong, nonatomic, readonly) NSArray *activeCampaigns;
-@property (strong, nonatomic, readonly) NSDictionary *campaignDictionaries;
-
 // Singleton object for accessing authenticated User, activeCampaigns
 + (DSOUserManager *)sharedInstance;
 

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -26,8 +26,8 @@
 // Posts login request to the API with given email and password, and saves session tokens to remain authenticated upon future app usage.
 - (void)createSessionWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-// Use saved session to set relevant DSOAPI headers and loads the current user's campaignSignups.
-- (void)startSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+// Use saved session to set relevant DSOAPI headers and loads the current user.
+- (void)continueSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 // Returns whether an authenticated user session has been saved.
 - (BOOL)userHasCachedSession;

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -46,9 +46,10 @@
 
 -(void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler ;
 
-// Returns DSOCampaign for a given Campaign id if it exists in the activeCampaigns property.
-- (DSOCampaign *)activeCampaignWithId:(NSInteger)campaignID;
+// Returns DSOCampaign from local storage, if exists.
+- (DSOCampaign *)campaignWithID:(NSInteger)campaignID;
 
+// Loads Campaign with given ID from the API, and stores locally.
 - (void)loadAndStoreCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 @end

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -106,7 +106,7 @@
     [[DSOAPI sharedInstance] setHTTPHeaderFieldSession:self.sessionToken];
 
     NSString *userID = [SSKeychain passwordForService:self.currentService account:@"UserID"];
-    [[DSOAPI sharedInstance] loadUserWithUserId:userID completionHandler:^(DSOUser *user) {
+    [[DSOAPI sharedInstance] loadUserWithID:userID completionHandler:^(DSOUser *user) {
         self.user = user;
         if (completionHandler) {
             completionHandler();

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -58,19 +58,6 @@
     }
 }
 
-- (NSArray *)activeCampaigns {
-    return [self.mutableCampaigns copy];
-}
-
-- (NSDictionary *)campaignDictionaries {
-    NSMutableDictionary *campaigns = [[NSMutableDictionary alloc] init];
-    for (DSOCampaign *campaign in self.activeCampaigns) {
-        NSString *campaignIDString = [NSString stringWithFormat:@"%li", (long)campaign.campaignID];
-        campaigns[campaignIDString] = campaign.dictionary;
-    }
-    return [campaigns copy];
-}
-
 - (NSString *)currentService {
     return [DSOAPI sharedInstance].baseURL.absoluteString;
 }

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -96,7 +96,7 @@
     return [SSKeychain passwordForService:self.currentService account:@"Session"];
 }
 
-- (void)startSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+- (void)continueSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     if (self.sessionToken.length == 0) {
         // @todo: Should return error here.
         return;
@@ -225,17 +225,6 @@
         for (DSOCampaign *campaign in campaigns) {
             [self.mutableCampaigns addObject:campaign];
         }
-
-        [self startSessionWithCompletionHandler:^ {
-            NSLog(@"syncCurrentUserWithCompletionHandler");
-            if (completionHandler) {
-                completionHandler(self.activeCampaigns);
-            }
-        } errorHandler:^(NSError *error) {
-            if (errorHandler) {
-                errorHandler(error);
-            }
-        }];
     } errorHandler:^(NSError *error) {
         if (errorHandler) {
             errorHandler(error);

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -186,14 +186,9 @@
 
         NSDictionary *responseDict = responseObject[@"data"];
         self.user.avatarURL = responseDict[@"photo"];
-        // Not needed when we first start a session.
-        if (sendAppEvent) {
-          NSLog(@"Sending currentUserChanged eventDispatcher");
-          [[self appDelegate].bridge.eventDispatcher sendAppEventWithName:@"currentUserChanged" body:responseDict];
-        }
-        else {
-            NSLog(@"Not sending currentUserChanged eventDispatcher");
-        }
+        NSLog(@"postAvatarImage currentUserChanged eventDispatcher");
+        [[self appDelegate].bridge.eventDispatcher sendAppEventWithName:@"currentUserChanged" body:responseDict];
+
         if (completionHandler) {
             completionHandler(responseDict);
         }

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -201,7 +201,7 @@
     }];
 }
 
-- (DSOCampaign *)activeCampaignWithId:(NSInteger)campaignID {
+- (DSOCampaign *)campaignWithID:(NSInteger)campaignID {
     for (DSOCampaign *campaign in self.mutableCampaigns) {
         if (campaign.campaignID == campaignID) {
             return campaign;

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -163,7 +163,7 @@ var CampaignView = React.createClass({
       return (
         <NetworkErrorView
           title="Action isn't loading right now"
-          retryHandler={this.fetchData}
+          retryHandler={null}
           errorMessage={this.state.error.message}
         />);
     }

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -50,10 +50,13 @@ var CampaignView = React.createClass({
     this.campaignLoadedSubscription.remove();
   },
   handleCampaignLoadedEvent: function(campaign) {
-    console.log("heard it");
-    console.log(campaign);
     if (Number(campaign.id) == this.props.id) {
-      console.log("its a match");
+      if (campaign.error) {
+        this.setState({
+          error: true,
+        });
+        return;
+      }
       this.setState({
         campaign: campaign,
       });
@@ -79,13 +82,11 @@ var CampaignView = React.createClass({
     }
   },
   fetchData: function() {
-    console.log("fetchData");
     this.setState({
       error: false,
       loaded: false,
     });
     if (!this.state.campaign.id) {
-      console.log("no campaign id");
       return;
     }
     var statusUrl = this.props.signupUrl;

--- a/ReactComponents/CauseDetailView.js
+++ b/ReactComponents/CauseDetailView.js
@@ -18,9 +18,10 @@ var NetworkImage = require('./NetworkImage.js');
 
 var CauseDetailView = React.createClass({
   getInitialState: function() {
-    var ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
     return {
-      dataSource: ds.cloneWithRows(this.props.campaigns),
+      dataSource: new ListView.DataSource({
+        rowHasChanged: (row1, row2) => row1 !== row2,
+      }),
     };
   },
   render: function() {

--- a/ReactComponents/NetworkErrorView.js
+++ b/ReactComponents/NetworkErrorView.js
@@ -12,25 +12,31 @@ var Style = require('./Style.js');
 
 var NetworkErrorView = React.createClass({
   render: function() {
+    var retryText, retryHandler = null;
+    if (this.props.retryHandler) {
+      retryHandler = this.props.retryHandler;
+      retryText = (
+        <Text style={[Style.textCaption, styles.text, {marginTop: 44}]}>
+          Please tap to retry
+        </Text>
+      );
+    } 
     return (
       <View style={styles.container}>
-        <TouchableHighlight onPress={this.props.retryHandler}>
-
-        <View style={styles.button}>
-          <Image
-            style={styles.image}
-            source={{uri: 'Fail Icon'}}
-          />  
-          <Text style={[Style.textHeading, styles.text]}>
-            {this.props.title}
-          </Text>
-          <Text style={[Style.textBody, styles.text]}>
-            {this.props.errorMessage}
-          </Text>
-          <Text style={[Style.textCaption, styles.text, {marginTop: 44}]}>
-            Please tap to retry
-          </Text>
-        </View>
+        <TouchableHighlight onPress={retryHandler}>
+          <View style={styles.button}>
+            <Image
+              style={styles.image}
+              source={{uri: 'Fail Icon'}}
+            />  
+            <Text style={[Style.textHeading, styles.text]}>
+              {this.props.title}
+            </Text>
+            <Text style={[Style.textBody, styles.text]}>
+              {this.props.errorMessage}
+            </Text>
+            {retryText}
+          </View>
         </TouchableHighlight>   
       </View>
     );


### PR DESCRIPTION
Splitting out into a PR now to keep things readable, although it causes the Cause Detail load as empty list (in prep to begin work on #821).

* Closes #857 -- store a given Campaign into memory upon first loading, instead of loading the entire 300 campaigns upon app launch. This improves app start up time significantly for slow connections
    * Makes changes to the `LDTCampaignViewController` accordingly. If we don't have the Campaign in storage, the `CampaignView` first will load with an empty `campaign` state - listening for an event of loading the campaign and then loading its gallery.
    * Removes the `loadCurrentUserAndActiveCampaignsWithCompletionHander` method completely, instead we just need to load the Current User within the TabBar if we have a session saved and no loaded user.

* Closes #869: renames `startSessionWithCompletionHandler` as `continueSession` to better indicate why we should be calling this method.

