### PR TITLE
More Reportbacks

### DIFF
--- a/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
+++ b/Lets Do This/Controllers/Campaign/LDTCampaignViewController.m
@@ -41,8 +41,8 @@
     [super viewDidLoad];
 
     [self styleView];
-
-    NSString *galleryUrl = [NSString stringWithFormat:@"%@reportback-items?load_user=true&status=approved,promoted&campaigns=%li", [DSOAPI sharedInstance].phoenixApiURL, (long)self.campaign.campaignID];
+    // Grab 100 records for now until we add paginated requests.
+    NSString *galleryUrl = [NSString stringWithFormat:@"%@reportback-items?load_user=true&status=approved,promoted&campaigns=%li&count=100", [DSOAPI sharedInstance].phoenixApiURL, (long)self.campaign.campaignID];
     NSString *signupURLString = [NSString stringWithFormat:@"%@signups?user=%@", [DSOAPI sharedInstance].baseURL, [DSOUserManager sharedInstance].user.userID];
     NSDictionary *appProperties;
     NSDictionary *campaignDict = [[NSDictionary alloc] init];

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -86,7 +86,8 @@ var UserView = React.createClass({
         'X-DS-REST-API-Key': this.props.apiKey,
       },
     };
-    var url = this.props.baseUrl + 'signups?user=' + this.state.user.id;
+    // Grab 200 records for now until we add paginated requests.
+    var url = this.props.baseUrl + 'signups?user=' + this.state.user.id + '&count=200';
     fetch(url, options)
       .then((response) => response.json())
       .catch((error) => this.catchError(error))
@@ -114,6 +115,11 @@ var UserView = React.createClass({
 
     for (let i = 0; i < signups.length; i++) {
       let signup = signups[i];
+
+      // Data safety check:
+      if ((!signup.campaign) || (!signup.campaign_run)) {
+        continue;
+      }
       
       if (Helpers.reportbackItemExistsForSignup(signup)) {
         signup.reportbackItem = signup.reportback.reportback_items.data[0];


### PR DESCRIPTION
Sets `count` query string param to display more photos on the Campaign Detail and on the Profile, per https://github.com/DoSomething/phoenix/pull/6249. Closes #941

Also adds safety check for Signups without a Campaign or Reportback. Found this one by spot checking power user [Ben Kassoy's profile](https://northstar.dosomething.org/v1/signups?user=554c2f3f469c64ed7d8b6061&count=100)

![screen shot 2016-03-10 at 9 55 25 pm](https://cloud.githubusercontent.com/assets/1236811/13695311/429290e6-e712-11e5-9ed0-4a95dbefb771.png)

cc @jonuy @angaither