### PR TITLE
AFNetworking 3.0

### DIFF
--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -78,7 +78,6 @@
         _apiKey = apiKey;
         if (activityLoggerEnabled) {
             [[AFNetworkActivityLogger sharedLogger] startLogging];
-            [[AFNetworkActivityLogger sharedLogger] setLevel:AFLoggerLevelDebug];
         }
         self.responseSerializer = [AFJSONResponseSerializer serializer];
         self.requestSerializer = [AFJSONRequestSerializer serializer];

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -131,7 +131,7 @@
         params[@"parse_installation_ids"] = deviceToken;
     }
     
-    [self POST:url parameters:[params copy] success:^(NSURLSessionDataTask *task, id responseObject) {
+    [self POST:url parameters:[params copy] progress:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         if (completionHandler) {
             completionHandler(responseObject);
         }
@@ -146,7 +146,7 @@
     NSString *url = @"auth/token";
     NSDictionary *params = @{@"email" : email, @"password" : password};
 
-    [self POST:url parameters:params success:^(NSURLSessionDataTask *task, id responseObject) {
+    [self POST:url parameters:params  progress:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         NSString *sessionToken = [responseObject valueForKeyPath:@"data.key"];
         self.sessionToken = sessionToken;
         DSOUser *user = [[DSOUser alloc] initWithDict:[responseObject valueForKeyPath:@"data.user.data"]];
@@ -167,7 +167,7 @@
     
     [self POST:url parameters:nil constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
         [formData appendPartWithFileData:imageData name:@"photo" fileName:fileNameForImage mimeType:@"image/jpeg"];
-    } success:^(NSURLSessionDataTask *task, id responseObject) {
+    }  progress:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         DSOUser *updatedUser = [[DSOUser alloc] initWithDict:[responseObject valueForKeyPath:@"data"]];
         if (completionHandler) {
             completionHandler(updatedUser);
@@ -184,7 +184,7 @@
     if (deviceToken) {
         url = [NSString stringWithFormat:@"%@?parse_installation_ids=%@", url, deviceToken];
     }
-    [self POST:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
+    [self POST:url parameters:nil progress:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         [self deleteSessionToken];
         if (completionHandler) {
             completionHandler(responseObject);
@@ -199,7 +199,7 @@
 - (void)postSignupForCampaign:(DSOCampaign *)campaign completionHandler:(void(^)(DSOSignup *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSDictionary *params = @{@"campaign_id" : [NSNumber numberWithInteger:campaign.campaignID], @"source" : LDTSOURCENAME};
     NSString *url = @"signups";
-    [self POST:url parameters:params success:^(NSURLSessionDataTask *task, id responseObject) {
+    [self POST:url parameters:params progress:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         if (completionHandler) {
             completionHandler((DSOSignup *)responseObject[@"data"]);
         }
@@ -222,7 +222,7 @@
                              @"file": fileString,
                              };
 
-    [self POST:url parameters:params success:^(NSURLSessionDataTask *task, id responseObject) {
+    [self POST:url parameters:params progress:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         if (completionHandler) {
             completionHandler((DSOReportback *)responseObject[@"data"]);
         }
@@ -239,7 +239,7 @@
     }
     [self.requestSerializer setValue:self.sessionToken forHTTPHeaderField:@"Session"];
     NSString *url = [NSString stringWithFormat:@"profile"];
-    [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
+    [self GET:url parameters:nil progress:nil success:^(NSURLSessionDataTask *task, id responseObject) {
           DSOUser *user = [[DSOUser alloc] initWithDict:responseObject[@"data"]];
           if (completionHandler) {
               completionHandler(user);
@@ -254,7 +254,7 @@
 - (void)postCurrentUserDeviceToken:(NSString *)deviceToken completionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *url = @"profile";
     NSDictionary *params = @{@"parse_installation_ids" : deviceToken};
-    [self POST:url parameters:params success:^(NSURLSessionDataTask *task, id responseObject) {
+    [self POST:url parameters:params progress:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         if (completionHandler) {
             completionHandler(responseObject);
         }
@@ -269,7 +269,7 @@
 - (void)loadCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *url = [NSString stringWithFormat:@"%@campaigns/%li", self.phoenixApiURL, (long)campaignID];
 
-    [self GET:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
+    [self GET:url parameters:nil progress:nil success:^(NSURLSessionDataTask *task, id responseObject) {
         DSOCampaign *campaign = [[DSOCampaign alloc] initWithDict:responseObject[@"data"]];
         // API returns 200 if campaign is not found, so check for valid ID.
         // @todo This whole check be deprecated once https://github.com/DoSomething/phoenix/issues/6261 is resolved.

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -8,7 +8,9 @@
 //
 
 #import "DSOAPI.h"
-#import "AFNetworkActivityLogger.h"
+#import <AFNetworkActivityLogger/AFNetworkActivityLogger.h>
+#import <AFNetworkActivityLogger/AFNetworkActivityConsoleLogger.h>
+
 #import "NSDictionary+DSOJsonHelper.h"
 #import <SSKeychain/SSKeychain.h>
 
@@ -76,9 +78,16 @@
 
     if (self) {
         _apiKey = apiKey;
+
         if (activityLoggerEnabled) {
+            // By default there's only 1 logger in loggers
+            // @see https://github.com/AFNetworking/AFNetworkActivityLogger/tree/3_0_0#logging-levels
+    
+            AFNetworkActivityConsoleLogger *logger = [AFNetworkActivityLogger sharedLogger].loggers.anyObject;
+            logger.level = AFLoggerLevelDebug;
             [[AFNetworkActivityLogger sharedLogger] startLogging];
         }
+
         self.responseSerializer = [AFJSONResponseSerializer serializer];
         self.requestSerializer = [AFJSONRequestSerializer serializer];
         self.requestSerializer.timeoutInterval = 30;

--- a/Podfile
+++ b/Podfile
@@ -6,8 +6,8 @@ inhibit_all_warnings!
 install! 'cocoapods', :deterministic_uuids => false
 
 target 'Lets Do This' do
-	pod 'AFNetworking', '2.6.0'
-	pod 'AFNetworkActivityLogger', '2.0.4'
+	pod 'AFNetworking', '3.1.0'
+	pod 'AFNetworkActivityLogger', :git => 'https://github.com/AFNetworking/AFNetworkActivityLogger.git', :branch => '3_0_0'
     pod 'Parse', '1.8.5'
     pod 'SDWebImage', '3.7.3'
     pod 'SSKeychain', '1.2.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,27 +1,20 @@
 PODS:
-  - AFNetworkActivityLogger (2.0.4):
-    - AFNetworking/NSURLConnection (~> 2.0)
-    - AFNetworking/NSURLSession (~> 2.0)
-  - AFNetworking (2.6.0):
-    - AFNetworking/NSURLConnection (= 2.6.0)
-    - AFNetworking/NSURLSession (= 2.6.0)
-    - AFNetworking/Reachability (= 2.6.0)
-    - AFNetworking/Security (= 2.6.0)
-    - AFNetworking/Serialization (= 2.6.0)
-    - AFNetworking/UIKit (= 2.6.0)
-  - AFNetworking/NSURLConnection (2.6.0):
+  - AFNetworkActivityLogger (3.0.0):
+    - AFNetworking/NSURLSession (~> 3.0)
+  - AFNetworking (3.1.0):
+    - AFNetworking/NSURLSession (= 3.1.0)
+    - AFNetworking/Reachability (= 3.1.0)
+    - AFNetworking/Security (= 3.1.0)
+    - AFNetworking/Serialization (= 3.1.0)
+    - AFNetworking/UIKit (= 3.1.0)
+  - AFNetworking/NSURLSession (3.1.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.6.0):
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.6.0)
-  - AFNetworking/Security (2.6.0)
-  - AFNetworking/Serialization (2.6.0)
-  - AFNetworking/UIKit (2.6.0):
-    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (3.1.0)
+  - AFNetworking/Security (3.1.0)
+  - AFNetworking/Serialization (3.1.0)
+  - AFNetworking/UIKit (3.1.0):
     - AFNetworking/NSURLSession
   - Bolts/Tasks (1.7.0)
   - Crashlytics (3.7.0):
@@ -53,8 +46,8 @@ PODS:
     - HexColors (~> 2.3.0)
 
 DEPENDENCIES:
-  - AFNetworkActivityLogger (= 2.0.4)
-  - AFNetworking (= 2.6.0)
+  - AFNetworkActivityLogger (from `https://github.com/AFNetworking/AFNetworkActivityLogger.git`, branch `3_0_0`)
+  - AFNetworking (= 3.1.0)
   - Crashlytics (= 3.7.0)
   - Fabric (= 1.6.3)
   - GoogleAnalytics (= 3.13.0)
@@ -73,19 +66,25 @@ DEPENDENCIES:
   - TSMessages (from `https://github.com/DoSomething/TSMessages.git`)
 
 EXTERNAL SOURCES:
+  AFNetworkActivityLogger:
+    :branch: '3_0_0'
+    :git: https://github.com/AFNetworking/AFNetworkActivityLogger.git
   React:
     :path: ./node_modules/react-native
   TSMessages:
     :git: https://github.com/DoSomething/TSMessages.git
 
 CHECKOUT OPTIONS:
+  AFNetworkActivityLogger:
+    :commit: abc565fe804f210dfda3b028c9a64e7c32e44600
+    :git: https://github.com/AFNetworking/AFNetworkActivityLogger.git
   TSMessages:
     :commit: 7d2cd35e34bf9b666cb45123c079029b780306a0
     :git: https://github.com/DoSomething/TSMessages.git
 
 SPEC CHECKSUMS:
-  AFNetworkActivityLogger: 121486778117d53b3ab1c61d264b88081d0c3eee
-  AFNetworking: 79f7eb1a0fcfa7beb409332b2ca49afe9ce53b05
+  AFNetworkActivityLogger: e77f68d014becb33c4306a23f56a64906ff72670
+  AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   Bolts: a0058fa3b331c5a1e4402d534f2dae36dbff31e4
   Crashlytics: c3a2333dea9e2733d2777f730910321fc9e25c0d
   Fabric: cbe0ca6c9531bba17910052f6f105fcbc5fa7f67
@@ -101,6 +100,6 @@ SPEC CHECKSUMS:
   TapjoySDK: af2985b5de89af5b9ba61c762a7ecad76fc60c78
   TSMessages: 6e403b790139636c15ab4f51946537095e03e79c
 
-PODFILE CHECKSUM: b4e4092d7cdc2f6688079f43fec8748557ffcdf6
+PODFILE CHECKSUM: 9940b22ee4ab1eafde871e21c3ed63ff2314af92
 
 COCOAPODS: 1.0.0


### PR DESCRIPTION
Updates Podfile to AFNetworking 3.1 to close #1032.. but not amped up about needing to [fork a 3.0 branch of the `AFNetworkActivityLogger`](https://github.com/AFNetworking/AFNetworkActivityLogger/pull/38). The errors in this branch don't return the `debug` object in Northstar errors like `develop` currently does.

This branch:
````
2016-05-27 12:33:22.955 DoSomething[7484:1161539] [Error] POST 'https://northstar-qa.dosomething.org/v1/auth/register?create_drupal_user=1' (500) [1.0283 s]: Error Domain=com.alamofire.error.serialization.response Code=-1011 "Request failed: internal server error (500)" UserInfo={com.alamofire.serialization.response.error.response=<NSHTTPURLResponse: 0x7fe45d978d50> { URL: https://northstar-qa.dosomething.org/v1/auth/register?create_drupal_user=1 } { status code: 500, headers {
    "Cache-Control" = "no-cache";
    "Content-Type" = "application/json";
    Date = "Fri, 27 May 2016 19:33:22 GMT";
    Server = "nginx/1.4.6 (Ubuntu)";
    "Transfer-Encoding" = Identity;
} }, NSErrorFailingURLKey=https://northstar-qa.dosomething.org/v1/auth/register?create_drupal_user=1, com.alamofire.serialization.response.error.data=<7b226572 ..  [removed] ...  222c226c 696e6522 3a31367d 7d>, NSLocalizedDescription=Request failed: internal server error (500)}
````
`develop`:

````
2016-05-27 12:49:18.012 DoSomething[8346:1266812] 500 'https://northstar-qa.dosomething.org/v1/auth/register?create_drupal_user=1' [0.6757 s]: {
    "Cache-Control" = "no-cache";
    "Content-Type" = "application/json";
    Date = "Fri, 27 May 2016 19:49:17 GMT";
    Server = "nginx/1.4.6 (Ubuntu)";
    "Transfer-Encoding" = Identity;
} {
    debug =     {
        file = "/var/www/northstar/releases/20160513190527/app/Http/Transformers/UserTransformer.php";
        line = 16;
    };
    error =     {
        code = 500;
        message = "Type error: Argument 1 passed to Northstar\\Http\\Transformers\\UserTransformer::transform() must be an instance of Northstar\\Models\\User, null given, called in /var/www/northstar/releases/20160513190527/vendor/league/fractal/src/Scope.php on line 338";
    };
}
````