### PR TITLE
Fixes crashing nested DSOCampaign properties

### DIFF
--- a/Lets Do This/Categories/NSDictionary+DSOJsonHelper.h
+++ b/Lets Do This/Categories/NSDictionary+DSOJsonHelper.h
@@ -9,6 +9,7 @@
 @interface NSDictionary (DSOJsonHelper)
 
 - (id)valueForJSONKey:(NSString *)key;
+- (NSDictionary *)dictionaryForKeyPath:(NSString *)keyPath;
 - (NSString *)valueForKeyAsString:(NSString *)key;
 - (NSInteger)valueForKeyAsInt:(NSString *)key;
 - (BOOL)valueForKeyAsBool:(NSString *)key;

--- a/Lets Do This/Categories/NSDictionary+DSOJsonHelper.m
+++ b/Lets Do This/Categories/NSDictionary+DSOJsonHelper.m
@@ -18,6 +18,13 @@
     return value;
 }
 
+- (NSDictionary *)dictionaryForKeyPath:(NSString *)keyPath {
+    if ([[self valueForKeyPath:keyPath] isKindOfClass:[NSDictionary class]]) {
+        return [self valueForKeyPath:keyPath];
+    }
+    return nil;
+}
+
 - (NSString *)valueForKeyAsString:(NSString *)key; {
     id value = [self valueForJSONKey:key];
     if(value == nil) {

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -10,17 +10,19 @@
 
 @interface DSOCampaign : NSObject
 
-@property (strong, nonatomic, readonly) NSDictionary *dictionary;
 @property (assign, nonatomic, readonly) NSInteger campaignID;
 @property (strong, nonatomic, readonly) NSString *coverImage;
-@property (strong, nonatomic, readonly) NSString *solutionCopy;
-@property (strong, nonatomic, readonly) NSString *solutionSupportCopy;
 @property (strong, nonatomic, readonly) NSString *reportbackNoun;
 @property (strong, nonatomic, readonly) NSString *reportbackVerb;
+@property (strong, nonatomic, readonly) NSString *solutionCopy;
+@property (strong, nonatomic, readonly) NSString *solutionSupportCopy;
 @property (strong, nonatomic, readonly) NSString *status;
 @property (strong, nonatomic, readonly) NSString *tagline;
 @property (strong, nonatomic, readonly) NSString *title;
 @property (strong, nonatomic, readonly) NSString *type;
+
+// Formats campaign properties to be used by ReactComponents.
+@property (strong, nonatomic, readonly) NSDictionary *dictionary;
 
 - (instancetype)initWithCampaignID:(NSInteger)campaignID;
 - (instancetype)initWithCampaignID:(NSInteger)campaignID title:(NSString *)title;

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -28,6 +28,8 @@
 
 @implementation DSOCampaign
 
+#pragma mark - NSObject
+
 - (instancetype)initWithCampaignID:(NSInteger)campaignID {
     self = [super init];
 
@@ -57,44 +59,58 @@
         _status = [values valueForKeyAsString:@"status"];
         _type = [values valueForKeyAsString:@"type"];
         _tagline = [values valueForKeyAsString:@"tagline"];
-        _reportbackNoun = [values valueForKeyPath:@"reportback_info.noun"];
-        _reportbackVerb = [values valueForKeyPath:@"reportback_info.verb"];
-        _coverImage = [[values valueForKeyPath:@"cover_image.default.sizes.landscape"] valueForKeyAsString:@"uri"];
-        _solutionCopy = [[values valueForKeyPath:@"solutions.copy"] valueForKeyAsString:@"raw"];
-        _solutionSupportCopy = [[values valueForKeyPath:@"solutions.support_copy"] valueForKeyAsString:@"raw"];
+
+        if ([values dictionaryForKeyPath:@"reportback_info"]) {
+            _reportbackNoun = [values[@"reportback_info"] valueForKeyAsString:@"noun"];
+            _reportbackVerb = [values[@"reportback_info"] valueForKeyAsString:@"verb"];
+        }
+        else {
+            _reportbackNoun = @"";
+            _reportbackVerb = @"";
+        }
+
+        if ([values dictionaryForKeyPath:@"cover_image.default.sizes.landscape"]) {
+            _coverImage = [[values dictionaryForKeyPath:@"cover_image.default.sizes.landscape"] valueForKeyAsString:@"uri"];
+        }
+        else {
+            _coverImage = @"";
+        }
+
+        if ([values dictionaryForKeyPath:@"solutions.copy"]) {
+            _solutionCopy = [[values dictionaryForKeyPath:@"solutions.copy"] valueForKeyAsString:@"raw"];
+        }
+        else {
+            _solutionCopy = @"";
+        }
+
+        if ([values dictionaryForKeyPath:@"solutions.support_copy"]) {
+            _solutionSupportCopy = [[values dictionaryForKeyPath:@"solutions.support_copy"] valueForKeyAsString:@"raw"];
+        }
+        else {
+            _solutionSupportCopy = @"";
+        }
     }
 	
     return self;
 }
 
+#pragma mark - Accessors
+
 - (NSDictionary *)dictionary {
-    NSString *coverImage;
-    if (self.coverImage) {
-        coverImage = self.coverImage;
-    }
-    else {
-        coverImage = @"";
-    }
-    // @todo This is hack for default solutionCopy nullValue not being set
-    if (!self.solutionCopy) {
-        self.solutionCopy = @"";
-    }
-    if (!self.solutionSupportCopy) {
-        self.solutionSupportCopy = @"";
-    }
-    NSDictionary *reportbackInfo = @{@"noun" : self.reportbackNoun, @"verb" : self.reportbackVerb};
-    NSDictionary *dict = @{
+    return @{
              @"id" : [NSNumber numberWithInteger:self.campaignID],
              @"status": self.status,
              @"title" : self.title,
-             @"image_url" : coverImage,
+             @"image_url" : self.coverImage,
              @"tagline" : self.tagline,
              @"type" : self.type,
-             @"reportback_info" : reportbackInfo,
+             @"reportback_info" : @{
+                     @"noun" : self.reportbackNoun,
+                     @"verb" : self.reportbackVerb
+                     },
              @"solutionCopy" : self.solutionCopy,
              @"solutionSupportCopy" : self.solutionSupportCopy,
              };
-    return dict;
 }
 
 @end


### PR DESCRIPTION
Closes #930 by no longer worrying if the `solutions` properties are not objects: if not, we won't display them per anticipated changes in https://github.com/DoSomething/phoenix/issues/6250.

Cleans up setting default property values within the constructor, instead of the `dictionary` accessor method.