### PR TITLE
Upgrade React Native to 0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/DoSomething/LetsDoThis-iOS#readme",
   "dependencies": {
-    "react-native": "^0.19.0"
+    "react": "^0.14.8",
+    "react-native": "^0.22.2"
   }
 }


### PR DESCRIPTION
Closes #984. 

Steps to update locally:

1. `npm update` -- Updates the `node_modules` JS magic
2. `pod install` -- Updates the Objective C React Native magic
3. Success. If your simulator is [stuck in hot reloading](https://github.com/facebook/react-native/issues/6597#issuecomment-206939864), clear the reset the simulator's content and settings. 