### PR TITLE
Upgrades React Native to 0.27

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,15 +33,15 @@ PODS:
   - NSString+RemoveEmoji (0.1.0)
   - Parse (1.8.5):
     - Bolts/Tasks (>= 1.2.2)
-  - React/Core (0.26.1)
-  - React/RCTImage (0.26.1):
+  - React/Core (0.27.2)
+  - React/RCTImage (0.27.2):
     - React/Core
     - React/RCTNetwork
-  - React/RCTNetwork (0.26.1):
+  - React/RCTNetwork (0.27.2):
     - React/Core
-  - React/RCTText (0.26.1):
+  - React/RCTText (0.27.2):
     - React/Core
-  - React/RCTWebSocket (0.26.1):
+  - React/RCTWebSocket (0.27.2):
     - React/Core
   - SDWebImage (3.7.3):
     - SDWebImage/Core (= 3.7.3)
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   NewRelicAgent: c85f94358d6e02761cae6707364c4402a352a08f
   NSString+RemoveEmoji: 6901fb3a1cc9b6d0c0fc858155898b041fdfb493
   Parse: 17ad8e0677ed682f7f00503860fcda0f4eb74168
-  React: 9a7eb5f6e7146734fb50ab17f515087d302d5cca
+  React: ed545be51aeb5c3988abb0b17bf174b87aac1a17
   SDWebImage: 1d2b1a1efda1ade1b00b6f8498865f8ddedc8a84
   SSKeychain: 3f42991739c6c60a9cf1bbd4dff6c0d3694bcf3d
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/DoSomething/LetsDoThis-iOS#readme",
   "dependencies": {
-    "react": "15.0.2",
-    "react-native": "^0.26.1"
+    "react": "15.1.0",
+    "react-native": "^0.27.2"
   }
 }


### PR DESCRIPTION
Once merged, upgrade locally by:

1. `npm install`
2. `pod install`
3. open `Lets Do This.xcworkspace` 