### PR TITLE
RefreshControl cleanup

### DIFF
--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -167,17 +167,13 @@ var CampaignView = React.createClass({
 
     return (      
       <ListView
-      dataSource={this.state.dataSource}
-      renderHeader={this.renderHeader}
-      renderRow={this.renderRow}
-      refreshControl= {
-        <RefreshControl
-          refreshing={this.state.isRefreshing}
+        dataSource={this.state.dataSource}
+        renderHeader={this.renderHeader}
+        renderRow={this.renderRow}
+        refreshControl= {<RefreshControl
           onRefresh={this._onRefresh}
-          tintColor="#CCC"
-          colors={['#ff0000', '#00ff00', '#0000ff']}
-          progressBackgroundColor="#ffff00"
-        />}
+          refreshing={this.state.isRefreshing}
+          tintColor="#CCC" />}
       />
     );
   },

--- a/ReactComponents/CauseDetailView.js
+++ b/ReactComponents/CauseDetailView.js
@@ -82,14 +82,10 @@ var CauseDetailView = React.createClass({
         dataSource={this.state.dataSource}
         renderRow={this.renderRow}
         renderHeader={this.renderHeader}
-        refreshControl= {
-        <RefreshControl
-          refreshing={this.state.isRefreshing}
+        refreshControl= {<RefreshControl
           onRefresh={this._onRefresh}
-          tintColor="#CCC"
-          colors={['#ff0000', '#00ff00', '#0000ff']}
-          progressBackgroundColor="#ffff00"
-        />}
+          refreshing={this.state.isRefreshing}
+          tintColor="#CCC" />}
       />
     );
   },

--- a/ReactComponents/CauseListView.js
+++ b/ReactComponents/CauseListView.js
@@ -76,15 +76,10 @@ var CauseListView = React.createClass({
         dataSource={this.state.dataSource}
         renderRow={this.renderRow}
         style={styles.listView}
-        refreshControl={
-          <RefreshControl
-            refreshing={this.state.isRefreshing}
-            onRefresh={this._onRefresh}
-            tintColor="#CCC"
-            colors={['#ff0000', '#00ff00', '#0000ff']}
-            progressBackgroundColor="#ffff00"
-          />
-        }
+        refreshControl={<RefreshControl
+          onRefresh={this._onRefresh}
+          refreshing={this.state.isRefreshing}
+          tintColor="#CCC" />}
       />
     );
   },

--- a/ReactComponents/NewsFeedView.js
+++ b/ReactComponents/NewsFeedView.js
@@ -78,15 +78,10 @@ var NewsFeedView = React.createClass({
         dataSource={this.state.dataSource}
         renderRow={this.renderRow}
         style={styles.listView}
-        refreshControl={
-          <RefreshControl
-            refreshing={this.state.isRefreshing}
-            onRefresh={this._onRefresh}
-            tintColor="#CCC"
-            colors={['#ff0000', '#00ff00', '#0000ff']}
-            progressBackgroundColor="#ffff00"
-          />
-        }
+        refreshControl={<RefreshControl
+          onRefresh={this._onRefresh}
+          refreshing={this.state.isRefreshing}
+          tintColor="#CCC" />}
       />
     );
   },

--- a/ReactComponents/UserView.js
+++ b/ReactComponents/UserView.js
@@ -236,15 +236,10 @@ var UserView = React.createClass({
         renderRow={this.renderRow}
         renderHeader={this.renderHeader}
         renderSectionHeader = {this.renderSectionHeader}
-        refreshControl={
-          <RefreshControl
-            refreshing={this.state.isRefreshing}
-            onRefresh={this._onRefresh}
-            tintColor="#ccc"
-            colors={['#ff0000', '#00ff00', '#0000ff']}
-            progressBackgroundColor="#ffff00"
-          />
-        }
+        refreshControl={<RefreshControl
+          onRefresh={this._onRefresh}
+          refreshing={this.state.isRefreshing}
+          tintColor="#CCC" />}
       />
     );
   },


### PR DESCRIPTION
Closes #906 -- no visible changes here, just removing the Android-only `colors` and `progressBackgroundColor` properties because i shoulda just [RTFM](https://facebook.github.io/react-native/docs/refreshcontrol.html#props) instead of [RATM](https://www.youtube.com/watch?v=Lp3kcHchD1Y)

Seemed easier solution is to just keep repeating the `tintColor` value vs. a separate `RefreshControl` component, as each `RefreshControl` still needs its own unique `onRefresh` and `refreshing` property values.