### PR TITLE
Updates NewRelicAgent to 5.4.1

### DIFF
--- a/Lets Do This/Classes/LDTAppDelegate.m
+++ b/Lets Do This/Classes/LDTAppDelegate.m
@@ -30,7 +30,12 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     NSDictionary *keysDict = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"keys" ofType:@"plist"]];
     NSDictionary *environmentDict = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"environment" ofType:@"plist"]];
-    
+
+    [NRLogger setLogLevels:NRLogLevelNone];
+    if (environmentDict[@"NewRelicLoggerEnabled"] && [environmentDict[@"NewRelicLoggerEnabled"] boolValue]) {
+        [NRLogger setLogLevels:NRLogLevelError|NRLogLevelWarning];
+    }
+
     [NewRelicAgent startWithApplicationToken:keysDict[@"newRelicAppToken"]];
 
     NSString *GAItrackingID = keysDict[@"googleAnalyticsLiveTrackingID"];

--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ target 'Lets Do This' do
 	pod 'Crashlytics', '3.7.0'
     pod 'SVProgressHUD', '1.1.3'
     pod 'GoogleAnalytics', '3.13.0'
-    pod 'NewRelicAgent', '5.3.4'
+    pod 'NewRelicAgent', '5.4.1'
     pod 'NSString+RemoveEmoji', '0.1.0'
     pod 'TapjoySDK', '11.5.1'
 end


### PR DESCRIPTION
Closes #970 - Upgrade looks ok -- Apparently these messages when running on Simulator are [not unexpected](https://discuss.newrelic.com/t/unable-to-remove-session-attribute/35466). Will be adding a new entry to `environments.plist` to disable.
> 2016-04-28 15:46:50.463 DoSomething[4873:37082] NewRelic(5.4.1,0x7ff73b601730):	SessionAttributeManager.cxx:315	removeSessionAttribute
	Unable to remove session attribute "upgradeFrom"; attribute not found.
2016-04-28 15:46:50.463 DoSomething[4873:37082] NewRelic(5.4.1,0x7ff73b601730):	SessionAttributeManager.cxx:315	removeSessionAttribute
	Unable to remove session attribute "com.newrelic.SecureUDID.returnedNil"; attribute not found.
2016-04-28 15:46:50.464 DoSomething[4873:37082] NewRelic(5.4.1,0x7ff73b601730):	SessionAttributeManager.cxx:315	removeSessionAttribute
	Unable to remove session attribute "nr.deviceDidChange"; attribute not found.
2016-04-28 15:46:50.464 DoSomething[4873:37082] NewRelic(5.4.1,0x7ff73b601730):	SessionAttributeManager.cxx:315	removeSessionAttribute
	Unable to remove session attribute "install"; attribute not found.
2016-04-28 15:46:50.464 DoSomething[4873:37082] NewRelic(5.4.1,0x7ff73b601730):	SessionAttributeManager.cxx:315	removeSessionAttribute
	Unable to remove session attribute "sessionDuration"; attribute not found.
2016-04-28 15:46:50.482 DoSomething[4873:37238] NewRelic(5.4.1,0x7ff73b66e2d0):	NRMAUncaughtExceptionHandler.m:88	__37-[NRMAUncaughtExceptionHandler start]_block_invoke
	New Relic Crash Reporting is DISABLED because it has detected the debugger is enabled.