### PR TITLE
Crashlytics logging on for Login and Register errors

### DIFF
--- a/Lets Do This/Categories/NSError+LDT.h
+++ b/Lets Do This/Categories/NSError+LDT.h
@@ -9,6 +9,7 @@
 @interface NSError (LDT)
 
 - (BOOL)networkConnectionError;
+- (NSInteger)networkResponseCode;
 - (NSString *)readableTitle;
 - (NSString *)readableMessage;
 

--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -13,6 +13,7 @@
 #import "LDTUserRegisterViewController.h"
 #import "UITextField+LDT.h"
 #import "GAI+LDT.h"
+#import <Crashlytics/Crashlytics.h>
 
 @interface LDTUserLoginViewController ()
 
@@ -137,13 +138,21 @@
     } errorHandler:^(NSError *error) {
         [SVProgressHUD dismiss];
         [self.passwordTextField becomeFirstResponder];
-        if (error.code == -1011) {
+
+        // We get a 401 back for incorrect login credentials.
+        if (error.networkConnectionError || error.networkResponseCode == 401) {
+            NSLog(@"Excluding error from Crashlytics.");
+        }
+        else {
+            [CrashlyticsKit recordError:error];
+        }
+
+        if (error.networkResponseCode == 401) {
             [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Sorry, unrecognized email or password." subtitle:nil];
         }
         else {
             [LDTMessage displayErrorMessageInViewController:self.navigationController error:error];
         }
-        [self.emailTextField setBorderColor:UIColor.redColor];
     }];
 }
 

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -178,8 +178,11 @@
             }];
 
         } failure:^(NSError *error) {
-            // Only record error in Crashlytics if error is NOT lack of connectivity, timeout, or email already exists.
-            if ((error.code != -1009) && (error.code != -1001) && (error.code != 422)) {
+            // We get a 422 back when email or mobile already exists.
+            if (error.networkConnectionError || error.networkResponseCode == 422) {
+                NSLog(@"Excluding error from Crashlytics.");
+            }
+            else {
                 [CrashlyticsKit recordError:error];
             }
             [SVProgressHUD dismiss];


### PR DESCRIPTION
Adds a `NSError` category method, `-(NSInteger)networkResponseCode` which parses the response of a failed API request to return its error code.

* Fixes #938 by fixing the check for the 422 code.

* Resolves #939 by logging Crashlytics on the Login screen, excluding any 401 (invalid credentials) and network connection errors.

TODO: 
* [ ] DRY the `readableStringAsTitle` method to use networkResponseCode` instead
* [ ] Output the messages of a 422 on Signup and Reportback errors to help track down weird things
* [ ] Changes per  https://github.com/DoSomething/northstar/pull/305