### PR TITLE
Display subtitle in Signup error message

### DIFF
--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -88,7 +88,7 @@ RCT_EXPORT_METHOD(postSignup:(NSInteger)campaignID) {
         [LDTMessage displaySuccessMessageInViewController:self.tabBarController title:@"Niiiiice." subtitle:[NSString stringWithFormat:@"You signed up for %@.", campaign.title]];
     } errorHandler:^(NSError *error) {
         [SVProgressHUD dismiss];
-        [LDTMessage displayErrorMessageInViewController:self.tabBarController title:error.readableTitle];
+        [LDTMessage displayErrorMessageInViewController:self.tabBarController title:error.readableTitle subtitle:error.readableMessage];
     }];
 }
 

--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -127,7 +127,7 @@
 
 - (IBAction)submitButtonTouchUpInside:(id)sender {
     if (![self validateEmailForCandidate:self.emailTextField.text]) {
-        [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Please enter a valid email."];
+        [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Please enter a valid email."subtitle:nil];
         return;
     }
     [self.view endEditing:YES];
@@ -144,7 +144,7 @@
         [SVProgressHUD dismiss];
         [self.passwordTextField becomeFirstResponder];
         if (error.code == -1011) {
-            [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Sorry, unrecognized email or password."];
+            [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Sorry, unrecognized email or password." subtitle:nil];
         }
         else {
             [LDTMessage displayErrorMessageInViewController:self.navigationController error:error];

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -338,7 +338,7 @@
     
     if (errorMessages.count > 0) {
         NSString *errorMessage = [[errorMessages copy] componentsJoinedByString:@"\n"];
-        [LDTMessage displayErrorMessageInViewController:self.navigationController title:errorMessage];
+        [LDTMessage displayErrorMessageInViewController:self.navigationController title:errorMessage subtitle:nil];
         return NO;
     }
     return YES;
@@ -417,7 +417,7 @@
         }
         NSUInteger newLength = [textField.text length] + [string length] - range.length;
         if (newLength > 60) {
-            [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Your email can't be longer than 60 characters."];
+            [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Your email can't be longer than 60 characters." subtitle:nil];
             return NO;
         }
         else {

--- a/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
+++ b/Lets Do This/Controllers/Reportback/LDTSubmitReportbackViewController.m
@@ -130,7 +130,7 @@
     }
     if (errorMessages.count > 0) {
         NSString *errorMessage = [[errorMessages copy] componentsJoinedByString:@"\n"];
-        [LDTMessage displayErrorMessageInViewController:self.navigationController title:errorMessage];
+        [LDTMessage displayErrorMessageInViewController:self.navigationController title:errorMessage subtitle:nil];
         self.captionTextIsValid = NO;
         [self.submitButton enable:NO];
         return NO;
@@ -156,7 +156,7 @@
     }
     if (errorMessages.count > 0) {
         NSString *errorMessage = [[errorMessages copy] componentsJoinedByString:@"\n"];
-        [LDTMessage displayErrorMessageInViewController:self.navigationController title:errorMessage];
+        [LDTMessage displayErrorMessageInViewController:self.navigationController title:errorMessage subtitle:nil];
         self.quantityTextIsValid = NO;
         [self.submitButton enable:NO];
         return NO;
@@ -264,7 +264,7 @@
         }
         NSUInteger newLength = [textField.text length] + [string length] - range.length;
         if (newLength > 60) {
-            [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Your caption can't be longer than 60 characters."];
+            [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Your caption can't be longer than 60 characters." subtitle:nil];
             return NO;
         }
         else {

--- a/Lets Do This/Views/LDTMessage.h
+++ b/Lets Do This/Views/LDTMessage.h
@@ -10,7 +10,7 @@
 
 @interface LDTMessage : TSMessage
 
-+ (void)displayErrorMessageInViewController:(UIViewController *)viewController title:(NSString *)title;
++ (void)displayErrorMessageInViewController:(UIViewController *)viewController title:(NSString *)title subtitle:(NSString *)subtitle;
 + (void)displayErrorMessageInViewController:(UIViewController *)viewController error:(NSError *)error;
 + (void)displaySuccessMessageInViewController:(UIViewController *)viewController title:(NSString *)title subtitle:(NSString *)subtitle;
 

--- a/Lets Do This/Views/LDTMessage.m
+++ b/Lets Do This/Views/LDTMessage.m
@@ -11,8 +11,8 @@
 
 @implementation LDTMessage
 
-+ (void)displayErrorMessageInViewController:(UIViewController *)viewController title:(NSString *)title {
-    [self showNotificationInViewController:viewController title:title subtitle:nil image:nil type:TSMessageNotificationTypeError duration:TSMessageNotificationDurationAutomatic callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionNavBarOverlay canBeDismissedByUser:YES];
++ (void)displayErrorMessageInViewController:(UIViewController *)viewController title:(NSString *)title subtitle:(NSString *)subtitle{
+    [self showNotificationInViewController:viewController title:title subtitle:subtitle image:nil type:TSMessageNotificationTypeError duration:TSMessageNotificationDurationAutomatic callback:nil buttonTitle:nil buttonCallback:nil atPosition:TSMessageNotificationPositionNavBarOverlay canBeDismissedByUser:YES];
 }
 
 + (void)displayErrorMessageForError:(NSError *)error {


### PR DESCRIPTION
Closes #898 by adding a `subtitle` param to `displayErrorMessageInViewController:title:subtitle:`

![simulator screen shot mar 2 2016 6 29 14 pm](https://cloud.githubusercontent.com/assets/1236811/13484649/9e87c470-e0b4-11e5-9f19-251edb83c411.png)