### PR TITLE
DSOAPI.sessionToken + DSOUserManager cleanup

### DIFF
--- a/Lets Do This/Controllers/Base/LDTTabBarController.h
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.h
@@ -8,7 +8,8 @@
 
 @interface LDTTabBarController : UITabBarController
 
-- (void)reloadCurrentUser;
+// Pops each child UINavigationController to its RootView, sets selectedTab to first.
+- (void)reset;
 
 - (void)presentAvatarAlertController;
 

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -121,11 +121,11 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
     }];
 }
 
-- (void)reloadCurrentUser {
-    // @todo Pop all child view controllers, not just first.
-    UINavigationController *initialVC = (UINavigationController *)self.viewControllers[0];
-    [initialVC popToRootViewControllerAnimated:YES];
-    [self loadCurrentUser];
+- (void)reset {
+    for (UINavigationController *child in self.viewControllers) {
+        [child popToRootViewControllerAnimated:YES];
+    }
+    self.selectedIndex = 0;
 }
 
 - (void)presentEpicFailForError:(NSError *)error {

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -111,8 +111,8 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
         [SVProgressHUD dismiss];
         // If we receieve HTTP 401 error:
         if (error.code == -1011) {
-            // Session is borked, so we'll get a 401 when we try to logout too with endSessionWithCompletionHandler:erroHandler, therefore just use endSession.
-            [[DSOUserManager sharedInstance] endSession];
+            // Session is borked, so we'll get a 401 when we try to logout too with endSessionWithCompletionHandler:erroHandler, so instead use the force.
+            [[DSOUserManager sharedInstance] forceLogout];
             [self presentUserConnectViewController];
         }
         else {

--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -65,7 +65,7 @@
                       @"signupUrl" : signupURLString,
                       @"currentUser" : [DSOUserManager sharedInstance].user.dictionary,
                       @"apiKey": [DSOAPI sharedInstance].apiKey,
-                      @"sessionToken": [DSOUserManager sharedInstance].sessionToken,
+                      @"sessionToken": [DSOAPI sharedInstance].sessionToken,
                       };
     __block LDTAppDelegate *appDelegate = (LDTAppDelegate *)[UIApplication sharedApplication].delegate;
     self.reactRootView = [[RCTRootView alloc] initWithBridge:appDelegate.bridge moduleName:@"CampaignView" initialProperties: appProperties];

--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -131,7 +131,7 @@
     }
     [self.view endEditing:YES];
     [SVProgressHUD showWithStatus:@"Signing in..."];
-    [[DSOUserManager sharedInstance] createSessionWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
+    [[DSOUserManager sharedInstance] loginWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
         [SVProgressHUD dismiss];
         [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
     } errorHandler:^(NSError *error) {

--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -11,7 +11,6 @@
 #import "LDTButton.h"
 #import "LDTMessage.h"
 #import "LDTUserRegisterViewController.h"
-#import "LDTTabBarController.h"
 #import "UITextField+LDT.h"
 #import "GAI+LDT.h"
 
@@ -134,12 +133,7 @@
     [SVProgressHUD showWithStatus:@"Signing in..."];
     [[DSOUserManager sharedInstance] createSessionWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
         [SVProgressHUD dismiss];
-        if ([self.presentingViewController isKindOfClass:[LDTTabBarController class]]) {
-            LDTTabBarController *rootVC = (LDTTabBarController *)self.presentingViewController;
-            [rootVC dismissViewControllerAnimated:YES completion:^{
-                [rootVC reloadCurrentUser];
-            }];
-        }
+        [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
     } errorHandler:^(NSError *error) {
         [SVProgressHUD dismiss];
         [self.passwordTextField becomeFirstResponder];

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -162,7 +162,7 @@
                 [[GAI sharedInstance] trackEventWithCategory:@"account" action:@"provide mobile number" label:nil value:nil];
             }
 
-            [[DSOUserManager sharedInstance] createSessionWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
+            [[DSOUserManager sharedInstance] loginWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
                 if (self.userDidPickAvatarPhoto) {
                     [[DSOUserManager sharedInstance] postAvatarImage:self.imageView.image sendAppEvent:NO completionHandler:^(NSDictionary *completionHandler) {
                         NSLog(@"Successful user avatar upload.");

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -9,7 +9,6 @@
 #import "LDTUserRegisterViewController.h"
 #import "LDTTheme.h"
 #import "LDTAppDelegate.h"
-#import "LDTTabBarController.h"
 #import "LDTUserLoginViewController.h"
 #import "UITextField+LDT.h"
 #import "GAI+LDT.h"
@@ -164,7 +163,6 @@
             }
 
             [[DSOUserManager sharedInstance] createSessionWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
-                
                 if (self.userDidPickAvatarPhoto) {
                     [[DSOUserManager sharedInstance] postAvatarImage:self.imageView.image sendAppEvent:NO completionHandler:^(NSDictionary *completionHandler) {
                         NSLog(@"Successful user avatar upload.");
@@ -172,14 +170,8 @@
                         NSLog(@"Unsuccessful user avatar upload: %@", error.localizedDescription);
                     }];
                 }
-
-                if ([self.presentingViewController isKindOfClass:[LDTTabBarController class]]) {
-                    LDTTabBarController *rootVC = (LDTTabBarController *)self.presentingViewController;
-                    [rootVC dismissViewControllerAnimated:YES completion:^{
-                        [SVProgressHUD dismiss];
-                        [rootVC reloadCurrentUser];
-                    }];
-                }
+                [SVProgressHUD dismiss];
+                [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
             } errorHandler:^(NSError *error) {
                 [SVProgressHUD dismiss];
                 [LDTMessage displayErrorMessageInViewController:self.navigationController error:error];

--- a/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
@@ -147,7 +147,7 @@
         [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"log out" label:nil value:nil];
         [SVProgressHUD showWithStatus:@"Logging out..."];
 
-        [[DSOUserManager sharedInstance] endSessionWithCompletionHandler:^ {
+        [[DSOUserManager sharedInstance] logoutWithCompletionHandler:^ {
             [SVProgressHUD dismiss];
             [self pushUserConnectViewController];
         } errorHandler:^(NSError *error) {

--- a/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
@@ -172,10 +172,12 @@
 
 - (void)pushUserConnectViewController {
     [self.navigationController pushViewController:[[LDTUserConnectViewController alloc] init] animated:YES];
+    // @todo: statusBar color change
+    // @see https://github.com/DoSomething/LetsDoThis-iOS/issues/893
     [self.navigationController styleNavigationBar:LDTNavigationBarStyleClear];
-    // Now that tabBar is hidden, select the first tab, so it will be the first tab selected upon next login.
+
     LDTTabBarController *tabBar = (LDTTabBarController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
-    [tabBar setSelectedIndex:0];
+    [tabBar reset];
 }
 
 - (void)handleFeedbackTap:(UITapGestureRecognizer *)recognizer {

--- a/Lets Do This/Controllers/User/LDTUserViewController.m
+++ b/Lets Do This/Controllers/User/LDTUserViewController.m
@@ -102,7 +102,7 @@
     NSString *sessionToken = @"";
     if (self.user) {
         userDict = self.user.dictionary;
-        sessionToken = [DSOUserManager sharedInstance].sessionToken;
+        sessionToken = [DSOAPI sharedInstance].sessionToken;
     }
     appProperties = @{
            @"user" : userDict,

--- a/Lets Do This/Models/DSOUser.h
+++ b/Lets Do This/Models/DSOUser.h
@@ -22,7 +22,6 @@
 @property (nonatomic, strong, readonly) NSString *email;
 @property (nonatomic, strong, readonly) NSString *firstName;
 @property (nonatomic, strong, readonly) NSString *mobile;
-@property (nonatomic, strong, readonly) NSString *sessionToken;
 @property (nonatomic, strong, readonly) NSString *userID;
 @property (nonatomic, strong, readonly) UIImage *photo;
 

--- a/Lets Do This/Models/DSOUser.m
+++ b/Lets Do This/Models/DSOUser.m
@@ -18,7 +18,6 @@
 @property (nonatomic, strong, readwrite) NSString *email;
 @property (nonatomic, strong, readwrite) NSString *firstName;
 @property (nonatomic, strong, readwrite) NSString *mobile;
-@property (nonatomic, strong, readwrite) NSString *sessionToken;
 @property (nonatomic, strong, readwrite) NSString *userID;
 
 @end
@@ -40,7 +39,6 @@
         _firstName = [dict valueForKeyAsString:@"first_name"];
         _email = dict[@"email"];
         _phoenixID = [dict valueForKeyAsInt:@"drupal_id"];
-        _sessionToken = dict[@"session_token"];
         _avatarURL = [dict valueForKeyAsString:@"photo"];
         if ([dict valueForJSONKey:@"parse_installation_ids"]) {
             _deviceTokens = dict[@"parse_installation_ids"];

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -15,14 +15,15 @@
 
 @interface DSOAPI : AFHTTPSessionManager
 
+// Used by View Controllers with React Native views to share same API session.
 @property (nonatomic, strong, readonly) NSString *apiKey;
+@property (nonatomic, strong, readonly) NSString *currentService;
 @property (nonatomic, strong, readonly) NSString *phoenixBaseURL;
 @property (nonatomic, strong, readonly) NSString *phoenixApiURL;
 @property (nonatomic, strong, readonly) NSString *newsApiURL;
+@property (nonatomic, strong, readonly) NSString *sessionToken;
 
 + (DSOAPI *)sharedInstance;
-
-- (void)setHTTPHeaderFieldSession:(NSString *)token;
 
 // Creates a DoSomething.org account with given properties. This API call does not additionally create an authenticated sesssion to log the user in, must additionally call createSessionForEmail:password:completionHandler:errorHandler.
 - (void)createUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler;
@@ -30,16 +31,19 @@
 // Creates authenticated session for given email/password combination, returns the corresponding loaded DSOUser upon copmletion.
 - (void)createSessionForEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)loadUserWithSession:(NSString *)session completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+// Loads the current user with saved sessionToken, if exists.
+- (void)loadCurrentUserWithCompletionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+// @todo Rename as endSession to keep consistent
 // Removes deviceToken from the current User's account, and ends session.
 - (void)logoutWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+
+// Used to override ending a session for edge case failed logout requests (e.g. 401).
+- (void)deleteSessionToken;
 
 - (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postReportbackForCampaign:(DSOCampaign *)campaign fileString:(NSString *)fileString caption:(NSString *)caption quantity:(NSInteger)quantity completionHandler:(void(^)(DSOReportback *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
-
 
 - (void)postCurrentUserDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -35,7 +35,7 @@
 
 - (void)postReportbackForCampaign:(DSOCampaign *)campaign fileString:(NSString *)fileString caption:(NSString *)caption quantity:(NSInteger)quantity completionHandler:(void(^)(DSOReportback *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)loadUserWithID:(NSString *)userID completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+- (void)loadUserWithSession:(NSString *)session completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postCurrentUserDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -25,22 +25,22 @@
 
 + (DSOAPI *)sharedInstance;
 
-// Creates a DoSomething.org account with given properties. This API call does not additionally create an authenticated sesssion to log the user in, must additionally call createSessionForEmail:password:completionHandler:errorHandler.
+// Creates a DoSomething.org account with given properties. This API call does not automatically create an authenticated sesssion to log the user in, must additionally call createSessionForEmail:password:completionHandler:errorHandler.
 - (void)createUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler;
 
-// Creates authenticated session for given email/password combination, returns the corresponding loaded DSOUser upon copmletion.
+// Creates authenticated session for given email/password combination, returns the corresponding loaded DSOUser upon completion.
 - (void)createSessionForEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 // Loads the current user with saved sessionToken, if exists.
 - (void)loadCurrentUserWithCompletionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-// @todo Rename as endSession to keep consistent
-// Removes deviceToken from the current User's account, and ends session.
-- (void)logoutWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+// Ends session and removes deviceToken from the current User's account. deviceToken may be set to nil if user has not granted push notifications.
+- (void)endSessionWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 // Used to override ending a session for edge case failed logout requests (e.g. 401).
 - (void)deleteSessionToken;
 
+// Posts avatar for the given user (which should always be the current authenticated user).
 - (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postReportbackForCampaign:(DSOCampaign *)campaign fileString:(NSString *)fileString caption:(NSString *)caption quantity:(NSInteger)quantity completionHandler:(void(^)(DSOReportback *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -24,18 +24,22 @@
 
 - (void)setHTTPHeaderFieldSession:(NSString *)token;
 
+// Creates a DoSomething.org account with given properties. This API call does not additionally create an authenticated sesssion to log the user in, must additionally call createSessionForEmail:password:completionHandler:errorHandler.
 - (void)createUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler;
 
-- (void)loginWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+// Creates authenticated session for given email/password combination, returns the corresponding loaded DSOUser upon copmletion.
+- (void)createSessionForEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-// Removes deviceToken from the current User and ends session.
+- (void)loadUserWithSession:(NSString *)session completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+
+// Removes deviceToken from the current User's account, and ends session.
 - (void)logoutWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postReportbackForCampaign:(DSOCampaign *)campaign fileString:(NSString *)fileString caption:(NSString *)caption quantity:(NSInteger)quantity completionHandler:(void(^)(DSOReportback *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-- (void)loadUserWithSession:(NSString *)session completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+
 
 - (void)postCurrentUserDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -117,7 +117,7 @@
     }];
 }
 
-- (void)loginWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+- (void)createSessionForEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *url = @"auth/token";
     NSDictionary *params = @{@"email" : email, @"password" : password};
 

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -212,8 +212,9 @@
     }];
 }
 
-- (void)loadUserWithID:(NSString *)userID completionHandler:(void (^)(DSOUser *))completionHandler errorHandler:(void (^)(NSError *))errorHandler {
-    NSString *url = [NSString stringWithFormat:@"users/_id/%@", userID];
+- (void)loadUserWithSession:(NSString *)session completionHandler:(void (^)(DSOUser *))completionHandler errorHandler:(void (^)(NSError *))errorHandler {
+    [self setHTTPHeaderFieldSession:session];
+    NSString *url = [NSString stringWithFormat:@"profile"];
     [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
           DSOUser *user = [[DSOUser alloc] initWithDict:responseObject[@"data"]];
           if (completionHandler) {

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -104,7 +104,6 @@
     return [SSKeychain passwordForService:self.currentService account:@"Session"];
 }
 
-
 #pragma mark - DSOAPI
 
 - (void)createUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler {
@@ -167,7 +166,7 @@
     }];
 }
 
-- (void)logoutWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+- (void)endSessionWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *url = @"auth/invalidate";
     if (deviceToken) {
         url = [NSString stringWithFormat:@"%@?parse_installation_ids=%@", url, deviceToken];

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -13,9 +13,6 @@
 // Stores the current/authenticated user.
 @property (strong, nonatomic, readonly) DSOUser *user;
 
-// Stores session token for authenticated API requests.
-@property (strong, nonatomic, readonly) NSString *sessionToken;
-
 // Singleton object for accessing authenticated User, stored campaigns.
 + (DSOUserManager *)sharedInstance;
 

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -19,8 +19,8 @@
 // Singleton object for accessing authenticated User, stored campaigns.
 + (DSOUserManager *)sharedInstance;
 
-// Posts login request to the API with given email and password, and saves session tokens to remain authenticated upon future app usage.
-- (void)createSessionWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+// Posts auth request to the API with given email and password, and saves session tokens to remain authenticated upon future app usage.
+- (void)loginWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 // Use saved session to set relevant DSOAPI headers and loads the current user.
 - (void)continueSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -25,11 +25,11 @@
 // Returns whether an authenticated user session has been saved.
 - (BOOL)userHasCachedSession;
 
-// Logs out the user and deletes the saved session tokens. Called when User logs out from Settings screen.
-- (void)endSessionWithCompletionHandler:(void(^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+// Logs out the user and deletes the current user and saved session tokens. Called when User logs out from Settings screen.
+- (void)logoutWithCompletionHandler:(void(^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-// Deletes the current user and saved session tokens, without making API requests. Hack for now to solve for scenarios where logout request seems to complete but we didn't get a chance to delete the logged in user's saved session tokens.
-- (void)endSession;
+// Deletes the current user and saved session tokens, without making API request. Hack for now to solve for scenarios where logout request seems to complete but we didn't get a chance to delete the logged in user's saved session tokens.
+- (void)forceLogout;
 
 // Posts Signup to API, calls relevant GoogleAnalytics and React Native eventDispatcher.
 - (void)signupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -34,7 +34,6 @@
 // Deletes the current user and saved session tokens, without making API requests. Hack for now to solve for scenarios where logout request seems to complete but we didn't get a chance to delete the logged in user's saved session tokens.
 - (void)endSession;
 
-
 - (void)signupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)reportbackForCampaign:(DSOCampaign *)campaign fileString:(NSString *)fileString caption:(NSString *)caption quantity:(NSInteger)quantity completionHandler:(void(^)(DSOReportback *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -16,7 +16,7 @@
 // Stores session token for authenticated API requests.
 @property (strong, nonatomic, readonly) NSString *sessionToken;
 
-// Singleton object for accessing authenticated User, activeCampaigns
+// Singleton object for accessing authenticated User, stored campaigns.
 + (DSOUserManager *)sharedInstance;
 
 // Posts login request to the API with given email and password, and saves session tokens to remain authenticated upon future app usage.
@@ -34,10 +34,13 @@
 // Deletes the current user and saved session tokens, without making API requests. Hack for now to solve for scenarios where logout request seems to complete but we didn't get a chance to delete the logged in user's saved session tokens.
 - (void)endSession;
 
+// Posts Signup to API, calls relevant GoogleAnalytics and React Native eventDispatcher.
 - (void)signupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+// Posts Reportback to API, calls relevant GoogleAnalytics and React Native eventDispatcher.
 - (void)reportbackForCampaign:(DSOCampaign *)campaign fileString:(NSString *)fileString caption:(NSString *)caption quantity:(NSInteger)quantity completionHandler:(void(^)(DSOReportback *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+// Posts Avatar to API, calls React Native eventDispatcher if sendAppEvent.
 - (void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler ;
 
 // Returns DSOCampaign from local storage, if exists.

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -111,15 +111,10 @@
         // @todo: Should return error here.
         return;
     }
-
-    // @todo: Once Northstar API supports it, actively check for whether or saved session is valid before trying to start.
-    // @see https://github.com/DoSomething/northstar/issues/186
-    [[DSOAPI sharedInstance] setHTTPHeaderFieldSession:self.sessionToken];
-
     NSString *userID = [SSKeychain passwordForService:self.currentService account:@"UserID"];
     NSString *logMessage = [NSString stringWithFormat:@"user %@", userID];
     CLS_LOG(@"%@", logMessage);
-    [[DSOAPI sharedInstance] loadUserWithID:userID completionHandler:^(DSOUser *user) {
+    [[DSOAPI sharedInstance] loadUserWithSession:self.sessionToken completionHandler:^(DSOUser *user) {
         self.user = user;
         NSString *deviceToken = [self appDelegate].deviceToken;
 

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -54,23 +54,17 @@
         [Crashlytics sharedInstance].userIdentifier = user.userID;
         [[self appDelegate].bridge.eventDispatcher sendAppEventWithName:@"currentUserChanged" body:user.dictionary];
         [SSKeychain setPassword:self.user.userID forService:self.currentService account:@"UserID"];
-        if (user.sessionToken) {
-            // Save session in Keychain for when app is quit.
-            [SSKeychain setPassword:user.sessionToken forService:self.currentService account:@"Session"];
-        }
     }
     else {
         [Crashlytics sharedInstance].userIdentifier = nil;
-        [SSKeychain deletePasswordForService:self.currentService account:@"Session"];
         [SSKeychain deletePasswordForService:self.currentService account:@"UserID"];
+        // Force delete cached API session if it hasn't been properly deleted.
+        NSString *sessionToken = [DSOAPI sharedInstance].sessionToken;
+        if (sessionToken && sessionToken.length > 0) {
+            [[DSOAPI sharedInstance] deleteSessionToken];
+        }
     }
 }
-
-// @todo: Implement setSessionToken: instaed of calling SSKeychain.
-- (NSString *)sessionToken {
-    return [SSKeychain passwordForService:self.currentService account:@"Session"];
-}
-
 
 #pragma mark - DSOUserManager
 
@@ -87,7 +81,7 @@
 }
 
 - (BOOL)userHasCachedSession {
-    return self.sessionToken.length > 0;
+    return [DSOAPI sharedInstance].sessionToken.length > 0;
 }
 
 - (void)loginWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
@@ -107,16 +101,15 @@
       }];
 }
 
-
 - (void)continueSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    if (self.sessionToken.length == 0) {
+    if ([DSOAPI sharedInstance].sessionToken.length == 0) {
         // @todo: Should return error here.
         return;
     }
     NSString *userID = [SSKeychain passwordForService:self.currentService account:@"UserID"];
     NSString *logMessage = [NSString stringWithFormat:@"user %@", userID];
     CLS_LOG(@"%@", logMessage);
-    [[DSOAPI sharedInstance] loadUserWithSession:self.sessionToken completionHandler:^(DSOUser *user) {
+    [[DSOAPI sharedInstance] loadCurrentUserWithCompletionHandler:^(DSOUser *user) {
         self.user = user;
         NSString *deviceToken = [self appDelegate].deviceToken;
 
@@ -149,19 +142,23 @@
     }];
 }
 
+- (void)endSession {
+    self.user = nil;
+}
 
 - (void)endSessionWithCompletionHandler:(void(^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *logMessage = @"logout";
     CLS_LOG(@"%@", logMessage);
     [[DSOAPI sharedInstance] logoutWithDeviceToken:self.deviceToken completionHandler:^(NSDictionary *responseDict) {
-        self.user = nil;
+        [self endSession];
         if (completionHandler) {
             completionHandler();
         }
     } errorHandler:^(NSError *error) {
         // Only perform logout tasks if error is NOT a lack of connectivity.
+        // @todo: Or timeout
         if (error.code != -1009) {
-            self.user = nil;
+            [self endSession];
         }
         [self recordError:error logMessage:logMessage];
         if (errorHandler) {

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -51,10 +51,10 @@
 - (void)setUser:(DSOUser *)user {
     _user = user;
     if (user) {
-        [[Crashlytics sharedInstance] setUserIdentifier:user.userID];
+        [Crashlytics sharedInstance].userIdentifier = user.userID;
     }
     else {
-        [[Crashlytics sharedInstance] setUserIdentifier:nil];
+        [Crashlytics sharedInstance].userIdentifier = nil;
     }
 }
 
@@ -86,9 +86,7 @@
     CLS_LOG(@"login");
     [[DSOAPI sharedInstance] loginWithEmail:email password:password completionHandler:^(DSOUser *user) {
         self.user = user;
-        // Needed for when we're logging in as a different user.
         [[self appDelegate].bridge.eventDispatcher sendAppEventWithName:@"currentUserChanged" body:user.dictionary];
-        [[DSOAPI sharedInstance] setHTTPHeaderFieldSession:user.sessionToken];
         // Save session in Keychain for when app is quit.
         [SSKeychain setPassword:user.sessionToken forService:self.currentService account:@"Session"];
         [SSKeychain setPassword:self.user.userID forService:self.currentService account:@"UserID"];


### PR DESCRIPTION
* Closes #911: Uses the `profile` endpoint, refactors the storage of a session token into `DSOAPI,  resolving weirdness of storing the `sessionToken` on `DSOUser`

* Fixes bug where logging in as a different user would not reset the app's different tabs to the initial screens

* Removes unnecessary 2nd network request upon submitting the login/register controllers: this was calling the `reloadCurrentUser` method, which was necessary when we were storing a user's signups locally in memory. We aren't doing that anymore -- cleanup task from #844

* Renames methods for better readability: the `DSOAPI` managed our authentication token, where as the `DSOUserManager` handles the Login, Regiser, and Logout actions.  Adds lots of inline documentation