### PR TITLE
Display Campaign sponsor

### DIFF
--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -77,7 +77,7 @@
 
     if ([environmentDict objectForKey:@"ReactNativeUseOfflineBundle"] && ![environmentDict[@"ReactNativeUseOfflineBundle"] boolValue]) {
         // Run "npm start" from the project root to enable local React Native development.
-        self.jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle"];
+        self.jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle?platform=ios&dev=true"];
         NSLog(@"[LDTAppDelegate] Running React Native from localhost development server.");
     }
     else {

--- a/Lets Do This/Controllers/Base/LDTTabBarController.m
+++ b/Lets Do This/Controllers/Base/LDTTabBarController.m
@@ -252,7 +252,7 @@ typedef NS_ENUM(NSInteger, LDTSelectedImageType) {
 #pragma mark - UITabBarControllerDelegate
 
 - (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController {
-    CLS_LOG(@"selectedIndex %li", self.selectedIndex);
+    CLS_LOG(@"selectedIndex %li", (unsigned long)self.selectedIndex);
 }
 
 @end

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -16,6 +16,7 @@
 @property (strong, nonatomic, readonly) NSString *reportbackVerb;
 @property (strong, nonatomic, readonly) NSString *solutionCopy;
 @property (strong, nonatomic, readonly) NSString *solutionSupportCopy;
+@property (strong, nonatomic, readonly) NSString *sponsorImageURL;
 @property (strong, nonatomic, readonly) NSString *status;
 @property (strong, nonatomic, readonly) NSString *tagline;
 @property (strong, nonatomic, readonly) NSString *title;

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -18,6 +18,7 @@
 @property (strong, nonatomic, readwrite) NSString *reportbackVerb;
 @property (strong, nonatomic, readwrite) NSString *solutionCopy;
 @property (strong, nonatomic, readwrite) NSString *solutionSupportCopy;
+@property (strong, nonatomic, readwrite) NSString *sponsorImageURL;
 @property (strong, nonatomic, readwrite) NSString *status;
 @property (strong, nonatomic, readwrite) NSString *tagline;
 @property (strong, nonatomic, readwrite) NSString *title;
@@ -89,6 +90,19 @@
         else {
             _solutionSupportCopy = @"";
         }
+
+        _sponsorImageURL = @"";
+        if ([values dictionaryForKeyPath:@"affiliates"]) {
+            NSArray *partnerData = [values valueForKeyPath:@"affiliates.partners"];
+            if (partnerData.count > 0) {
+                // API is hardcoded to return single partner for now
+                // @see https://github.com/DoSomething/phoenix/issues/6396
+                NSDictionary *partnerDict = partnerData[0];
+                if ([partnerDict valueForKeyAsBool:@"sponsor"]) {
+                    _sponsorImageURL = [[partnerDict dictionaryForKeyPath:@"media"] valueForKeyAsString:@"uri"];
+                }
+            }
+        }
     }
 	
     return self;
@@ -110,6 +124,7 @@
                      },
              @"solutionCopy" : self.solutionCopy,
              @"solutionSupportCopy" : self.solutionSupportCopy,
+             @"sponsorImageUrl": self.sponsorImageURL
              };
 }
 

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -286,7 +286,10 @@ var CampaignView = React.createClass({
         </Text>
       </View>
     );
-    var sponsorImageUrl = 'https://www.dosomething.org/sites/default/files/styles/wmax-423px/public/partners/HM-1.png?itok=N8vhbM3I';
+    var sponsored = null;
+    if (campaign.sponsorImageUrl) {
+      sponsored = <SponsorView imageUrl={campaign.sponsorImageUrl} />;
+    }
 
     return (
       <View>
@@ -298,9 +301,7 @@ var CampaignView = React.createClass({
             displayProgress={true}
           />
         </View>
-        <SponsorView 
-          imageUrl={sponsorImageUrl}
-        />
+        {sponsored}
         <Text style={[Style.textSubheading, styles.tagline]}>
           {campaign.tagline}
         </Text>

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -17,6 +17,7 @@ var Style = require('./Style.js');
 var Helpers = require('./Helpers.js');
 var NetworkErrorView = require('./NetworkErrorView.js');
 var ReportbackItemView = require('./ReportbackItemView.js');
+var SponsorView = require('./SponsorView.js');
 var Bridge = require('react-native').NativeModules.LDTReactBridge;
 var NetworkImage = require('./NetworkImage.js');
 
@@ -285,6 +286,7 @@ var CampaignView = React.createClass({
         </Text>
       </View>
     );
+    var sponsorImageUrl = 'https://www.dosomething.org/sites/default/files/styles/wmax-423px/public/partners/HM-1.png?itok=N8vhbM3I';
 
     return (
       <View>
@@ -296,6 +298,9 @@ var CampaignView = React.createClass({
             displayProgress={true}
           />
         </View>
+        <SponsorView 
+          imageUrl={sponsorImageUrl}
+        />
         <Text style={[Style.textSubheading, styles.tagline]}>
           {campaign.tagline}
         </Text>

--- a/ReactComponents/SponsorView.js
+++ b/ReactComponents/SponsorView.js
@@ -1,0 +1,40 @@
+'use strict';
+
+import React, {
+  StyleSheet,
+  Text,
+  Image,
+  View,
+} from 'react-native';
+
+var Style = require('./Style.js');
+
+var SponsorView = React.createClass({
+  render: function() {
+    var label = "Powered by".toUpperCase();
+    return (
+      <View style={styles.container}>
+        <Text style={[Style.textBodyBold, styles.content]}>{label}</Text>
+        <Image 
+          source={{uri: this.props.imageUrl}}
+          style={styles.image} 
+        />
+      </View>
+    );
+  }
+});
+
+var styles = React.StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+  content: {
+    color: '#D6D6D6',
+    textAlign: 'center',
+  },
+  image: {
+    height: 50,
+  }
+});
+
+module.exports = SponsorView;

--- a/ReactComponents/SponsorView.js
+++ b/ReactComponents/SponsorView.js
@@ -16,6 +16,7 @@ var SponsorView = React.createClass({
       <View style={styles.container}>
         <Text style={[Style.textBodyBold, styles.content]}>{label}</Text>
         <Image 
+          resizeMode="contain"
           source={{uri: this.props.imageUrl}}
           style={styles.image} 
         />
@@ -26,14 +27,14 @@ var SponsorView = React.createClass({
 
 var styles = React.StyleSheet.create({
   container: {
-    padding: 20,
+    paddingTop: 8,
   },
   content: {
     color: '#D6D6D6',
     textAlign: 'center',
   },
   image: {
-    height: 50,
+    height: 23,
   }
 });
 


### PR DESCRIPTION
Closes #991:
* Adds a new `NSString` property `DSOCampaign.sponsorImageURL`, populated by new `affiliates` (https://github.com/DoSomething/phoenix/pull/6395)
    * hardcoded to display a single Sponsor (Campaigns may potentially need to display more than 1 in the future https://github.com/DoSomething/phoenix/issues/6396) 
* Adds a new `SponsorView` component to render a given `sponsorImageUrl`
    * Got stuck on getting the sponsor logo to display to the right of the powered by without setting a fixed height and width, so adding the logo underneath the "Powered by" label for now.

![screen shot 2016-04-26 at 2 00 29 pm](https://cloud.githubusercontent.com/assets/1236811/14834467/710c2812-0bb9-11e6-9096-775914d9efa2.png)

