### PR TITLE
Removes description from Cause List (initial Actions screen)

### DIFF
--- a/ReactComponents/CauseListView.js
+++ b/ReactComponents/CauseListView.js
@@ -118,7 +118,6 @@ var CauseListView = React.createClass({
           <View style={[styles.contentContainer, styles.bordered]}>
             <View>
               <Text style={Style.textHeading}>{cause.title}</Text>
-              <Text style={Style.textCaption}>{cause.description}</Text>
             </View>
           </View>
           <View style={[styles.arrowContainer, styles.bordered]}>


### PR DESCRIPTION
Closes #913, closes #919 (duplicate issue)

Screenshot from 5S:

![simulator screen shot mar 7 2016 9 27 32 am](https://cloud.githubusercontent.com/assets/1236811/13577398/2799ad6a-e447-11e5-9999-9a7d5f1d0e0c.png)
