### PR TITLE
[DSOAPI errorForAPIError]

### DIFF
--- a/Lets Do This/Categories/NSError+LDT.h
+++ b/Lets Do This/Categories/NSError+LDT.h
@@ -9,7 +9,6 @@
 @interface NSError (LDT)
 
 - (BOOL)networkConnectionError;
-- (NSInteger)networkResponseCode;
 - (NSString *)readableTitle;
 - (NSString *)readableMessage;
 

--- a/Lets Do This/Categories/NSError+LDT.m
+++ b/Lets Do This/Categories/NSError+LDT.m
@@ -54,15 +54,4 @@
     return @"Looks like there was an issue with that request. We're looking into it now!";
 }
 
-// @todo: Move this logic into DSOAPI to create a new error returned with relevant response code and error messages.
-- (NSInteger)networkResponseCode {
-    NSData *errorData = self.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
-    if (errorData) {
-        NSDictionary *responseDict = [NSJSONSerialization JSONObjectWithData:errorData options:kNilOptions error:nil];
-        NSInteger code = [[responseDict dictionaryForKeyPath:@"error"] valueForKeyAsInt:@"code"];
-        return code;
-    }
-    return 0;
-}
-
 @end

--- a/Lets Do This/Categories/NSError+LDT.m
+++ b/Lets Do This/Categories/NSError+LDT.m
@@ -42,7 +42,7 @@
             return @"Seems like the Internet is trying to cause drama.";
         }
     }
-    if (self.localizedFailureReason) {
+    if (self.code != 500 && self.localizedFailureReason) {
         if (isTitle) {
             return self.localizedDescription;
         }

--- a/Lets Do This/Categories/NSError+LDT.m
+++ b/Lets Do This/Categories/NSError+LDT.m
@@ -42,6 +42,12 @@
             return @"Seems like the Internet is trying to cause drama.";
         }
     }
+    if (self.localizedFailureReason) {
+        if (isTitle) {
+            return self.localizedDescription;
+        }
+        else return self.localizedFailureReason;
+    }
     if (isTitle) {
         return @"Oops! Our bad.";
     }

--- a/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserLoginViewController.m
@@ -13,7 +13,6 @@
 #import "LDTUserRegisterViewController.h"
 #import "UITextField+LDT.h"
 #import "GAI+LDT.h"
-#import <Crashlytics/Crashlytics.h>
 
 @interface LDTUserLoginViewController ()
 
@@ -39,13 +38,7 @@
 #pragma mark - NSObject
 
 -(id)init{
-    self = [super initWithNibName:NSStringFromClass([self class]) bundle:nil];
-	
-    if (self) {
-		
-    }
-	
-    return self;
+    return [super initWithNibName:NSStringFromClass([self class]) bundle:nil];
 }
 
 #pragma mark - UIViewController
@@ -58,16 +51,11 @@
     self.passwordTextField.placeholder = @"Password";
     [self.registerLink setTitle:@"Don't have an account? Register here" forState:UIControlStateNormal];
 
-    self.textFields = @[self.emailTextField,
-                        self.passwordTextField
-                        ];
-	
+    self.textFields = @[self.emailTextField, self.passwordTextField];
     for (UITextField *aTextField in self.textFields) {
         aTextField.delegate = self;
     }
-	
-    self.textFieldsRequired = @[self.emailTextField,
-                                self.passwordTextField];
+    self.textFieldsRequired = self.textFields;
 
     [self.submitButton setTitle:@"Sign in".uppercaseString forState:UIControlStateNormal];
     [self.submitButton enable:NO];
@@ -138,16 +126,7 @@
     } errorHandler:^(NSError *error) {
         [SVProgressHUD dismiss];
         [self.passwordTextField becomeFirstResponder];
-
-        // We get a 401 back for incorrect login credentials.
-        if (error.networkConnectionError || error.networkResponseCode == 401) {
-            NSLog(@"Excluding error from Crashlytics.");
-        }
-        else {
-            [CrashlyticsKit recordError:error];
-        }
-
-        if (error.networkResponseCode == 401) {
+        if (error.code == 401) {
             [LDTMessage displayErrorMessageInViewController:self.navigationController title:@"Sorry, unrecognized email or password." subtitle:nil];
         }
         else {

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -25,6 +25,9 @@
 
 + (DSOAPI *)sharedInstance;
 
+// Used to override ending a session for edge case failed logout requests (e.g. 401).
+- (void)deleteSessionToken;
+
 // Creates a DoSomething.org account with given properties. This API call does not automatically create an authenticated sesssion to log the user in, must additionally call createSessionForEmail:password:completionHandler:errorHandler.
 - (void)createUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler;
 
@@ -36,9 +39,6 @@
 
 // Ends session and removes deviceToken from the current User's account. deviceToken may be set to nil if user has not granted push notifications.
 - (void)endSessionWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
-// Used to override ending a session for edge case failed logout requests (e.g. 401).
-- (void)deleteSessionToken;
 
 // Posts avatar for the given user (which should always be the current authenticated user).
 - (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -260,10 +260,10 @@
     [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         DSOCampaign *campaign = [[DSOCampaign alloc] initWithDict:responseObject[@"data"]];
         // API returns 200 if campaign is not found, so check for valid ID.
-        // @todo This will be deprecated once https://github.com/DoSomething/phoenix/issues/6261 is resolved.
+        // @todo This whole check be deprecated once https://github.com/DoSomething/phoenix/issues/6261 is resolved.
         if (campaign.campaignID == 0) {
-            NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
-            userInfo[NSLocalizedDescriptionKey] = [NSString stringWithFormat:@"Campaign ID %li not found.", (long)campaignID];
+            NSString *errorDescription = [NSString stringWithFormat:@"Campaign ID %li not found.", (long)campaignID];
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errorDescription};
             NSError *error = [NSError errorWithDomain:@"org.dosomething.api.campaigns" code:404 userInfo:userInfo];
             if (errorHandler) {
                 errorHandler(error);
@@ -299,7 +299,7 @@
         }
         apiFailureReason = [fieldMessages componentsJoinedByString:@"\n"];
     }
-    NSDictionary *userInfo = @{NSLocalizedDescriptionKey : [errorDict valueForKeyAsString:@"message"], NSLocalizedFailureReasonErrorKey : apiFailureReason, NSLocalizedRecoverySuggestionErrorKey : @""};
+    NSDictionary *userInfo = @{NSLocalizedDescriptionKey : [errorDict valueForKeyAsString:@"message"], NSLocalizedFailureReasonErrorKey : apiFailureReason};
     return [NSError errorWithDomain:apiDomain code:apiCode userInfo:userInfo];
 }
 

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -106,6 +106,10 @@
 
 #pragma mark - DSOAPI
 
+- (void)deleteSessionToken {
+    [SSKeychain deletePasswordForService:self.currentService account:@"Session"];
+}
+
 - (void)createUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler {
     if (!countryCode) {
         countryCode = @"";
@@ -121,9 +125,8 @@
             completionHandler(responseObject);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
         if (errorHandler) {
-            errorHandler(error);
+            errorHandler([self errorForAPIError:error domain:@"auth.register"]);
         }
     }];
 }
@@ -140,9 +143,8 @@
             completionHandler(user);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
         if (errorHandler) {
-            errorHandler(error);
+            errorHandler([self errorForAPIError:error domain:@"auth.token"]);
         }
     }];
 }
@@ -159,9 +161,8 @@
             completionHandler(responseObject);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
         if (errorHandler) {
-            errorHandler(error);
+            errorHandler([self errorForAPIError:error domain:@"users.avatar"]);
         }
     }];
 }
@@ -177,15 +178,10 @@
             completionHandler(responseObject);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
         if (errorHandler) {
-            errorHandler(error);
+            errorHandler([self errorForAPIError:error domain:@"auth.invalidate"]);
         }
     }];
-}
-
-- (void)deleteSessionToken {
-    [SSKeychain deletePasswordForService:self.currentService account:@"Session"];
 }
 
 - (void)postSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
@@ -196,9 +192,8 @@
             completionHandler((DSOSignup *)responseObject[@"data"]);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
         if (errorHandler) {
-            errorHandler(error);
+            errorHandler([self errorForAPIError:error domain:@"signups"]);
         }
     }];
 }
@@ -220,9 +215,8 @@
             completionHandler((DSOReportback *)responseObject[@"data"]);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
         if (errorHandler) {
-            errorHandler(error);
+            errorHandler([self errorForAPIError:error domain:@"reportbacks"]);
         }
     }];
 }
@@ -239,9 +233,8 @@
               completionHandler(user);
           }
       } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
           if (errorHandler) {
-              errorHandler(error);
+              errorHandler([self errorForAPIError:error domain:@"profile"]);
           }
       }];
 }
@@ -254,9 +247,8 @@
             completionHandler(responseObject);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
         if (errorHandler) {
-            errorHandler(error);
+            errorHandler([self errorForAPIError:error domain:@"profile"]);
         }
     }];
 }
@@ -268,10 +260,11 @@
     [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         DSOCampaign *campaign = [[DSOCampaign alloc] initWithDict:responseObject[@"data"]];
         // API returns 200 if campaign is not found, so check for valid ID.
+        // @todo This will be deprecated once https://github.com/DoSomething/phoenix/issues/6261 is resolved.
         if (campaign.campaignID == 0) {
-            NSMutableDictionary *errorDetails = [[NSMutableDictionary alloc] init];
-            errorDetails[NSLocalizedDescriptionKey] = [NSString stringWithFormat:@"Campaign ID %li not found.", (long)campaignID];
-            NSError *error = [NSError errorWithDomain:@"org.dosomething.www" code:404 userInfo:errorDetails];
+            NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
+            userInfo[NSLocalizedDescriptionKey] = [NSString stringWithFormat:@"Campaign ID %li not found.", (long)campaignID];
+            NSError *error = [NSError errorWithDomain:@"org.dosomething.api.campaigns" code:404 userInfo:userInfo];
             if (errorHandler) {
                 errorHandler(error);
             }
@@ -282,15 +275,32 @@
             }
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
-        [self logError:error methodName:NSStringFromSelector(_cmd) URLString:url];
         if (errorHandler) {
-            errorHandler(error);
+            errorHandler([self errorForAPIError:error domain:@"campaigns"]);
         }
     }];
 }
 
-- (void)logError:(NSError *)error methodName:(NSString *)methodName URLString:(NSString *)URLString {
-    NSLog(@"\n*** DSOAPI ****\n\nError %li: %@\n%@\n%@ \n\n", (long)error.code, error.localizedDescription, methodName, URLString);
+- (NSError *)errorForAPIError:(NSError *)error domain:(NSString *)domain {
+    NSData *errorData = error.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey];
+    if (!errorData) {
+        return error;
+    }
+    NSString *apiDomain = [NSString stringWithFormat:@"org.dosomething.api.%@", domain];
+    NSDictionary *responseDict = [NSJSONSerialization JSONObjectWithData:errorData options:kNilOptions error:nil];
+    NSDictionary *errorDict =  [responseDict dictionaryForKeyPath:@"error"];
+    NSInteger apiCode = [errorDict valueForKeyAsInt:@"code"];
+    NSString *apiFailureReason = @"";
+    if (errorDict[@"fields"]) {
+        NSMutableArray *fieldMessages = [[NSMutableArray alloc] init];
+        for (NSArray *field in [errorDict[@"fields"] allValues]) {
+            NSString *fieldMessage = [field componentsJoinedByString:@"\n"];
+            [fieldMessages addObject:fieldMessage];
+        }
+        apiFailureReason = [fieldMessages componentsJoinedByString:@"\n"];
+    }
+    NSDictionary *userInfo = @{NSLocalizedDescriptionKey : [errorDict valueForKeyAsString:@"message"], NSLocalizedFailureReasonErrorKey : apiFailureReason, NSLocalizedRecoverySuggestionErrorKey : @""};
+    return [NSError errorWithDomain:apiDomain code:apiCode userInfo:userInfo];
 }
 
 @end

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -16,14 +16,17 @@
 // Singleton object for accessing authenticated User, stored campaigns.
 + (DSOUserManager *)sharedInstance;
 
-// Posts auth request to the API with given email and password, and saves session tokens to remain authenticated upon future app usage.
+// Returns whether an authenticated user session has been saved.
+- (BOOL)userHasCachedSession;
+
+// Posts new user registration to API.
+- (void)registerUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler;
+
+// Posts auth request to the API with given email and password of an existing user, and saves session tokens to remain authenticated upon future app usage.
 - (void)loginWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 // Use saved session to set relevant DSOAPI headers and loads the current user.
 - (void)continueSessionWithCompletionHandler:(void (^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
-
-// Returns whether an authenticated user session has been saved.
-- (BOOL)userHasCachedSession;
 
 // Logs out the user and deletes the current user and saved session tokens. Called when User logs out from Settings screen.
 - (void)logoutWithCompletionHandler:(void(^)(void))completionHandler errorHandler:(void(^)(NSError *))errorHandler;

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -87,12 +87,11 @@
 
 - (void)registerUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler {
     CLS_LOG(@"register");
-    [[DSOAPI sharedInstance] createUserWithEmail:email password:password firstName:firstName        mobile:mobile countryCode:countryCode deviceToken:deviceToken success:^(NSDictionary *response) {
+    [[DSOAPI sharedInstance] createUserWithEmail:email password:password firstName:firstName mobile:mobile countryCode:countryCode deviceToken:deviceToken success:^(NSDictionary *response) {
         if (completionHandler) {
             completionHandler(response);
         }
     } failure:^(NSError *error) {
-        NSLog(@"Error %@", error);
         // Filter any 422's (email/mobile exists).
         if (error.code != 422) {
             [self recordError:error logMessage:@"register"];

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -85,6 +85,24 @@
     return [DSOAPI sharedInstance].sessionToken.length > 0;
 }
 
+- (void)registerUserWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName mobile:(NSString *)mobile countryCode:(NSString *)countryCode deviceToken:(NSString *)deviceToken success:(void(^)(NSDictionary *))completionHandler failure:(void(^)(NSError *))errorHandler {
+    CLS_LOG(@"register");
+    [[DSOAPI sharedInstance] createUserWithEmail:email password:password firstName:firstName        mobile:mobile countryCode:countryCode deviceToken:deviceToken success:^(NSDictionary *response) {
+        if (completionHandler) {
+            completionHandler(response);
+        }
+    } failure:^(NSError *error) {
+        NSLog(@"Error %@", error);
+        // Filter any 422's (email/mobile exists).
+        if (error.code != 422) {
+            [self recordError:error logMessage:@"register"];
+        }
+        if (errorHandler) {
+            errorHandler(error);
+        }
+    }];
+}
+
 - (void)loginWithEmail:(NSString *)email password:(NSString *)password completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     CLS_LOG(@"login");
     [[DSOAPI sharedInstance] createSessionForEmail:email password:password completionHandler:^(DSOUser *user) {

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -93,7 +93,8 @@
             completionHandler(user);
         }
       } errorHandler:^(NSError *error) {
-          if (error.code >= 500) {
+          // Filter any 401's (invalid login credentials).
+          if (error.code != 401) {
               [self recordError:error logMessage:@"login"];
           }
           if (errorHandler) {


### PR DESCRIPTION
Closes #945:

- New `DSOAPI` instance method `-(NSError *)errorForAPIError:(NSError *)error` takes a given `NSError` returned by `AFNetworking` , and returns a new one with a `domain` and `code` based on the failed network response sent if exists. If it doesn't it simply returns the same `NSError`.

- Adjusts accordingly view controllers to simply check for returned `error.code`, deprecates category method, `[NSError+LDT networkRequestCode]` introduced in #940 

- Moves `[CrashlyticsKit recordError:]` calls and logic out of the User Login and Register controllers and instead into the relevant `DSOUserManager` methods being called -- to keep all filtering based on code defined in this single location.

Speaking of filters, we're filtering out:
* Any network connection errors (no connection, timeout, user turned off cellular data for the app, international roaming)
* 401 for Login (invalid email/password)
* 422 for Register (email/password already exists)

The screenshot below contains some of the above errors we will be filtering. I removed those checks to verify the errors were being logged in Crashlytics as expected. The first record for the `alamofire` domain is where all this errors get stored as sessions without these custom domain/codes.  

![it's beautiful](https://cloud.githubusercontent.com/assets/1236811/13689905/351395cc-e6e1-11e5-8397-37f869a1ac90.png)