### PR TITLE
Safety checks on User Profile

### DIFF
--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -225,7 +225,7 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
         UIImage *selectedImage = info[UIImagePickerControllerEditedImage];
         if (self.selectedImageType == LDTSelectedImageTypeAvatar) {
             [SVProgressHUD showWithStatus:@"Uploading..."];
-            [[DSOUserManager sharedInstance] postAvatarImage:selectedImage sendAppEvent:YES completionHandler:^(NSDictionary *completionHandler) {
+            [[DSOUserManager sharedInstance] postAvatarImage:selectedImage completionHandler:^(DSOUser *completionHandler) {
                 [SVProgressHUD dismiss];
                 [LDTMessage displaySuccessMessageWithTitle:@"Hey good lookin'." subtitle:@"You've successfully changed your profile photo."];
             } errorHandler:^(NSError *error) {

--- a/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
+++ b/Lets Do This/Controllers/Login/LDTUserRegisterViewController.m
@@ -165,7 +165,7 @@
             [[DSOUserManager sharedInstance] loginWithEmail:self.emailTextField.text password:self.passwordTextField.text completionHandler:^(DSOUser *user) {
 
                 if (self.userDidPickAvatarPhoto) {
-                    [[DSOUserManager sharedInstance] postAvatarImage:self.imageView.image sendAppEvent:NO completionHandler:^(NSDictionary *completionHandler) {
+                    [[DSOUserManager sharedInstance] postAvatarImage:self.imageView.image completionHandler:^(DSOUser *completionHandler) {
                         NSLog(@"Successful user avatar upload.");
                     } errorHandler:^(NSError *error) {
                         [LDTMessage displayErrorMessageInViewController:appDelegate.window.rootViewController title:@"Error uploading avatar." subtitle:@"Please try again from your profile."];

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -41,7 +41,7 @@
 - (void)endSessionWithDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 // Posts avatar for the given user (which should always be the current authenticated user).
-- (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+- (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
 - (void)postReportbackForCampaign:(DSOCampaign *)campaign fileString:(NSString *)fileString caption:(NSString *)caption quantity:(NSInteger)quantity completionHandler:(void(^)(DSOReportback *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -149,7 +149,7 @@
     }];
 }
 
-- (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(id))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+- (void)postAvatarForUser:(DSOUser *)user avatarImage:(UIImage *)avatarImage completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *url = [NSString stringWithFormat:@"users/%@/avatar", user.userID];
     NSData *imageData = UIImageJPEGRepresentation(avatarImage, 1.0);
     NSString *fileNameForImage = [NSString stringWithFormat:@"User_%@_ProfileImage", user.userID];
@@ -157,8 +157,9 @@
     [self POST:url parameters:nil constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
         [formData appendPartWithFileData:imageData name:@"photo" fileName:fileNameForImage mimeType:@"image/jpeg"];
     } success:^(NSURLSessionDataTask *task, id responseObject) {
+        DSOUser *updatedUser = [[DSOUser alloc] initWithDict:[responseObject valueForKeyPath:@"data"]];
         if (completionHandler) {
-            completionHandler(responseObject);
+            completionHandler(updatedUser);
         }
     } failure:^(NSURLSessionDataTask *task, NSError *error) {
         if (errorHandler) {

--- a/Lets Do This/Networking/DSOUserManager.h
+++ b/Lets Do This/Networking/DSOUserManager.h
@@ -40,8 +40,8 @@
 // Posts Reportback to API, calls relevant GoogleAnalytics and React Native eventDispatcher.
 - (void)reportbackForCampaign:(DSOCampaign *)campaign fileString:(NSString *)fileString caption:(NSString *)caption quantity:(NSInteger)quantity completionHandler:(void(^)(DSOReportback *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
-// Posts Avatar to API, calls React Native eventDispatcher if sendAppEvent.
-- (void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler ;
+// Posts Avatar to API, returns updated current user in completion handler.
+- (void)postAvatarImage:(UIImage *)avatarImage completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler ;
 
 // Returns DSOCampaign from local storage, if exists.
 - (DSOCampaign *)campaignWithID:(NSInteger)campaignID;

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -7,6 +7,7 @@
 //
 
 #import "DSOUserManager.h"
+#import "NSDictionary+DSOJsonHelper.h"
 #import <SSKeychain/SSKeychain.h>
 #import "GAI+LDT.h"
 #import <Crashlytics/Crashlytics.h>
@@ -216,17 +217,12 @@
     }];
 }
 
-- (void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
-    [[DSOAPI sharedInstance] postAvatarForUser:[DSOUserManager sharedInstance].user avatarImage:avatarImage completionHandler:^(id responseObject) {
-        CLS_LOG(@"%@", avatarImage);
-        // @todo Safety test all of these keys.
-        NSDictionary *responseDict = responseObject[@"data"];
-        self.user.avatarURL = responseDict[@"photo"];
-        NSLog(@"postAvatarImage currentUserChanged eventDispatcher");
-        [[self appDelegate].bridge.eventDispatcher sendAppEventWithName:@"currentUserChanged" body:responseDict];
-
+- (void)postAvatarImage:(UIImage *)avatarImage completionHandler:(void(^)(DSOUser *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    [[DSOAPI sharedInstance] postAvatarForUser:[DSOUserManager sharedInstance].user avatarImage:avatarImage completionHandler:^(DSOUser *user) {
+        // @todo: hack for now, having trouble just updating avatar only in RN
+        self.user = user;
         if (completionHandler) {
-            completionHandler(responseDict);
+            completionHandler(user);
         }
     } errorHandler:^(NSError * error) {
         [self recordError:error logMessage:@"avatar"];

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -219,6 +219,7 @@
 - (void)postAvatarImage:(UIImage *)avatarImage sendAppEvent:(BOOL)sendAppEvent completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     [[DSOAPI sharedInstance] postAvatarForUser:[DSOUserManager sharedInstance].user avatarImage:avatarImage completionHandler:^(id responseObject) {
         CLS_LOG(@"%@", avatarImage);
+        // @todo Safety test all of these keys.
         NSDictionary *responseDict = responseObject[@"data"];
         self.user.avatarURL = responseDict[@"photo"];
         NSLog(@"postAvatarImage currentUserChanged eventDispatcher");

--- a/Lets Do This/Networking/DSOUserManager.m
+++ b/Lets Do This/Networking/DSOUserManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "DSOUserManager.h"
-#import "NSDictionary+DSOJsonHelper.h"
 #import <SSKeychain/SSKeychain.h>
 #import "GAI+LDT.h"
 #import <Crashlytics/Crashlytics.h>

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -261,7 +261,7 @@ var UserView = React.createClass({
       avatarUri =  'Avatar';
     }
     var headerText = null;
-    if (this.state.user.country.length > 0) {
+    if (this.state.user.country && this.state.user.country.length > 0) {
       headerText = this.state.user.country.toUpperCase();
     }
     var avatar = (

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -91,7 +91,10 @@ var UserView = React.createClass({
       .then((response) => response.json())
       .catch((error) => this.catchError(error))
       .then((responseData) => {
+        // This was added because of this https://github.com/DoSomething/LetsDoThis-iOS/pull/853#discussion_r54018442
         if (!responseData) {
+          // You'd assume error should be undefined here since the catch isn't firing
+          console.log(error);
           this.setState({
             error: error,
           });
@@ -103,7 +106,9 @@ var UserView = React.createClass({
           });
           return;
         }
-        this.loadSignups(responseData.data);
+        if (responseData.data) {
+          this.loadSignups(responseData.data);
+        }
       })
       .done();
   },

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -92,6 +92,15 @@ var UserView = React.createClass({
       .catch((error) => this.catchError(error))
       .then((responseData) => {
         if (!responseData) {
+          this.setState({
+            error: error,
+          });
+          return;
+        }
+        if (responseData.error) {
+          this.setState({
+            error: responseData.error,
+          });
           return;
         }
         this.loadSignups(responseData.data);
@@ -207,6 +216,7 @@ var UserView = React.createClass({
   },
   render: function() {
     if (this.state.error) {
+      // @todo Refactor NetworkErrorView to accept error object, instead of errorMessage
       return (
         <NetworkErrorView
           title="Profile isn't loading right now"

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -91,13 +91,10 @@ var UserView = React.createClass({
       .then((response) => response.json())
       .catch((error) => this.catchError(error))
       .then((responseData) => {
-        // This was added because of this https://github.com/DoSomething/LetsDoThis-iOS/pull/853#discussion_r54018442
+        // This was added here -- https://github.com/DoSomething/LetsDoThis-iOS/pull/853#discussion_r54018442
+        // If we turn on airplane mode and load this view, the catchError executes above 
+        // but this then block still executes. feels like i'm doing something wrong here.
         if (!responseData) {
-          // You'd assume error should be undefined here since the catch isn't firing
-          console.log(error);
-          this.setState({
-            error: error,
-          });
           return;
         }
         if (responseData.error) {


### PR DESCRIPTION
* Closes #961, checking for existence of a `responseData.error` and only calling `loadSignups` if `responseData.data` exists
* Closes #958, I think. I can't replicate this but this was previously optimistic code, expecting that `data.country` would exist every time we get a response back from the API. Looks it didn't in #958, so this PR tidies up the `[DSOAPI postAvatarForUser:avatarImage:completionHandler:errorHandler:]` to return a `DSOUser`, which should be created with proper object.property checks, instead blindly trusting whatever `id` we get back from API