### PR TITLE
Display unrecognized email/password message

### DIFF
--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -143,7 +143,12 @@
     } errorHandler:^(NSError *error) {
         [SVProgressHUD dismiss];
         [self.passwordTextField becomeFirstResponder];
-        [LDTMessage displayErrorMessageInViewController:self.navigationController error:error];
+        if (error.code == -1011) {
+            [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Sorry, unrecognized email or password."];
+        }
+        else {
+            [LDTMessage displayErrorMessageInViewController:self.navigationController error:error];
+        }
         [self.emailTextField setBorderColor:UIColor.redColor];
     }];
 }


### PR DESCRIPTION
Fixes #879, was previously displaying the generic "Oops our bad" message.