### PR TITLE
Adds Campaign Magic Link support

### DIFF
--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -140,4 +140,9 @@ RCT_EXPORT_METHOD(shareReportbackItem:(NSInteger)id shareMessage:(NSString *)sha
     }];
 }
 
+RCT_EXPORT_METHOD(openMagicLinkForCampaign:(NSInteger)campaignID) {
+    NSLog(@"magic link for campaign %li", campaignID);
+    //[[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlString]];
+}
+
 @end

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -140,9 +140,15 @@ RCT_EXPORT_METHOD(shareReportbackItem:(NSInteger)id shareMessage:(NSString *)sha
     }];
 }
 
+// Opens given campaign in web, with our current user magically authenticated without login.
 RCT_EXPORT_METHOD(openMagicLinkForCampaign:(NSInteger)campaignID) {
-    NSLog(@"magic link for campaign %li", campaignID);
-    //[[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlString]];
+    DSOAPI *api = [DSOAPI sharedInstance];
+    [api createAuthenticatedWebSessionForCurrentUserWithCompletionHandler:^(NSDictionary *response) {
+        NSString *magicLink = [NSString stringWithFormat:@"%@?redirect=node/%li", response[@"url"], campaignID];
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:magicLink]];
+    } errorHandler:^(NSError *error) {
+        [LDTMessage displayErrorMessageInViewController:self.tabBarController title:error.readableTitle subtitle:error.readableMessage];
+    }];
 }
 
 @end

--- a/Lets Do This/Controllers/LDTReactBridge.m
+++ b/Lets Do This/Controllers/LDTReactBridge.m
@@ -143,6 +143,7 @@ RCT_EXPORT_METHOD(shareReportbackItem:(NSInteger)id shareMessage:(NSString *)sha
 // Opens given campaign in web, with our current user magically authenticated without login.
 RCT_EXPORT_METHOD(openMagicLinkForCampaign:(NSInteger)campaignID) {
     DSOAPI *api = [DSOAPI sharedInstance];
+    [[GAI sharedInstance] trackEventWithCategory:@"campaign" action:@"magic-link" label:[NSString stringWithFormat:@"%li", (long)campaignID]  value:nil];
     [api createAuthenticatedWebSessionForCurrentUserWithCompletionHandler:^(NSDictionary *response) {
         NSString *magicLink = [NSString stringWithFormat:@"%@?redirect=node/%li", response[@"url"], campaignID];
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:magicLink]];

--- a/Lets Do This/Models/DSOCampaign.h
+++ b/Lets Do This/Models/DSOCampaign.h
@@ -14,6 +14,7 @@
 @property (strong, nonatomic, readonly) NSArray *attachments;
 @property (assign, nonatomic, readonly) NSInteger campaignID;
 @property (strong, nonatomic, readonly) NSString *coverImage;
+@property (strong, nonatomic, readonly) NSString *magicLinkCopy;
 @property (strong, nonatomic, readonly) NSString *reportbackNoun;
 @property (strong, nonatomic, readonly) NSString *reportbackVerb;
 @property (strong, nonatomic, readonly) NSString *solutionCopy;

--- a/Lets Do This/Models/DSOCampaign.m
+++ b/Lets Do This/Models/DSOCampaign.m
@@ -16,6 +16,7 @@
 @property (strong, nonatomic, readwrite) NSDictionary *dictionary;
 @property (assign, nonatomic, readwrite) NSInteger campaignID;
 @property (strong, nonatomic, readwrite) NSString *coverImage;
+@property (strong, nonatomic, readwrite) NSString *magicLinkCopy;
 @property (strong, nonatomic, readwrite) NSString *reportbackNoun;
 @property (strong, nonatomic, readwrite) NSString *reportbackVerb;
 @property (strong, nonatomic, readwrite) NSString *solutionCopy;
@@ -62,6 +63,7 @@
         _status = [values valueForKeyAsString:@"status"];
         _type = [values valueForKeyAsString:@"type"];
         _tagline = [values valueForKeyAsString:@"tagline"];
+        _magicLinkCopy = [values valueForKeyAsString:@"magic_link_copy"];
         _actionGuides = values[@"action_guides"];
         _attachments = values[@"attachments"];
 
@@ -131,7 +133,8 @@
              @"solutionSupportCopy" : self.solutionSupportCopy,
              @"sponsorImageUrl": self.sponsorImageURL,
              @"actionGuides": self.actionGuides,
-             @"attachments": self.attachments
+             @"attachments": self.attachments,
+             @"magicLinkCopy": self.magicLinkCopy
              };
 }
 

--- a/Lets Do This/Networking/DSOAPI.h
+++ b/Lets Do This/Networking/DSOAPI.h
@@ -51,4 +51,7 @@
 
 - (void)loadCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
 
+// Creates a web session for our current user and returns a magic authenticated URL.
+- (void)createAuthenticatedWebSessionForCurrentUserWithCompletionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler;
+
 @end

--- a/Lets Do This/Networking/DSOAPI.m
+++ b/Lets Do This/Networking/DSOAPI.m
@@ -257,6 +257,18 @@
     }];
 }
 
+- (void)createAuthenticatedWebSessionForCurrentUserWithCompletionHandler:(void(^)(NSDictionary *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
+    NSString *url = @"auth/phoenix";
+    [self POST:url parameters:nil success:^(NSURLSessionDataTask *task, id responseObject) {
+        if (completionHandler) {
+            completionHandler(responseObject);
+        }
+    } failure:^(NSURLSessionDataTask *task, NSError *error) {
+        if (errorHandler) {
+            errorHandler([self errorForAPIError:error domain:url]);
+        }
+    }];
+}
 
 - (void)loadCampaignWithID:(NSInteger)campaignID completionHandler:(void(^)(DSOCampaign *))completionHandler errorHandler:(void(^)(NSError *))errorHandler {
     NSString *url = [NSString stringWithFormat:@"%@campaigns/%li", self.phoenixApiURL, (long)campaignID];

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -254,6 +254,7 @@ var CampaignView = React.createClass({
           {solutionSupportText}
           {submitText}
         </View>
+        {this.renderMagicLink()}
         <CampaignResources 
           key={this.state.campaign.id}
           campaign={this.state.campaign}/>
@@ -328,6 +329,23 @@ var CampaignView = React.createClass({
           </Text>
         </View>
       </View>
+    );
+  },
+  renderMagicLink: function() {
+    if (!this.state.campaign.magicLinkCopy) {
+      return null;
+    }
+    var id = this.state.campaign.id;
+    return (
+      <TouchableHighlight
+        onPress={() => Bridge.openMagicLinkForCampaign(id)}
+        >
+        <View style={[styles.row, {paddingBottom: 4}]}>
+          <Text style={[styles.content, Style.textBodyBold, Style.textColorCtaBlue]}>
+            {this.state.campaign.magicLinkCopy}
+          </Text>
+        </View>
+      </TouchableHighlight>
     );
   },
   renderRow: function(rowData) {

--- a/ReactComponents/CampaignView.js
+++ b/ReactComponents/CampaignView.js
@@ -337,9 +337,7 @@ var CampaignView = React.createClass({
     }
     var id = this.state.campaign.id;
     return (
-      <TouchableHighlight
-        onPress={() => Bridge.openMagicLinkForCampaign(id)}
-        >
+      <TouchableHighlight onPress={() => Bridge.openMagicLinkForCampaign(id)}>
         <View style={[styles.row, {paddingBottom: 4}]}>
           <Text style={[styles.content, Style.textBodyBold, Style.textColorCtaBlue]}>
             {this.state.campaign.magicLinkCopy}


### PR DESCRIPTION
#### What's this PR do?
* Adds a new `DSOCampaign.magicLinkCopy` property and loads from API. 
* When set, our `CampaignView` renders the copy as a link that opens the Campaign up in a web browser, with our current user authenticated automagically 🐇 🎩 🔥 
* Adds Google Analytics event tracking on tap

#### How should this be reviewed?

#####  Local:
Run this branch on Debug. Load Animals > Space Jam (campaign id 1631) and verify:
* [x] The Magic Link renders per [design](https://github.com/dosomething/letsdothis-ios/issues/1035#issuecomment-241552196) and [copy matches API](https://staging.dosomething.org/api/v1/campaigns/1631).

* [x] Upon tapping, the Space Jam campaign is opened in web browser

    * NOTE: The Space Jam campaign will display a red warning with PHP notices that can be crossed out, and then displays a message about Global Translations are not enabled for Space Jam. That's ok for our testing purposes, the campaign is loaded. 


* [x] On web, verify our current user logged in.

    * Click on the Hamburger menu to go to My Account. Verify account matches your current user in iOS app.
  
* [x] Back in iOS app, verify the Magic Link doesn't appear when not set, like in Animals > Justice For Elephants (campaign id 1198)

#####  Fabric:

Verify Animals > Bumble Bands has a Magic Link rendered per https://github.com/DoSomething/LetsDoThis-iOS/issues/1035#issuecomment-241581164

Can test the toggle with a production campaign by setting and unsetting its Magic Link Property in the Phoenix admin. To verify changes, you'll need to force quit the iOS app and reload the campaign.


#### Screenshot
![simulator screen shot aug 22 2016 3 47 21 pm](https://cloud.githubusercontent.com/assets/1236811/17874334/d885d128-687f-11e6-939e-290d1319d3e3.png)



#### Relevant tickets
Fixes #1035 

cc @lkpttn @NearChaos 
