### PR TITLE
Delete stored API session if havent onboarding #950

### DIFF
--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -50,6 +50,11 @@
     [SVProgressHUD setFont:LDTTheme.font];
     [TSMessageView addNotificationDesignFromFile:@"LDTMessageDefaultDesign.json"];
 
+    if (![[NSUserDefaults standardUserDefaults] boolForKey:@"hasCompletedOnboarding"]) {
+        // Resolves edge-case when deleted from device and this is re-install (GH #950).
+        [[DSOAPI sharedInstance] deleteSessionToken];
+    }
+
     [Parse setApplicationId:keysDict[@"parseApplicationId"] clientKey:keysDict[@"parseClientKey"]];
     UIUserNotificationType userNotificationTypes = (UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound);
     UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:userNotificationTypes categories:nil];


### PR DESCRIPTION
Refactored API session token storage in `SSKeychain` for better security in #924, but forgot that `SSKeychain` entries don't get deleted from device upon app install. The `NSUserDefaults` do however (which is how we were storing the session token prior to #924)

Fixes #950 by implementing [this SO solution](http://stackoverflow.com/a/6203301/1470725).