### PR TITLE
Update navigationBar color

### DIFF
--- a/Lets Do This/Categories/UINavigationController+LDT.m
+++ b/Lets Do This/Categories/UINavigationController+LDT.m
@@ -12,10 +12,10 @@
 @implementation UINavigationController (LDT)
 
 - (void)styleNavigationBar:(LDTNavigationBarStyle)style {
-    self.navigationBar.tintColor = LDTTheme.ctaBlueColor;
+    self.navigationBar.tintColor = LDTTheme.copyGrayColor;
     NSMutableDictionary *titleBarAttributes = [NSMutableDictionary dictionaryWithDictionary: [[UINavigationBar appearance] titleTextAttributes]];
     titleBarAttributes[NSFontAttributeName] = LDTTheme.fontBold;
-    titleBarAttributes[NSForegroundColorAttributeName] = LDTTheme.ctaBlueColor;
+    titleBarAttributes[NSForegroundColorAttributeName] = LDTTheme.copyGrayColor;
     self.navigationBar.titleTextAttributes = titleBarAttributes;
     if (style == LDTNavigationBarStyleNormal) {
         self.navigationBar.translucent = NO;

--- a/Lets Do This/Categories/UIViewController+LDT.m
+++ b/Lets Do This/Categories/UIViewController+LDT.m
@@ -18,7 +18,7 @@
 - (void)styleRightBarButton {
     NSMutableDictionary *titleBarAttributes = [NSMutableDictionary dictionaryWithDictionary: [[UINavigationBar appearance] titleTextAttributes]];
     titleBarAttributes[NSFontAttributeName] = LDTTheme.fontBold;
-    titleBarAttributes[NSForegroundColorAttributeName] = LDTTheme.ctaBlueColor;
+    titleBarAttributes[NSForegroundColorAttributeName] = LDTTheme.copyGrayColor;
     [self.navigationItem.rightBarButtonItem setTitleTextAttributes:titleBarAttributes forState:UIControlStateNormal];
 }
 

--- a/Lets Do This/Views/Base/LDTTheme.h
+++ b/Lets Do This/Views/Base/LDTTheme.h
@@ -15,6 +15,7 @@
 
 @interface LDTTheme : NSObject
 
++(UIColor *)copyGrayColor;
 +(UIColor *)ctaBlueColor;
 +(UIColor *)disabledGrayColor;
 +(UIColor *)facebookBlueColor;

--- a/Lets Do This/Views/Base/LDTTheme.m
+++ b/Lets Do This/Views/Base/LDTTheme.m
@@ -17,6 +17,7 @@ const CGFloat kFontSizeTitle = 24.0f;
 NSString *fontName = @"BrandonGrotesque-Regular";
 NSString *fontNameBold = @"BrandonGrotesque-Bold";
 NSString *hexCtaBlue = @"#3932A9";
+NSString *hexCopyGray = @"#4A4A4A";
 
 @interface LDTTheme () <RCTBridgeModule>
 
@@ -28,6 +29,10 @@ RCT_EXPORT_MODULE();
 
 + (UIColor *)ctaBlueColor {
     return [self colorFromHexString:hexCtaBlue];
+}
+
++ (UIColor *)copyGrayColor {
+    return [self colorFromHexString:hexCopyGray];
 }
 
 +(UIColor *)disabledGrayColor {
@@ -109,6 +114,7 @@ RCT_EXPORT_MODULE();
              @"fontSizeHeading": [NSNumber numberWithFloat:kFontSizeHeading],
              @"fontSizeTitle": [NSNumber numberWithFloat:kFontSizeTitle],
              @"colorCtaBlue" : hexCtaBlue,
+             @"colorCopyGray" : hexCopyGray,
              };
 }
 

--- a/ReactComponents/Style.js
+++ b/ReactComponents/Style.js
@@ -8,7 +8,7 @@ var {
 
 var Theme = require('react-native').NativeModules.LDTTheme;
 var colorCtaBlue = Theme.colorCtaBlue;
-var colorTextDefault = '#4A4A4A';
+var colorTextDefault = Theme.colorCopyGray;
 var fontFamilyName = Theme.fontName;
 var fontFamilyBoldName = Theme.fontNameBold;
 var fontSizeCaption = Theme.fontSizeCaption;


### PR DESCRIPTION
Updates navigationBar tint to dark gray color per design (https://github.com/DoSomething/LetsDoThis-iOS/issues/819#issuecomment-182979958) 

* Defines and exports said color in `LDTTheme` to DRY

![simulator screen shot feb 29 2016 5 15 30 pm](https://cloud.githubusercontent.com/assets/1236811/13414559/a03200b8-df08-11e5-99bd-e854b6a4a708.png)
Sets navigationBar text to 