### PR TITLE
User.deviceTokens

### DIFF
--- a/Lets Do This/Classes/LDTAppDelegate.h
+++ b/Lets Do This/Classes/LDTAppDelegate.h
@@ -12,6 +12,7 @@
 
 @property (strong, nonatomic, readonly) LDTTabBarController *tabBarController;
 @property (strong, nonatomic, readonly) RCTBridge *bridge;
+@property (strong, nonatomic, readonly) NSString *deviceToken;
 @property (strong, nonatomic, readonly) NSURL *jsCodeLocation;
 @property (strong, nonatomic) UIWindow *window;
 @property (strong, nonatomic) UIView *statusBarBackgroundView;

--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -18,6 +18,7 @@
 
 @interface LDTAppDelegate()
 
+@property (strong, nonatomic, readwrite) NSString *deviceToken;
 @property (strong, nonatomic, readwrite) NSURL *jsCodeLocation;
 @property (strong, nonatomic, readwrite) RCTBridge *bridge;
 
@@ -102,11 +103,11 @@
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-    // Store the deviceToken in the current installation and save it to Parse.
     PFInstallation *currentInstallation = [PFInstallation currentInstallation];
     [currentInstallation setDeviceTokenFromData:deviceToken];
     currentInstallation.channels = @[ @"global" ];
     [currentInstallation saveInBackground];
+    self.deviceToken = [[[NSString stringWithFormat:@"%@", deviceToken] stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"<>"]] stringByReplacingOccurrencesOfString:@" " withString:@""];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -8,6 +8,7 @@
 
 #import "LDTUserRegisterViewController.h"
 #import "LDTTheme.h"
+#import "LDTAppDelegate.h"
 #import "LDTTabBarController.h"
 #import "LDTUserLoginViewController.h"
 #import "UITextField+LDT.h"
@@ -153,8 +154,10 @@
 - (IBAction)submitButtonTouchUpInside:(id)sender {
     if ([self validateForm]) {
         [self.view endEditing:YES];
+        LDTAppDelegate *appDelegate = (LDTAppDelegate *)[UIApplication sharedApplication].delegate;
+
         [SVProgressHUD showWithStatus:@"Creating account..."];
-        [[DSOAPI sharedInstance] createUserWithEmail:self.emailTextField.text password:self.passwordTextField.text firstName:self.firstNameTextField.text mobile:self.mobileTextField.text countryCode:self.countryCode success:^(NSDictionary *response) {
+        [[DSOAPI sharedInstance] createUserWithEmail:self.emailTextField.text password:self.passwordTextField.text firstName:self.firstNameTextField.text mobile:self.mobileTextField.text countryCode:self.countryCode deviceToken:appDelegate.deviceToken success:^(NSDictionary *response) {
             
             if (self.mobileTextField.text) {
                 [[GAI sharedInstance] trackEventWithCategory:@"account" action:@"provide mobile number" label:nil value:nil];
@@ -169,6 +172,7 @@
                         NSLog(@"Unsuccessful user avatar upload: %@", error.localizedDescription);
                     }];
                 }
+
                 if ([self.presentingViewController isKindOfClass:[LDTTabBarController class]]) {
                     LDTTabBarController *rootVC = (LDTTabBarController *)self.presentingViewController;
                     [rootVC dismissViewControllerAnimated:YES completion:^{

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -12,6 +12,7 @@
 
 @interface DSOUser : NSObject
 
+@property (nonatomic, strong, readonly) NSArray *deviceTokens;
 @property (nonatomic, strong, readonly) NSDictionary *dictionary;
 @property (nonatomic, assign, readonly) NSInteger phoenixID;
 @property (nonatomic, strong) NSString *avatarURL;

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -13,6 +13,7 @@
 
 @interface DSOUser()
 
+@property (nonatomic, strong, readwrite) NSArray *deviceTokens;
 @property (nonatomic, assign, readwrite) NSInteger phoenixID;
 @property (nonatomic, strong, readwrite) NSString *countryCode;
 @property (nonatomic, strong, readwrite) NSString *displayName;
@@ -43,6 +44,7 @@
         _phoenixID = [dict valueForKeyAsInt:@"drupal_id" nullValue:0];
         _sessionToken = dict[@"session_token"];
         _avatarURL = [dict valueForKeyAsString:@"photo" nullValue:@""];
+        _deviceTokens = dict[@"parse_installation_ids"];
     }
 
     return self;

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -44,7 +44,12 @@
         _phoenixID = [dict valueForKeyAsInt:@"drupal_id" nullValue:0];
         _sessionToken = dict[@"session_token"];
         _avatarURL = [dict valueForKeyAsString:@"photo" nullValue:@""];
-        _deviceTokens = dict[@"parse_installation_ids"];
+        if ([dict valueForJSONKey:@"parse_installation_ids"]) {
+            _deviceTokens = dict[@"parse_installation_ids"];
+        }
+        else {
+            _deviceTokens = [[NSArray alloc] init];
+        }
     }
 
     return self;

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -28,6 +28,7 @@
 
 - (void)loginWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+// Removes deviceToken from the current User and ends session.
 - (void)logoutWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
@@ -35,6 +36,8 @@
 - (void)postReportbackItem:(DSOReportbackItem *)reportbackItem completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)loadUserWithID:(NSString *)userID completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+
+- (void)postCurrentUserDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOCampaignSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -24,11 +24,11 @@
 
 - (void)setHTTPHeaderFieldSession:(NSString *)token;
 
-- (void)createUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler;
+- (void)createUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler;
 
 - (void)loginWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)logoutWithCompletionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+- (void)logoutWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -228,6 +228,22 @@
       }];
 }
 
+- (void)postCurrentUserDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    NSString *url = @"profile";
+    NSDictionary *params = @{@"parse_installation_ids" : deviceToken};
+    [self POST:url parameters:params success:^(NSURLSessionDataTask *task, id responseObject) {
+        if (completionHandler) {
+            completionHandler(responseObject);
+        }
+    } failure:^(NSURLSessionDataTask *task, NSError *error) {
+        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
+        if (errorHandler) {
+            errorHandler(error);
+        }
+    }];
+}
+
+
 - (void)loadCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *url = [NSString stringWithFormat:@"%@campaigns/%li", self.phoenixApiURL, (long)campaignID];
 

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -121,6 +121,26 @@
     CLS_LOG(@"%@", logMessage);
     [[DSOAPI sharedInstance] loadUserWithID:userID completionHandler:^(DSOUser *user) {
         self.user = user;
+        NSString *deviceToken = [self appDelegate].deviceToken;
+
+        if (deviceToken) {
+            BOOL deviceTokenStored = NO;
+            for (NSString *tokenString in self.user.deviceTokens) {
+                if ([deviceToken isEqualToString:tokenString]) {
+                    deviceTokenStored = YES;
+                }
+            }
+            if (!deviceTokenStored) {
+                NSString *tokenLogMessage = [NSString stringWithFormat:@"Posting device token %@", deviceToken];
+                CLS_LOG(@"%@", tokenLogMessage);
+                [[DSOAPI sharedInstance] postCurrentUserDeviceToken:deviceToken completionHandler:^(NSDictionary *response) {
+                    NSLog(@"Device token posted.");
+                } errorHandler:^(NSError *error) {
+                   [self recordError:error logMessage:tokenLogMessage];
+                }];
+            }
+        }
+
         if (completionHandler) {
             completionHandler();
         }

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -58,14 +58,24 @@
     }
 }
 
+// @todo: Implement setSessionToken: instaed of calling SSKeychain.
+- (NSString *)sessionToken {
+    return [SSKeychain passwordForService:self.currentService account:@"Session"];
+}
+
+
+#pragma mark - DSOUserManager
+
 - (NSString *)currentService {
     return [DSOAPI sharedInstance].baseURL.absoluteString;
 }
 
-#pragma mark - DSOUserManager
-
 - (LDTAppDelegate *)appDelegate {
     return ((LDTAppDelegate *)[UIApplication sharedApplication].delegate);
+}
+
+- (NSString *)deviceToken {
+    return [self appDelegate].deviceToken;
 }
 
 - (BOOL)userHasCachedSession {
@@ -95,9 +105,6 @@
       }];
 }
 
-- (NSString *)sessionToken {
-    return [SSKeychain passwordForService:self.currentService account:@"Session"];
-}
 
 - (void)continueSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     if (self.sessionToken.length == 0) {
@@ -131,10 +138,10 @@
     self.user = nil;
 }
 
-- (void)endSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+- (void)endSessionWithCompletionHandler:(void(^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *logMessage = @"logout";
     CLS_LOG(@"%@", logMessage);
-    [[DSOAPI sharedInstance] logoutWithCompletionHandler:^(NSDictionary *responseDict) {
+    [[DSOAPI sharedInstance] logoutWithDeviceToken:self.deviceToken completionHandler:^(NSDictionary *responseDict) {
         [self endSession];
         if (completionHandler) {
             completionHandler();


### PR DESCRIPTION
Adds a `deviceTokens` array property to `DSOUser`, to store the Northstar User's `parse_installation_ids`.

Closes #45: posts device token for new users upon registration, posts device token upon login if it doesn't already exist in Northstar

Closes #166: remove the device token from the user upon logging out.
