### PR TITLE
Sets webView.scalesPageToFit

### DIFF
--- a/Lets Do This/Controllers/Base/LDTWebViewController.m
+++ b/Lets Do This/Controllers/Base/LDTWebViewController.m
@@ -39,6 +39,7 @@
     self.title = self.navigationTitle;
     UIWebView *webView = [[UIWebView alloc] initWithFrame:self.view.frame];
     webView.delegate = self;
+    webView.scalesPageToFit = YES;
     NSURLRequest *urlRequest = [NSURLRequest requestWithURL:self.webViewURL];
     [webView loadRequest:urlRequest];
     [self.view addSubview:webView];


### PR DESCRIPTION
Missed this in #1015 

Per [Apple docs](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIWebView_Class/#//apple_ref/occ/instp/UIWebView/scalesPageToFit):
> A Boolean value determining whether the webpage scales to fit the view and the user can change the scale.