### PR TITLE
Adds Tapjoy v11

### DIFF
--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -15,6 +15,7 @@
 #import <Fabric/Fabric.h>
 #import <Crashlytics/Crashlytics.h>
 #import <RCTEventDispatcher.h>
+#import <Tapjoy/Tapjoy.h>
 
 @interface LDTAppDelegate()
 
@@ -44,6 +45,18 @@
         [GAI sharedInstance].logger.logLevel = kGAILogLevelVerbose;
     }
     [Fabric with:@[[Crashlytics startWithAPIKey:keysDict[@"fabricApiKey"]]]];
+
+    // Setup Tapjoy
+    // @see https://ltv.tapjoy.com/s/571fa5b3-fd4a-8000-8000-17367200018b/onboarding#guide/basic?os=ios
+    if (keysDict[@"tapjoySdkKey"]) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tjcConnectSuccess:) name:TJC_CONNECT_SUCCESS object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tjcConnectFail:) name:TJC_CONNECT_FAILED object:nil];
+        if ([environmentDict objectForKey:@"TapjoyDebugEnabled"] && [environmentDict[@"TapjoyDebugEnabled"] boolValue]) {
+            [Tapjoy setDebugEnabled:YES];
+        }
+        [Tapjoy connect:keysDict[@"tapjoySdkKey"]];
+    }
+
     [AFNetworkActivityIndicatorManager sharedManager].enabled = YES;
     [SVProgressHUD setDefaultMaskType:SVProgressHUDMaskTypeBlack];
     [SVProgressHUD setForegroundColor:LDTTheme.ctaBlueColor];
@@ -149,6 +162,16 @@
 
 - (LDTTabBarController *)tabBarController {
     return (LDTTabBarController *)self.window.rootViewController;
+}
+
+#pragma mark - Tapjoy
+
+-(void)tjcConnectSuccess:(NSNotification*)notifyObj {
+    NSLog(@"Tapjoy connect Succeeded");
+}
+
+-(void)tjcConnectFail:(NSNotification*)notifyObj {
+    NSLog(@"Tapjoy connect Failed");
 }
 
 @end

--- a/Podfile
+++ b/Podfile
@@ -15,6 +15,7 @@ target 'Lets Do This' do
     pod 'GoogleAnalytics', '3.13.0'
     pod 'NewRelicAgent', '5.3.4'
     pod 'NSString+RemoveEmoji', '0.1.0'
+    pod 'TapjoySDK', '11.5.1'
 end
 
 xcodeproj 'Lets Do This', 'Thor' => :release, 'Debug' => :debug, 'Release' => :release


### PR DESCRIPTION
Using version 11 of Tapjoy's SDK seems to work, I show up in real time, whereas I don't using v10 (refs #999)

Here's the debug log:

````
2016-04-28 10:10:33.987 DoSomething[445:124663] [TJLog level: 4] Connect success with type:0
Apr 28 10:10:34  DoSomething[445] <Notice>: starting profile request using - 3.1-77 with options: 1fc7e
2016-04-28 10:10:34.019 DoSomething[445:124663] Tapjoy connect Succeeded
2016-04-28 10:10:36.179 DoSomething[445:124663] -canOpenURL: failed for URL: "about:blank" - error: "This app is not allowed to query for scheme about"
2016-04-28 10:10:36.188 DoSomething[445:124663] [TJLog level: 4] Events proxy is ready
````

![tapjoy-live](https://cloud.githubusercontent.com/assets/1236811/14894998/55f07ba0-0d2b-11e6-8164-b2dbc9bfbae7.jpg)
