### PR TITLE
Move constantsToExport into LDTReactBridge

### DIFF
--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -16,6 +16,7 @@
 #import "LDTCauseDetailViewController.h"
 #import "LDTNewsArticleViewController.h"
 #import "LDTMessage.h"
+#import "LDTTheme.h"
 #import <SDWebImage/UIImageView+WebCache.h>
 #import "LDTActivityViewController.h"
 
@@ -44,6 +45,19 @@ RCT_EXPORT_MODULE();
 // @see http://facebook.github.io/react-native/docs/native-modules-ios.html#threading
 - (dispatch_queue_t)methodQueue {
     return dispatch_get_main_queue();
+}
+
+- (NSDictionary *)constantsToExport {
+    return @{
+             @"fontName": LDTTheme.fontName,
+             @"fontNameBold": LDTTheme.fontBoldName,
+             @"fontSizeCaption": [NSNumber numberWithFloat:LDTTheme.fontSizeCaption],
+             @"fontSizeBody": [NSNumber numberWithFloat:LDTTheme.fontSizeBody],
+             @"fontSizeHeading": [NSNumber numberWithFloat:LDTTheme.fontSizeHeading],
+             @"fontSizeTitle": [NSNumber numberWithFloat:LDTTheme.fontSizeTitle],
+             @"colorCtaBlue" : LDTTheme.hexCtaBlue,
+             @"colorCopyGray" : LDTTheme.hexCopyGray,
+             };
 }
 
 RCT_EXPORT_METHOD(pushUser:(NSDictionary *)userDict) {

--- a/Lets Do This/Views/Base/LDTTheme.h
+++ b/Lets Do This/Views/Base/LDTTheme.h
@@ -32,5 +32,11 @@
 +(UIFont *)fontTitle;
 +(NSString *)fontName;
 +(NSString *)fontBoldName;
++ (NSString *)hexCopyGray;
++ (NSString *)hexCtaBlue;
++ (CGFloat)fontSizeCaption;
++ (CGFloat)fontSizeBody;
++ (CGFloat)fontSizeHeading;
++ (CGFloat)fontSizeTitle;
 
 @end

--- a/Lets Do This/Views/Base/LDTTheme.m
+++ b/Lets Do This/Views/Base/LDTTheme.m
@@ -7,7 +7,6 @@
 //
 
 #import "LDTTheme.h"
-#import <RCTBridgeModule.h>
 
 const CGFloat kFontSizeCaption = 13.0f;
 const CGFloat kFontSizeBody = 16.0f;
@@ -19,13 +18,7 @@ NSString *fontNameBold = @"BrandonGrotesque-Bold";
 NSString *hexCtaBlue = @"#3932A9";
 NSString *hexCopyGray = @"#4A4A4A";
 
-@interface LDTTheme () <RCTBridgeModule>
-
-@end
-
 @implementation LDTTheme
-
-RCT_EXPORT_MODULE();
 
 + (UIColor *)ctaBlueColor {
     return [self colorFromHexString:hexCtaBlue];
@@ -95,27 +88,36 @@ RCT_EXPORT_MODULE();
     return fontNameBold;
 }
 
++ (NSString *)hexCopyGray {
+    return hexCopyGray;
+}
+
++ (NSString *)hexCtaBlue {
+    return hexCtaBlue;
+}
+
++ (CGFloat)fontSizeCaption {
+    return kFontSizeCaption;
+}
+
++ (CGFloat)fontSizeBody {
+    return kFontSizeBody;
+}
+
++ (CGFloat)fontSizeHeading {
+    return kFontSizeHeading;
+}
+
++ (CGFloat)fontSizeTitle {
+    return kFontSizeTitle;
+}
+
 +(UIColor *)colorFromHexString:(NSString *)hexString {
     unsigned rgbValue = 0;
     NSScanner *scanner = [NSScanner scannerWithString:hexString];
     [scanner setScanLocation:1]; // bypass '#' character
     [scanner scanHexInt:&rgbValue];
     return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
-}
-
-#pragma mark - RCTBridgeModule
-
-- (NSDictionary *)constantsToExport {
-    return @{
-             @"fontName": fontName,
-             @"fontNameBold": fontNameBold,
-             @"fontSizeCaption": [NSNumber numberWithFloat:kFontSizeCaption],
-             @"fontSizeBody": [NSNumber numberWithFloat:kFontSizeBody],
-             @"fontSizeHeading": [NSNumber numberWithFloat:kFontSizeHeading],
-             @"fontSizeTitle": [NSNumber numberWithFloat:kFontSizeTitle],
-             @"colorCtaBlue" : hexCtaBlue,
-             @"colorCopyGray" : hexCopyGray,
-             };
 }
 
 @end

--- a/ReactComponents/Style.js
+++ b/ReactComponents/Style.js
@@ -6,15 +6,15 @@ var {
   StyleSheet,
 } = React;
 
-var Theme = require('react-native').NativeModules.LDTTheme;
-var colorCtaBlue = Theme.colorCtaBlue;
-var colorTextDefault = Theme.colorCopyGray;
-var fontFamilyName = Theme.fontName;
-var fontFamilyBoldName = Theme.fontNameBold;
-var fontSizeCaption = Theme.fontSizeCaption;
-var fontSizeBody = Theme.fontSizeBody;
-var fontSizeHeading = Theme.fontSizeHeading;
-var fontSizeTitle = Theme.fontSizeTitle;
+var Bridge = require('react-native').NativeModules.LDTReactBridge;
+var colorCtaBlue = Bridge.colorCtaBlue;
+var colorTextDefault = Bridge.colorCopyGray;
+var fontFamilyName = Bridge.fontName;
+var fontFamilyBoldName = Bridge.fontNameBold;
+var fontSizeCaption = Bridge.fontSizeCaption;
+var fontSizeBody = Bridge.fontSizeBody;
+var fontSizeHeading = Bridge.fontSizeHeading;
+var fontSizeTitle = Bridge.fontSizeTitle;
 
 module.exports = StyleSheet.create({
   backgroundColorCtaBlue: {


### PR DESCRIPTION
Attempts to fix (but doesn't) #890 -- still getting the `Unbalanced calls start/end for tag 5` warnings when navigating to a Campaign from the News Feed. 

This at least moves all of our React Bridge code into a single class, so seems worth merging in.