### PR TITLE
Store parseInstallationId, not deviceToken

### DIFF
--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -125,7 +125,7 @@
     [currentInstallation setDeviceTokenFromData:deviceToken];
     currentInstallation.channels = @[ @"global" ];
     [currentInstallation saveInBackground];
-    self.deviceToken = [[[NSString stringWithFormat:@"%@", deviceToken] stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"<>"]] stringByReplacingOccurrencesOfString:@" " withString:@""];
+    self.deviceToken = currentInstallation.installationId;
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {


### PR DESCRIPTION
The fix for #978... although we're actually not passing a `deviceToken` around but a `parseInstallationId`.. which was a mixup from #912 referencing #705. oy!

Cleanup task to rename those methods and properties, since technically it's all a `parseInstallationId`, not a `deviceToken`.  Saving for post launch.

![screen shot 2016-03-25 at 10 47 37 am](https://cloud.githubusercontent.com/assets/1236811/14050127/09ed2268-f277-11e5-8fda-43d33de9e20e.png)
