### PR TITLE
Track Parse Push Notification opens

### DIFF
--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -61,6 +61,17 @@
     [application registerUserNotificationSettings:settings];
     [application registerForRemoteNotifications];
 
+    // Following code tracks opening Parse push notification
+    // @see https://www.parse.com/docs/ios/guide#push-notifications-tracking-pushes-and-app-opens
+    if (application.applicationState != UIApplicationStateBackground) {
+        BOOL preBackgroundPush = ![application respondsToSelector:@selector(backgroundRefreshStatus)];
+        BOOL oldPushHandlerOnly = ![self respondsToSelector:@selector(application:didReceiveRemoteNotification:fetchCompletionHandler:)];
+        BOOL noPushPayload = ![launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
+        if (preBackgroundPush || oldPushHandlerOnly || noPushPayload) {
+            [PFAnalytics trackAppOpenedWithLaunchOptions:launchOptions];
+        }
+    }
+
     // Clear out any badges, as we don't yet require user to take any action besides opening up the app.
     application.applicationIconBadgeNumber = 0;
 
@@ -128,6 +139,9 @@
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
     [PFPush handlePush:userInfo];
+    if (application.applicationState == UIApplicationStateInactive) {
+        [PFAnalytics trackAppOpenedWithRemoteNotificationPayload:userInfo];
+    }
 }
 
 # pragma mark - Accessors

--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -140,6 +140,7 @@
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
     [PFPush handlePush:userInfo];
     if (application.applicationState == UIApplicationStateInactive) {
+        application.applicationIconBadgeNumber = 0;
         [PFAnalytics trackAppOpenedWithRemoteNotificationPayload:userInfo];
     }
 }


### PR DESCRIPTION
Fixes #969 by implementing code in https://www.parse.com/docs/ios/guide#push-notifications-tracking-pushes-and-app-opens.  Ran tests sending push notifications to just my single deviceToken and looks like we're in business:
![screen shot 2016-03-24 at 9 34 28 pm](https://cloud.githubusercontent.com/assets/1236811/14038105/56677f62-f209-11e5-84a0-5af4dd44b13f.png)

@jonuy We're storing the deviceToken to `parse_installation_ids` (added in #912, based on Tong's initial branch in #705). Just double checking: Assume we want to store the Parse installation's `installationId` not the `deviceToken`, and that this was a bug we missed in #705 ?  

My device token is `18533d776392007005f4f0088824883ba039bad6fd36f1556e77c41f75e6ad0b`
The parse installation ID is `ed65ba7e-c828-4c3f-ab69-af8caea6cd4c`.
For user `aschachter+parse@dosomething.org`:

![screen shot 2016-03-24 at 10 43 26 pm](https://cloud.githubusercontent.com/assets/1236811/14038732/feaeb6e2-f211-11e5-9ca7-576838c491fb.png)

But this test account looks more like installation id's:
![screen shot 2016-03-24 at 10 41 50 pm](https://cloud.githubusercontent.com/assets/1236811/14038730/f83d070a-f211-11e5-8f10-c329e2780d99.png)
Guessing it was used to test android, hence the installation id's (vs device tokens..)