### PR TITLE
Ignore more network connection codes in Crashlytics

### DIFF
--- a/Lets Do This/Categories/NSError+LDT.h
+++ b/Lets Do This/Categories/NSError+LDT.h
@@ -8,6 +8,7 @@
 
 @interface NSError (LDT)
 
+- (BOOL)networkConnectionError;
 - (NSString *)readableTitle;
 - (NSString *)readableMessage;
 

--- a/Lets Do This/Categories/NSError+LDT.m
+++ b/Lets Do This/Categories/NSError+LDT.m
@@ -11,6 +11,12 @@
 
 @implementation NSError (LDT)
 
+- (BOOL)networkConnectionError {
+    NSInteger code = self.code;
+    // Many thanks to http://nshipster.com/nserror/#cfurlconnection-&-cfurlprotocol-errors
+    return (code == -1001 || code == -1005 || code == -1009 || code == -1018 || code == -1019 || code == -1020);
+}
+
 - (NSString *)readableTitle {
     return [self readableStringAsTitle:YES];
 
@@ -20,15 +26,7 @@
 }
 
 - (NSString *)readableStringAsTitle:(BOOL)isTitle {
-    if (self.code == -1009) {
-        if (isTitle) {
-            return @"No connection.";
-        }
-        else {
-            return @"Seems like the Internet is trying to cause drama.";
-        }
-    }
-    else if (self.code == -1001) {
+    if (self.code == -1001) {
         if (isTitle) {
             return @"The request timed out.";
         }
@@ -36,6 +34,15 @@
             return @"Seems like the Internet is trying to cause drama.";
         }
     }
+    else if (self.networkConnectionError) {
+        if (isTitle) {
+            return @"No connection.";
+        }
+        else {
+            return @"Seems like the Internet is trying to cause drama.";
+        }
+    }
+
     NSData *errorData = self.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
     if (errorData) {
         NSError *error = self;

--- a/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
@@ -152,9 +152,10 @@
             [self pushUserConnectViewController];
         } errorHandler:^(NSError *error) {
             [SVProgressHUD dismiss];
-            // Performs normal logout functionality even if we are presented with an error,
-            // but only if error is not a lack of connectivity. 
-            if (error.code != -1009) {
+            // If non-connection error, something's effed, login again.
+            // We make a similar check in LDTTabBarController -(void)loadCurrentUser.
+            if (!error.networkConnectionError) {
+                [[DSOUserManager sharedInstance] forceLogout];
                 [self pushUserConnectViewController];
             }
             else {

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -247,11 +247,12 @@
 }
 
 - (void)recordError:(NSError *)error logMessage:(NSString *)logMessage {
-    CLS_LOG(@"Error code %li -- %@", (long)error.code, logMessage);
-    // Only record error in Crashlytics if error is NOT lack of connectivity or timeout.
-    if ((error.code != -1009) && (error.code != -1001)) {
-        [CrashlyticsKit recordError:error];
+    CLS_LOG(@"error.code %li : %@", (long)error.code, logMessage);
+    if (error.networkConnectionError) {
+        NSLog(@"Excluding networking error from Crashlytics.");
+        return;
     }
+    [CrashlyticsKit recordError:error];
 }
 
 @end


### PR DESCRIPTION
Closes #932 and DRY logic with new category method.
