### PR TITLE
Campaign Resources: Action Guides

### DIFF
--- a/Lets Do This.xcodeproj/project.pbxproj
+++ b/Lets Do This.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		B2C3054B1BE142AE0046CD10 /* NSError+LDT.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C3054A1BE142AE0046CD10 /* NSError+LDT.m */; };
 		B2E652DF1B4380AD00EF9D69 /* LDTTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E652DE1B4380AD00EF9D69 /* LDTTheme.m */; };
 		B2E652E21B43822600EF9D69 /* LDTButton.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E652E11B43822600EF9D69 /* LDTButton.m */; };
+		B2EEF9BD1CEB79C30091E2B8 /* LDTReactViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2EEF9BC1CEB79C30091E2B8 /* LDTReactViewController.m */; };
 		B2F2BA831C6440BF001EB1D5 /* LDTUserViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F2BA821C6440BF001EB1D5 /* LDTUserViewController.m */; };
 		C20BA2831AF3DBE400E9886F /* DSOCampaign.m in Sources */ = {isa = PBXBuildFile; fileRef = C20BA2781AF3DBE400E9886F /* DSOCampaign.m */; };
 		C20BA2881AF3DBE400E9886F /* DSOUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C20BA2821AF3DBE400E9886F /* DSOUser.m */; };
@@ -146,6 +147,8 @@
 		B2E652DE1B4380AD00EF9D69 /* LDTTheme.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTTheme.m; path = Base/LDTTheme.m; sourceTree = "<group>"; };
 		B2E652E01B43822600EF9D69 /* LDTButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTButton.h; path = Base/LDTButton.h; sourceTree = "<group>"; };
 		B2E652E11B43822600EF9D69 /* LDTButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTButton.m; path = Base/LDTButton.m; sourceTree = "<group>"; };
+		B2EEF9BB1CEB79C30091E2B8 /* LDTReactViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTReactViewController.h; path = Base/LDTReactViewController.h; sourceTree = "<group>"; };
+		B2EEF9BC1CEB79C30091E2B8 /* LDTReactViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTReactViewController.m; path = Base/LDTReactViewController.m; sourceTree = "<group>"; };
 		B2F2BA811C6440BF001EB1D5 /* LDTUserViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LDTUserViewController.h; path = User/LDTUserViewController.h; sourceTree = "<group>"; };
 		B2F2BA821C6440BF001EB1D5 /* LDTUserViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LDTUserViewController.m; path = User/LDTUserViewController.m; sourceTree = "<group>"; };
 		B92B81EBB03D9FF4D34E3FD9 /* Pods-Lets Do This.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lets Do This.release.xcconfig"; path = "Pods/Target Support Files/Pods-Lets Do This/Pods-Lets Do This.release.xcconfig"; sourceTree = "<group>"; };
@@ -273,10 +276,12 @@
 		B27AF0E81B4F647A00164926 /* Base */ = {
 			isa = PBXGroup;
 			children = (
-				B240DD301B73DA4D00CA6C6E /* LDTTabBarController.h */,
-				B240DD311B73DA4D00CA6C6E /* LDTTabBarController.m */,
 				B212C2601B4ED6F300376BB1 /* LDTBaseViewController.h */,
 				B212C2611B4ED6F300376BB1 /* LDTBaseViewController.m */,
+				B2EEF9BB1CEB79C30091E2B8 /* LDTReactViewController.h */,
+				B2EEF9BC1CEB79C30091E2B8 /* LDTReactViewController.m */,
+				B240DD301B73DA4D00CA6C6E /* LDTTabBarController.h */,
+				B240DD311B73DA4D00CA6C6E /* LDTTabBarController.m */,
 				B21668E21CEA73CA006ADFE6 /* LDTWebViewController.h */,
 				B21668E31CEA73CA006ADFE6 /* LDTWebViewController.m */,
 			);
@@ -769,6 +774,7 @@
 				C2B151EF1ACE04C30028C336 /* main.m in Sources */,
 				B21126271B618038009128E7 /* DSOUserManager.m in Sources */,
 				B211C4221C3AF54800A94E64 /* LDTCauseListViewController.m in Sources */,
+				B2EEF9BD1CEB79C30091E2B8 /* LDTReactViewController.m in Sources */,
 				B2E652DF1B4380AD00EF9D69 /* LDTTheme.m in Sources */,
 				B20D06D11B3A58F40053D3B6 /* LDTMessage.m in Sources */,
 				B290D4C51C8A5961009E6295 /* DSOSignup.m in Sources */,

--- a/Lets Do This/Controllers/Base/LDTReactViewController.h
+++ b/Lets Do This/Controllers/Base/LDTReactViewController.h
@@ -1,0 +1,15 @@
+//
+//  LDTReactViewController.h
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 5/17/16.
+//  Copyright © 2016 Do Something. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface LDTReactViewController : UIViewController
+
+- (instancetype)initWithModuleName:(NSString *)moduleName initialProperties:(NSDictionary *)initialProperties title:(NSString *)title;
+
+@end

--- a/Lets Do This/Controllers/Base/LDTReactViewController.h
+++ b/Lets Do This/Controllers/Base/LDTReactViewController.h
@@ -10,6 +10,6 @@
 
 @interface LDTReactViewController : UIViewController
 
-- (instancetype)initWithModuleName:(NSString *)moduleName initialProperties:(NSDictionary *)initialProperties title:(NSString *)title;
+- (instancetype)initWithModuleName:(NSString *)moduleName initialProperties:(NSDictionary *)initialProperties title:(NSString *)title screenName:(NSString *)screenName;
 
 @end

--- a/Lets Do This/Controllers/Base/LDTReactViewController.m
+++ b/Lets Do This/Controllers/Base/LDTReactViewController.m
@@ -9,30 +9,36 @@
 #import "LDTReactViewController.h"
 #import "LDTAppDelegate.h"
 #import <RCTRootView.h>
+#import "GAI+LDT.h"
 
 @interface LDTReactViewController ()
 
 @property (strong, nonatomic) NSDictionary *initialProperties;
 @property (strong, nonatomic) NSString *moduleName;
 @property (strong, nonatomic) NSString *navigationTitle;
-
+@property (strong, nonatomic) NSString *screenName;
 @property (strong, nonatomic) RCTRootView *reactRootView;
 
 @end
 
 @implementation LDTReactViewController
 
-- (instancetype)initWithModuleName:(NSString *)moduleName initialProperties:(NSDictionary *)initialProperties title:(NSString *)title {
+#pragma mark - NSObject
+
+- (instancetype)initWithModuleName:(NSString *)moduleName initialProperties:(NSDictionary *)initialProperties title:(NSString *)title screenName:(NSString *)screenName{
     self = [super init];
     
     if (self) {
         _initialProperties = initialProperties;
         _moduleName = moduleName;
         _navigationTitle = title;
+        _screenName = screenName;
     }
     
     return self;
 }
+
+#pragma mark - UIViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -42,6 +48,12 @@
     __block LDTAppDelegate *appDelegate = (LDTAppDelegate *)[UIApplication sharedApplication].delegate;
     self.reactRootView = [[RCTRootView alloc] initWithBridge:appDelegate.bridge moduleName:self.moduleName initialProperties:self.initialProperties];
     self.view = self.reactRootView;
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    [[GAI sharedInstance] trackScreenView:self.screenName];
 }
 
 @end

--- a/Lets Do This/Controllers/Base/LDTReactViewController.m
+++ b/Lets Do This/Controllers/Base/LDTReactViewController.m
@@ -1,0 +1,47 @@
+//
+//  LDTReactViewController.m
+//  Lets Do This
+//
+//  Created by Aaron Schachter on 5/17/16.
+//  Copyright © 2016 Do Something. All rights reserved.
+//
+
+#import "LDTReactViewController.h"
+#import "LDTAppDelegate.h"
+#import <RCTRootView.h>
+
+@interface LDTReactViewController ()
+
+@property (strong, nonatomic) NSDictionary *initialProperties;
+@property (strong, nonatomic) NSString *moduleName;
+@property (strong, nonatomic) NSString *navigationTitle;
+
+@property (strong, nonatomic) RCTRootView *reactRootView;
+
+@end
+
+@implementation LDTReactViewController
+
+- (instancetype)initWithModuleName:(NSString *)moduleName initialProperties:(NSDictionary *)initialProperties title:(NSString *)title {
+    self = [super init];
+    
+    if (self) {
+        _initialProperties = initialProperties;
+        _moduleName = moduleName;
+        _navigationTitle = title;
+    }
+    
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.title = self.navigationTitle;
+
+    __block LDTAppDelegate *appDelegate = (LDTAppDelegate *)[UIApplication sharedApplication].delegate;
+    self.reactRootView = [[RCTRootView alloc] initWithBridge:appDelegate.bridge moduleName:self.moduleName initialProperties:self.initialProperties];
+    self.view = self.reactRootView;
+}
+
+@end

--- a/Lets Do This/Controllers/Base/LDTWebViewController.h
+++ b/Lets Do This/Controllers/Base/LDTWebViewController.h
@@ -10,6 +10,6 @@
 
 @interface LDTWebViewController : UIViewController
 
-- (instancetype)initWithWebViewURL:(NSURL *)webViewURL title:(NSString *)navigationTitle;
+- (instancetype)initWithWebViewURL:(NSURL *)webViewURL title:(NSString *)navigationTitle screenName:(NSString *)screenName;
 
 @end

--- a/Lets Do This/Controllers/Base/LDTWebViewController.m
+++ b/Lets Do This/Controllers/Base/LDTWebViewController.m
@@ -12,6 +12,7 @@
 @interface LDTWebViewController () <UIWebViewDelegate>
 
 @property (strong, nonatomic) NSString *navigationTitle;
+@property (strong, nonatomic) NSString *screenName;
 @property (strong, nonatomic) NSURL *webViewURL;
 
 @end
@@ -21,11 +22,12 @@
 
 #pragma mark - NSObject
 
-- (instancetype)initWithWebViewURL:(NSURL *)webViewURL title:(NSString *)navigationTitle{
+- (instancetype)initWithWebViewURL:(NSURL *)webViewURL title:(NSString *)navigationTitle screenName:(NSString *)screenName{
     self = [super init];
     
     if (self) {
         _navigationTitle = navigationTitle.uppercaseString;
+        _screenName = screenName;
         _webViewURL = webViewURL;
     }
     return self;
@@ -45,6 +47,11 @@
     [self.view addSubview:webView];
 }
 
-// @todo Track screenview in GAI+LDT
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    
+    [[GAI sharedInstance] trackScreenView:self.screenName];
+}
+
 
 @end

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -61,8 +61,7 @@ RCT_EXPORT_MODULE();
              };
 }
 
-RCT_EXPORT_METHOD(pushActionGuides:(NSArray *)actionGuides campaignID:(NSInteger)campaignID) {
-    NSString *screenName = [NSString stringWithFormat:@"campaign/%li/action-guides", (long)campaignID];
+RCT_EXPORT_METHOD(pushActionGuides:(NSArray *)actionGuides screenName:(NSString *)screenName) {
     NSDictionary *props = @{@"actionGuides": actionGuides};
     LDTReactViewController *viewController = [[LDTReactViewController alloc] initWithModuleName:@"ActionGuidesView" initialProperties:props title:@"Action Guides".uppercaseString screenName:screenName];
     [self.tabBarController pushViewController:viewController];
@@ -82,8 +81,8 @@ RCT_EXPORT_METHOD(pushCampaign:(NSInteger)campaignID) {
     [self.tabBarController pushViewController:viewController];
 }
 
-RCT_EXPORT_METHOD(pushWebView:(NSString*)urlString navigationTitle:(NSString *)navigationTitle) {
-    LDTWebViewController *viewController = [[LDTWebViewController alloc] initWithWebViewURL:[NSURL URLWithString:urlString] title:navigationTitle];
+RCT_EXPORT_METHOD(pushWebView:(NSString*)urlString navigationTitle:(NSString *)navigationTitle screenName:(NSString *)screenName) {
+    LDTWebViewController *viewController = [[LDTWebViewController alloc] initWithWebViewURL:[NSURL URLWithString:urlString] title:navigationTitle screenName:screenName];
     [self.tabBarController pushViewController:viewController];
 }
 

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -20,6 +20,7 @@
 #import "GAI+LDT.h"
 #import "LDTActivityViewController.h"
 #import "LDTWebViewController.h"
+#import "LDTReactViewController.h"
 
 @interface LDTReactBridge() <RCTBridgeModule>
 
@@ -58,6 +59,12 @@ RCT_EXPORT_MODULE();
              @"colorCtaBlue" : LDTTheme.hexCtaBlue,
              @"colorCopyGray" : LDTTheme.hexCopyGray,
              };
+}
+
+RCT_EXPORT_METHOD(pushActionGuides:(NSArray *)actionGuides) {
+    NSDictionary *props = @{@"actionGuides": actionGuides};
+    LDTReactViewController *viewController = [[LDTReactViewController alloc] initWithModuleName:@"ActionGuidesView" initialProperties:props title:@"Action Guides".uppercaseString];
+    [self.tabBarController pushViewController:viewController];
 }
 
 RCT_EXPORT_METHOD(pushUser:(NSDictionary *)userDict) {

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -61,9 +61,10 @@ RCT_EXPORT_MODULE();
              };
 }
 
-RCT_EXPORT_METHOD(pushActionGuides:(NSArray *)actionGuides) {
+RCT_EXPORT_METHOD(pushActionGuides:(NSArray *)actionGuides campaignID:(NSInteger)campaignID) {
+    NSString *screenName = [NSString stringWithFormat:@"campaign/%li/action-guides", (long)campaignID];
     NSDictionary *props = @{@"actionGuides": actionGuides};
-    LDTReactViewController *viewController = [[LDTReactViewController alloc] initWithModuleName:@"ActionGuidesView" initialProperties:props title:@"Action Guides".uppercaseString];
+    LDTReactViewController *viewController = [[LDTReactViewController alloc] initWithModuleName:@"ActionGuidesView" initialProperties:props title:@"Action Guides".uppercaseString screenName:screenName];
     [self.tabBarController pushViewController:viewController];
 }
 

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -10,6 +10,7 @@
 
 @interface DSOCampaign : NSObject
 
+@property (strong, nonatomic, readonly) NSArray *actionGuides;
 @property (strong, nonatomic, readonly) NSArray *attachments;
 @property (assign, nonatomic, readonly) NSInteger campaignID;
 @property (strong, nonatomic, readonly) NSString *coverImage;

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -11,6 +11,7 @@
 
 @interface DSOCampaign ()
 
+@property (strong, nonatomic, readwrite) NSArray *actionGuides;
 @property (strong, nonatomic, readwrite) NSArray *attachments;
 @property (strong, nonatomic, readwrite) NSDictionary *dictionary;
 @property (assign, nonatomic, readwrite) NSInteger campaignID;
@@ -61,6 +62,7 @@
         _status = [values valueForKeyAsString:@"status"];
         _type = [values valueForKeyAsString:@"type"];
         _tagline = [values valueForKeyAsString:@"tagline"];
+        _actionGuides = values[@"action_guides"];
         _attachments = values[@"attachments"];
 
         if ([values dictionaryForKeyPath:@"reportback_info"]) {
@@ -133,7 +135,8 @@
              @"solutionCopy" : self.solutionCopy,
              @"solutionSupportCopy" : self.solutionSupportCopy,
              @"sponsorImageUrl": self.sponsorImageURL,
-             @"attachments": self.attachments,
+             @"actionGuides": self.actionGuides,
+             @"attachments": self.attachments
              };
 }
 

--- a/ReactComponents/ActionGuidesView.js
+++ b/ReactComponents/ActionGuidesView.js
@@ -1,0 +1,23 @@
+'use strict';
+
+import React, {
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import Dimensions from 'Dimensions';
+
+var Style = require('./Style.js');
+
+var ActionGuidesView = React.createClass({
+  render: function() {
+    console.log(this.props.actionGuides);
+    return (
+      <View>
+        <Text>Action Guides</Text>
+      </View>
+    );
+  },
+});
+
+module.exports = ActionGuidesView;

--- a/ReactComponents/ActionGuidesView.js
+++ b/ReactComponents/ActionGuidesView.js
@@ -17,7 +17,7 @@ var ActionGuidesView = React.createClass({
       return self.renderActionGuide(actionGuide)
     });
     // DS API returns Action Guides as formatted HTML, time to build a webpage!
-    var html = "<html><body>" + content + "</body></html>";
+    var html = "<html><body style='color:#4A4A4A'>" + content + "</body></html>";
     return <WebView
       source={{html: html}}
       scalesPageToFit={true} />
@@ -31,13 +31,13 @@ var ActionGuidesView = React.createClass({
       content += this.renderCopy(actionGuide.subtitle);
     }
     if (actionGuide.intro.title) {
-      content += this.renderSubtitle(actionGuide.intro.title);
+      content += this.renderHeading(actionGuide.intro.title);
     }
     if (actionGuide.intro.copy) {
       content += this.renderCopy(actionGuide.intro.copy.formatted);
     }
     if (actionGuide.additional_text.title) {
-      content += this.renderSubtitle(actionGuide.additional_text.title);
+      content += this.renderHeading(actionGuide.additional_text.title);
     }  
     if (actionGuide.additional_text.copy) {
       content += this.renderCopy(actionGuide.additional_text.copy.formatted);
@@ -47,7 +47,7 @@ var ActionGuidesView = React.createClass({
   renderCopy: function(text) {
     return "<div style='font-family:BrandonGrotesque-Regular;font-size:32pt;padding:12pt 24pt'>" + text + "</div>";
   },
-  renderSubtitle: function(text) {
+  renderHeading: function(text) {
     return "<div style='color:#9C9C9C;font-family:BrandonGrotesque-Bold;font-size:26pt;padding:24pt 24pt 0 24pt;'>" + text.toUpperCase() + "</div>";
   },
   renderTitle: function(text) {

--- a/ReactComponents/ActionGuidesView.js
+++ b/ReactComponents/ActionGuidesView.js
@@ -1,23 +1,59 @@
 'use strict';
 
 import React, {
+  ListView,
   StyleSheet,
   Text,
   View,
+  WebView
 } from 'react-native';
-import Dimensions from 'Dimensions';
 
 var Style = require('./Style.js');
 
 var ActionGuidesView = React.createClass({
   render: function() {
-    console.log(this.props.actionGuides);
-    return (
-      <View>
-        <Text>Action Guides</Text>
-      </View>
-    );
+    var self = this;
+    var content = this.props.actionGuides.map(function(actionGuide) {
+      return self.renderActionGuide(actionGuide)
+    });
+    // DS API returns Action Guides as formatted HTML, time to build a webpage!
+    var html = "<html><body>" + content + "</body></html>";
+    return <WebView
+      source={{html: html}}
+      scalesPageToFit={true} />
   },
+  renderActionGuide: function(actionGuide) {
+    var content = "";
+    if (actionGuide.title) {
+      content += this.renderTitle(actionGuide.title);
+    }
+    if (actionGuide.subtitle) {
+      content += this.renderCopy(actionGuide.subtitle);
+    }
+    if (actionGuide.intro.title) {
+      content += this.renderSubtitle(actionGuide.intro.title);
+    }
+    if (actionGuide.intro.copy) {
+      content += this.renderCopy(actionGuide.intro.copy.formatted);
+    }
+    if (actionGuide.additional_text.title) {
+      content += this.renderSubtitle(actionGuide.additional_text.title);
+    }  
+    if (actionGuide.additional_text.copy) {
+      content += this.renderCopy(actionGuide.additional_text.copy.formatted);
+    }    
+    return content;
+  },
+  renderCopy: function(text) {
+    return "<div style='font-family:BrandonGrotesque-Regular;font-size:32pt;padding:12pt 24pt'>" + text + "</div>";
+  },
+  renderSubtitle: function(text) {
+    return "<div style='color:#9C9C9C;font-family:BrandonGrotesque-Bold;font-size:26pt;padding:24pt 24pt 0 24pt;'>" + text.toUpperCase() + "</div>";
+  },
+  renderTitle: function(text) {
+    return "<div align='center' style='background:#EEEEEE;font-family:BrandonGrotesque-Bold;font-size:36pt;padding:24pt'>" + text.toUpperCase() + "</div>";
+  }
 });
+
 
 module.exports = ActionGuidesView;

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -393,30 +393,45 @@ var CampaignResources = React.createClass({
     if (!this.props.campaign.actionGuides.length) {
       return null;
     }
+    var row = this.renderResourceRow("Action Guides");
     return (
       <TouchableHighlight 
         key="action-guides" 
         onPress={() => this.handleActionGuidesClick()}>
-        <View style={[styles.resourceRow, styles.bottomBorder]}>
-          <Text style={Style.textBody}>Action Guides</Text>
-        </View>
+        {row}
       </TouchableHighlight>
     );
   },
   renderAttachments: function() {
     var self = this;
     var content = this.props.campaign.attachments.map(function(attachment) {
+      var row = self.renderResourceRow(attachment.description);
       return (
         <TouchableHighlight 
           key={attachment.uri} 
           onPress={() => self.handleAttachmentClick(attachment.uri)}>
-          <View style={[styles.resourceRow, styles.bottomBorder]}>
-            <Text style={Style.textBody}>{attachment.description}</Text>
-          </View>
+          {row}
         </TouchableHighlight>
       );
     });
     return content;
+  },
+  renderResourceRow: function(text) {
+    return (
+      <View style={styles.row}>
+        <View style={styles.contentContainer}>
+          <View>
+            <Text style={Style.textBody}>{text}</Text>
+          </View>
+        </View>
+        <View style={[styles.arrowContainer, styles.bordered]}>
+            <Image
+              style={styles.arrowImage}
+              source={require('image!Arrow')}
+            />  
+        </View>
+      </View>
+    );
   }
 });
 
@@ -457,6 +472,13 @@ var styles = React.StyleSheet.create({
   },
   bottomBorder: {
     borderBottomColor: "#EEE",
+    borderBottomWidth: 1,
+  },
+  row: {
+    backgroundColor: '#FFFFFF',
+    flex: 1,
+    flexDirection: 'row',
+    borderBottomColor: "#EEE",
     borderBottomWidth: 1,  
   },
   resourceRow: {
@@ -464,7 +486,25 @@ var styles = React.StyleSheet.create({
     padding: 8,
     paddingTop: 11,
     paddingBottom: 11,
-  }
+  },
+  contentContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingLeft: 8,
+    height: 44,
+  },
+  arrowContainer: {
+    width: 38,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  arrowImage: {
+    width: 12,
+    height: 21,
+  },
 });
 
 

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -365,7 +365,7 @@ var CampaignView = React.createClass({
 
 var CampaignResources = React.createClass({
   handleActionGuidesClick: function() {
-    Bridge.pushActionGuides(this.props.campaign.actionGuides);
+    Bridge.pushActionGuides(this.props.campaign.actionGuides, this.props.campaign.id);
   },
   handleAttachmentClick: function(url) {
     Bridge.pushWebView(url, this.props.campaign.title);

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -365,10 +365,12 @@ var CampaignView = React.createClass({
 
 var CampaignResources = React.createClass({
   handleActionGuidesClick: function() {
-    Bridge.pushActionGuides(this.props.campaign.actionGuides, this.props.campaign.id);
+    var screenName = "campaign/" + this.props.campaign.id + "/action-guides";
+    Bridge.pushActionGuides(this.props.campaign.actionGuides, screenName);
   },
   handleAttachmentClick: function(url) {
-    Bridge.pushWebView(url, this.props.campaign.title);
+    var screenName = "campaign/" + this.props.campaign.id + "/attachment";
+    Bridge.pushWebView(url, this.props.campaign.title, screenName);
   },
   render: function() {
     if (!this.props.campaign.attachments.length && !this.props.campaign.actionGuides.length) {

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -364,11 +364,14 @@ var CampaignView = React.createClass({
 });
 
 var CampaignResources = React.createClass({
+  handleActionGuidesClick: function() {
+    Bridge.pushActionGuides(this.props.campaign.actionGuides);
+  },
   handleAttachmentClick: function(url) {
     Bridge.pushWebView(url, this.props.campaign.title);
   },
   render: function() {
-    if (!this.props.campaign.attachments.length) {
+    if (!this.props.campaign.attachments.length && !this.props.campaign.actionGuides.length) {
       return null;
     }
 
@@ -380,7 +383,23 @@ var CampaignResources = React.createClass({
           </Text>
         </View>
         {this.renderAttachments()}
+        {this.renderActionGuides()}
       </View>
+    );
+  },
+  renderActionGuides: function() {
+    var numGuides = this.props.campaign.actionGuides.length;
+    if (!this.props.campaign.actionGuides) {
+      return null;
+    }
+    return (
+      <TouchableHighlight 
+        key="action-guides" 
+        onPress={() => this.handleActionGuidesClick()}>
+        <View style={[styles.resourceRow, styles.bottomBorder]}>
+          <Text style={Style.textBody}>Action Guides</Text>
+        </View>
+      </TouchableHighlight>
     );
   },
   renderAttachments: function() {

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -388,8 +388,7 @@ var CampaignResources = React.createClass({
     );
   },
   renderActionGuides: function() {
-    var numGuides = this.props.campaign.actionGuides.length;
-    if (!this.props.campaign.actionGuides) {
+    if (!this.props.campaign.actionGuides.length) {
       return null;
     }
     return (

--- a/index.ios.js
+++ b/index.ios.js
@@ -17,3 +17,6 @@ AppRegistry.registerComponent('UserView', () => UserView);
 
 var CampaignView = require('./ReactComponents/CampaignView.js');
 AppRegistry.registerComponent('CampaignView', () => CampaignView);
+
+var ActionGuidesView = require('./ReactComponents/ActionGuidesView.js');
+AppRegistry.registerComponent('ActionGuidesView', () => ActionGuidesView);


### PR DESCRIPTION
* Closes #1014 by adding a `ActionGuidesView` React component to render a Campaign's `action_guides` array as one big ol webpage, because we get formatted HTML back in the `intro.copy` and `additional_text.copy` properties.
    * Concatenating all the data into a single `WebView` allows us to easily render with dynamic height (vs rendering each `copy.formatted` value as a separate `WebView` -- we'd need to specify height in each, which we'd only be able to do by calculating the `UILabel` height of each text for its font, e.g. #706) 

* Refs #1015 - Adds Google Analytics, Arrow icon (for now -- need Sketch export of file icon if we want to keep that)

* Starts on #971 by adding a `LDTReactViewController` to render our new `ActionGuidesView` component.  There's nothing about unique about this screen that warrants a separate sublcass. Next up: deprecate `LDTCauseListViewController` and  `LDTCauseDetailViewController` in favor of new `LDTReactViewController` class.

## Demo
![action-guides](https://cloud.githubusercontent.com/assets/1236811/15343348/d2fa6fc8-1c50-11e6-8bb7-bf3dbec6816f.gif)
