### PR TITLE
Download Campaign attachments

### DIFF
--- a/Lets Do This/Controllers/Base/LDTWebViewController.h
+++ b/Lets Do This/Controllers/Base/LDTWebViewController.h
@@ -10,6 +10,7 @@
 
 @interface LDTWebViewController : UIViewController
 
-- (instancetype)initWithWebViewURL:(NSURL *)webViewURL title:(NSString *)navigationTitle screenName:(NSString *)screenName;
+// If downloadable is true, a toolbar is displayed allowing user to download file at webViewURL and open in a UIDocumentInteractionController.
+- (instancetype)initWithWebViewURL:(NSURL *)webViewURL title:(NSString *)navigationTitle screenName:(NSString *)screenName isDownloadable:(BOOL)downloadable;
 
 @end

--- a/Lets Do This/Controllers/Base/LDTWebViewController.m
+++ b/Lets Do This/Controllers/Base/LDTWebViewController.m
@@ -14,6 +14,7 @@
 @property (strong, nonatomic) NSString *navigationTitle;
 @property (strong, nonatomic) NSString *screenName;
 @property (strong, nonatomic) NSURL *webViewURL;
+@property (strong, nonatomic) UIBarButtonItem *downloadButton;
 @property (strong, nonatomic) UIDocumentInteractionController *documentInteractionController;
 
 @end
@@ -50,10 +51,9 @@
     [self.view addSubview:webView];
 
     _documentInteractionController.delegate = self;
-    self.navigationController.toolbarHidden = NO;
-    UIBarButtonItem *downloadBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(downloadButtonTapped:)];
-    NSArray *items = [NSArray arrayWithObjects:downloadBarButtonItem, nil];
-    self.toolbarItems = items;
+    self.downloadButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(downloadButtonTapped:)];
+    self.navigationItem.rightBarButtonItem = self.downloadButton;
+
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -62,16 +62,9 @@
     [[GAI sharedInstance] trackScreenView:self.screenName];
 }
 
-- (void)viewWillDisappear:(BOOL)animated {
-    [super viewWillDisappear:animated];
-    
-    self.navigationController.toolbarHidden = YES;
-}
-
 #pragma mark - IBActions
 
 - (IBAction)downloadButtonTapped:(id)sender {
-    UIBarButtonItem *item = (UIBarButtonItem *)self.toolbarItems[0];
     NSURLRequest *request = [NSURLRequest requestWithURL:self.webViewURL];
     NSString *documentDir = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
     NSString *filePath = [documentDir stringByAppendingPathComponent:self.webViewURL.lastPathComponent];
@@ -83,7 +76,7 @@
         if (data) {
             [data writeToFile:filePath atomically:YES];
             self.documentInteractionController.URL = [NSURL fileURLWithPath:filePath];
-            [self.documentInteractionController presentOpenInMenuFromBarButtonItem:item animated:YES];
+            [self.documentInteractionController presentOpenInMenuFromBarButtonItem:self.downloadButton animated:YES];
         }
     }];
 }

--- a/Lets Do This/Controllers/Base/LDTWebViewController.m
+++ b/Lets Do This/Controllers/Base/LDTWebViewController.m
@@ -14,6 +14,7 @@
 @property (strong, nonatomic) NSString *navigationTitle;
 @property (strong, nonatomic) NSString *screenName;
 @property (strong, nonatomic) NSURL *webViewURL;
+@property (strong, nonatomic) UIDocumentInteractionController *documentInteractionController;
 
 @end
 
@@ -27,6 +28,7 @@
     self = [super init];
     
     if (self) {
+        _documentInteractionController = [[UIDocumentInteractionController alloc] init];
         _navigationTitle = navigationTitle.uppercaseString;
         _screenName = screenName;
         _webViewURL = webViewURL;
@@ -47,6 +49,7 @@
     [webView loadRequest:urlRequest];
     [self.view addSubview:webView];
 
+    _documentInteractionController.delegate = self;
     self.navigationController.toolbarHidden = NO;
     UIBarButtonItem *downloadBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(downloadButtonTapped:)];
     NSArray *items = [NSArray arrayWithObjects:downloadBarButtonItem, nil];
@@ -79,10 +82,8 @@
         }
         if (data) {
             [data writeToFile:filePath atomically:YES];
-            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-            UIDocumentInteractionController *documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:fileURL];
-            documentInteractionController.delegate = self;
-            [documentInteractionController presentOpenInMenuFromBarButtonItem:item animated:YES];
+            self.documentInteractionController.URL = [NSURL fileURLWithPath:filePath];
+            [self.documentInteractionController presentOpenInMenuFromBarButtonItem:item animated:YES];
         }
     }];
 }

--- a/Lets Do This/Controllers/Base/LDTWebViewController.m
+++ b/Lets Do This/Controllers/Base/LDTWebViewController.m
@@ -9,7 +9,7 @@
 #import "LDTWebViewController.h"
 #import "GAI+LDT.h"
 
-@interface LDTWebViewController () <UIWebViewDelegate>
+@interface LDTWebViewController () <UIWebViewDelegate, UIDocumentInteractionControllerDelegate>
 
 @property (strong, nonatomic) NSString *navigationTitle;
 @property (strong, nonatomic) NSString *screenName;
@@ -22,6 +22,7 @@
 
 #pragma mark - NSObject
 
+// @todo Pass optional downloadParam to conditionally display toolbar/download option.
 - (instancetype)initWithWebViewURL:(NSURL *)webViewURL title:(NSString *)navigationTitle screenName:(NSString *)screenName{
     self = [super init];
     
@@ -45,6 +46,11 @@
     NSURLRequest *urlRequest = [NSURLRequest requestWithURL:self.webViewURL];
     [webView loadRequest:urlRequest];
     [self.view addSubview:webView];
+
+    self.navigationController.toolbarHidden = NO;
+    UIBarButtonItem *downloadBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(downloadButtonTapped:)];
+    NSArray *items = [NSArray arrayWithObjects:downloadBarButtonItem, nil];
+    self.toolbarItems = items;
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -53,5 +59,32 @@
     [[GAI sharedInstance] trackScreenView:self.screenName];
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    
+    self.navigationController.toolbarHidden = YES;
+}
+
+#pragma mark - IBActions
+
+- (IBAction)downloadButtonTapped:(id)sender {
+    UIBarButtonItem *item = (UIBarButtonItem *)self.toolbarItems[0];
+    NSURLRequest *request = [NSURLRequest requestWithURL:self.webViewURL];
+    NSString *documentDir = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+    NSString *filePath = [documentDir stringByAppendingPathComponent:self.webViewURL.lastPathComponent];
+    [NSURLConnection sendAsynchronousRequest:request queue:[NSOperationQueue currentQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+        if (error) {
+            // @todo LDTMessage
+            NSLog(@"Download Error: %@", error.description);
+        }
+        if (data) {
+            [data writeToFile:filePath atomically:YES];
+            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
+            UIDocumentInteractionController *documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:fileURL];
+            documentInteractionController.delegate = self;
+            [documentInteractionController presentOpenInMenuFromBarButtonItem:item animated:YES];
+        }
+    }];
+}
 
 @end

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -80,9 +80,10 @@ RCT_EXPORT_METHOD(pushCampaign:(NSInteger)campaignID) {
     [self.tabBarController pushViewController:viewController];
 }
 
-RCT_EXPORT_METHOD(pushWebView:(NSString*)urlString navigationTitle:(NSString *)navigationTitle screenName:(NSString *)screenName) {
-    LDTWebViewController *viewController = [[LDTWebViewController alloc] initWithWebViewURL:[NSURL URLWithString:urlString] title:navigationTitle screenName:screenName];
-    [self.tabBarController pushViewController:viewController];
+RCT_EXPORT_METHOD(presentWebView:(NSString*)urlString navigationTitle:(NSString *)navigationTitle screenName:(NSString *)screenName isDownloadable:(BOOL)downloadable) {
+    LDTWebViewController *viewController = [[LDTWebViewController alloc] initWithWebViewURL:[NSURL URLWithString:urlString] title:navigationTitle screenName:screenName isDownloadable:downloadable];
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
+    [self.tabBarController presentViewController:navigationController animated:YES completion:nil];
 }
 
 RCT_EXPORT_METHOD(presentProveIt:(NSInteger)campaignID) {

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -372,7 +372,7 @@ var CampaignResources = React.createClass({
   },
   handleAttachmentClick: function(url) {
     var screenName = "campaign/" + this.props.campaign.id + "/attachment";
-    Bridge.pushWebView(url, this.props.campaign.title, screenName);
+    Bridge.presentWebView(url, this.props.campaign.title, screenName, true);
   },
   render: function() {
     if (!this.props.campaign.attachments.length && !this.props.campaign.actionGuides.length) {


### PR DESCRIPTION
Closes #1031: Adds a toolbar to the `LDTWebViewController` to download file to device and creates a `UIDocumentInteractionController` to open the file.

@lkpttn -- Can you add a mock of what the button should look like? We're not tied to using the `UINavigationController.toolbar` or `UIBarButtonItem` -- this was quickest way to get up and running.
