### PR TITLE
Fixes the "Rate DoSomething" link in the settings page

### DIFF
--- a/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
+++ b/Lets Do This/Controllers/Settings/LDTSettingsViewController.m
@@ -167,7 +167,7 @@
 
 - (void)handleRateTap:(UITapGestureRecognizer *)recognizer {
     [[GAI sharedInstance] trackEventWithCategory:@"behavior" action:@"tap on review app button" label:nil value:nil];
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://itunes.apple.com/app/998995766"]];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://itunes.apple.com/app/id998995766"]];
 }
 
 - (void)handleTermsTap:(UITapGestureRecognizer *)recognizer {


### PR DESCRIPTION
We just needed to add `id` to the url to get it to recognize the app in the store. Fixes #986 and #987 in iTunes connect.